### PR TITLE
feat: text size responsive hero sections

### DIFF
--- a/src/templates/contentsection/ContentSection.vue
+++ b/src/templates/contentsection/ContentSection.vue
@@ -38,15 +38,15 @@
               <Overline :label="overline" />
             </template>
             <template v-if="title">
-              <h1 v-if="titleTag === 'h1'" class="text-3xl font-medium text-balance">{{ title }}</h1>
-              <h2 v-if="titleTag === 'h2'" class="text-3xl font-medium text-balance">{{ title }}</h2>
-              <h3 v-if="titleTag === 'h3'" class="text-3xl font-medium text-balance">{{ title }}</h3>
-              <h4 v-if="titleTag === 'h4'" class="text-3xl font-medium text-balance">{{ title }}</h4>
-              <h5 v-if="titleTag === 'h5'" class="text-3xl font-medium text-balance">{{ title }}</h5>
-              <h6 v-if="titleTag === 'h6'" class="text-3xl font-medium text-balance">{{ title }}</h6>
+              <h1 v-if="titleTag === 'h1'" class="text-2xl md:text-3xl font-medium text-balance">{{ title }}</h1>
+              <h2 v-if="titleTag === 'h2'" class="text-2xl md:text-3xl font-medium text-balance">{{ title }}</h2>
+              <h3 v-if="titleTag === 'h3'" class="text-2xl md:text-3xl font-medium text-balance">{{ title }}</h3>
+              <h4 v-if="titleTag === 'h4'" class="text-2xl md:text-3xl font-medium text-balance">{{ title }}</h4>
+              <h5 v-if="titleTag === 'h5'" class="text-2xl md:text-3xl font-medium text-balance">{{ title }}</h5>
+              <h6 v-if="titleTag === 'h6'" class="text-2xl md:text-3xl font-medium text-balance">{{ title }}</h6>
             </template>
             <template v-else-if="$slots.title">
-              <div class="text-3xl lg:text-4xl font-medium text-balance">
+              <div class="text-2xl md:text-3xl lg:text-4xl font-medium text-balance">
                 <slot name="title" />
               </div>
             </template>

--- a/src/templates/herobase/HeroBase.vue
+++ b/src/templates/herobase/HeroBase.vue
@@ -39,16 +39,16 @@
           <template v-if="title">
             <h1
               v-if="titleTag === 'h1'"
-              class="font-medium text-4xl 2xl:text-5xl text-balance"
-              :class="[{ 'md:text-5xl' : isDisplay }]"
+              class="font-medium text-3xl md:text-4xl 2xl:text-5xl text-balance"
+              :class="[{ 'text-4xl md:text-5xl' : isDisplay }]"
             >
               {{ title }}
             </h1>
-            <h2 v-if="titleTag === 'h2'" class="text-4xl 2xl:text-5xl font-medium text-balance">{{ title }}</h2>
-            <h3 v-if="titleTag === 'h3'" class="text-4xl 2xl:text-5xl font-medium text-balance">{{ title }}</h3>
-            <h4 v-if="titleTag === 'h4'" class="text-4xl 2xl:text-5xl font-medium text-balance">{{ title }}</h4>
-            <h5 v-if="titleTag === 'h5'" class="text-4xl 2xl:text-5xl font-medium text-balance">{{ title }}</h5>
-            <h6 v-if="titleTag === 'h6'" class="text-4xl 2xl:text-5xl font-medium text-balance">{{ title }}</h6>
+            <h2 v-if="titleTag === 'h2'" class="text-3xl md:text-4xl 2xl:text-5xl font-medium text-balance">{{ title }}</h2>
+            <h3 v-if="titleTag === 'h3'" class="text-3xl md:text-4xl 2xl:text-5xl font-medium text-balance">{{ title }}</h3>
+            <h4 v-if="titleTag === 'h4'" class="text-3xl md:text-4xl 2xl:text-5xl font-medium text-balance">{{ title }}</h4>
+            <h5 v-if="titleTag === 'h5'" class="text-3xl md:text-4xl 2xl:text-5xl font-medium text-balance">{{ title }}</h5>
+            <h6 v-if="titleTag === 'h6'" class="text-3xl md:text-4xl 2xl:text-5xl font-medium text-balance">{{ title }}</h6>
           </template>
           <template v-else>
             <slot name="title" />

--- a/src/templates/sectionhighlight/SectionHighlight.vue
+++ b/src/templates/sectionhighlight/SectionHighlight.vue
@@ -8,7 +8,7 @@
               v-if="overline"
               :label="overline"
             />
-            <h2 class="text-3xl font-medium text-balance">{{ title }}</h2>
+            <h2 class="text-2xl md:text-3xl font-medium text-balance">{{ title }}</h2>
           </div>
           <LinkButton
             v-if="button"

--- a/src/templates/titlegroup/Titlegroup.vue
+++ b/src/templates/titlegroup/Titlegroup.vue
@@ -1,7 +1,7 @@
 <template>
   <hgroup>
-    <p class="text-[--surface-700] text-4xl font-medium">{{ subtitle }}</p>
-    <h1 class="text-4xl font-medium text-balance">{{ title }}</h1>
+    <p class="text-[--surface-700] text-3xl md:text-4xl font-medium">{{ subtitle }}</p>
+    <h1 class="text-3xl md:text-4xl font-medium text-balance">{{ title }}</h1>
   </hgroup>
 </template>
 


### PR DESCRIPTION
Adicionado breakpoint para mobile para Heroes e Sections.

Responsivo:
![image](https://github.com/user-attachments/assets/5154d48d-667f-4779-8d62-d0eee667f2f3)
![image](https://github.com/user-attachments/assets/f96d7cde-30e9-43e2-9131-65b279258c4d)

Desktop:
![image](https://github.com/user-attachments/assets/2d3e2b9d-c694-463a-9c28-c45d654e3d2a)
![image](https://github.com/user-attachments/assets/0c96fd70-11d3-4355-86bb-a39fe4c02b06)
