### PR TITLE
chore: storybook adjustments

### DIFF
--- a/src/stories/rules.js
+++ b/src/stories/rules.js
@@ -23,8 +23,8 @@ const Rules = {
   },
   section: {
     overline: "- **Overline:** Overlines should not exceed 32 characters to maintain their auxiliary purpose.",
-    title: "- **Title:** Titles should be between 40 and 60 characters, or a maximum of 3 lines in 1440px (width) for better readability.",
-    description: "- **Description:** Descriptions should be between 80 and 160 characters, ensuring they are concise and informative, without overwhelming the user.",
+    title: "- **Title:** Titles should be between 40 and 120 characters, or a maximum of 3 lines in 1440px (width) for better readability.",
+    description: "- **Description:** Descriptions should be between 80 and 280 characters, ensuring they are concise and informative, without overwhelming the user.",
     cta: '- **Actions (CTA):** Limit the number of CTA buttons to a maximum of 2. Ensure button labels are concise, with a maximum of 20 characters, and all links should be valid.',
     navigation: "- **Navigation:** Navigations is like a buttons, ensure the labels are concise, with a maximum of 20 characters, and all links should be valid. ",
     logos: '- **Logos:** Try to put multiples of 2 logos in logo-content-block. Ensure the svg logos are balanced and with the currentColor property in fill.',

--- a/src/stories/templates/sections/section-bullets-right.stories.js
+++ b/src/stories/templates/sections/section-bullets-right.stories.js
@@ -38,17 +38,17 @@ const MOCK = {
   }],
   "contentListBlock": [
     {
-      "icon": "pi pi-check",
+      "icon": "pi pi-bolt",
       "title": "Agile",
       "description": "Run code and deploy in minutes. From prototype to enterprise scale with NoOps, just code."
     },
     {
-      "icon": "pi pi-check",
+      "icon": "pi pi-arrow-right-arrow-left",
       "title": "Diverse use cases",
       "description": "Fraud detection, authentication and authorization, bot mitigation, and facial recognition, using technologies such as visual computing and artificial intelligence executed at the edge."
     },
     {
-      "icon": "pi pi-check",
+      "icon": "pi pi-dollar",
       "title": "Cost-effective",
       "description": "Pricing is based on the edge resources and/or private edge locations in use."
     }

--- a/src/stories/templates/sections/section-card-background-intercalated.stories.js
+++ b/src/stories/templates/sections/section-card-background-intercalated.stories.js
@@ -7,7 +7,7 @@ import Overline from '../../../templates/overline'
 import Rules from '../../rules'
 
 export default {
-  title: 'Blocks/Sections/section-card-intercalated',
+  title: 'Blocks/Sections/section-card-background-intercalated',
   tags: ['autodocs'],
   parameters: {
     docs: {

--- a/src/stories/templates/sections/section-howitworks.stories.js
+++ b/src/stories/templates/sections/section-howitworks.stories.js
@@ -1,9 +1,9 @@
 
-import Container from '../../../templates/container'
-import SectionSticky from '../../../templates/sectionsticky'
+import Container from '../../../templates/container/Container'
+import SectionSticky from '../../../templates/sectionsticky/SectionSticky'
 
 export default {
-  title: 'Blocks/Sections/section-sticky',
+  title: 'Blocks/Sections/section-howitworks',
   tags: ['autodocs'],
 }
 

--- a/src/stories/templates/sections/section-howitworks.stories.js
+++ b/src/stories/templates/sections/section-howitworks.stories.js
@@ -1,6 +1,6 @@
 
-import Container from '../../../templates/container/Container'
-import SectionSticky from '../../../templates/sectionsticky/SectionSticky'
+import Container from '../../../templates/container'
+import SectionSticky from '../../../templates/sectionsticky'
 
 export default {
   title: 'Blocks/Sections/section-howitworks',

--- a/src/stories/templates/sections/section-image-right.stories.js
+++ b/src/stories/templates/sections/section-image-right.stories.js
@@ -16,7 +16,6 @@ export default {
 ${Rules.section.overline}
 ${Rules.section.title}
 ${Rules.section.description}
-${Rules.section.cta}
 ${Rules.section.image}
         `,
       },
@@ -25,13 +24,9 @@ ${Rules.section.image}
 }
 
 const MOCK = {
-  overline: 'SAVE MORE BY RESERVING',
-  title: 'Get lower rates with Savings Plans',
-  description: "With Savings Plans, you qualify for even greater discounts by committing to a consistent amount of usage for a period of 1, 2, or 3 years. This model provides the flexibility to use Azion's products that best fit your needs while reducing your costs by up to 78%.",
-  "buttons": [{
-    "label": "Create a free account",
-    "link": "https://console.azion.com/signup"
-  }]
+  overline: 'Edge Connectivity',
+  title: 'Azion’s robust connectivity strategy helps us deliver the best performance, availability, and resiliency to our customers',
+  description: "Our highly distributed architecture includes edge nodes strategically located inside ISPs' (Internet Service Providers) last-mile networks and connectivity to multiple IXPs (Internet Exchange Points), private and public peerings, and Tier 1 transit providers around the world.",
 }
 
 const template = `
@@ -41,14 +36,16 @@ const template = `
       <LinkButton v-for="({ link, label }) in args.buttons" :link="link" :label="label" outlined />
     </template>
     <template #main>
+    <div class="w-full">
       <ImageSwitcher>
         <template #darkImage>
-          <img src="/assets/dark/illustration-demo.svg" />
+          <img width="540" height="auto" src="https://www.azion.com/assets/pages/products/images/dark/edge-network/network-ilustrationEN.png" />
         </template>
         <template #lightImage>
-          <img src="/assets/light/illustration-demo.svg" />
+          <img width="540" height="auto" src="https://www.azion.com/assets/pages/products/images/light/edge-network/network-ilustrationEN.png" />
         </template>
       </ImageSwitcher>
+      </div>
     </template>
   </ContentSection>
 </Container>`

--- a/src/stories/templates/sections/section-investor-logos.stories.js
+++ b/src/stories/templates/sections/section-investor-logos.stories.js
@@ -4,7 +4,7 @@ import ContentLogoBlock from '../../../templates/contentlogo'
 import Rules from '../../rules'
 
 export default {
-  title: 'Blocks/Sections/section-logos',
+  title: 'Blocks/Sections/section-investor-logos',
   tags: ['autodocs'],
   parameters: {
     docs: {
@@ -43,7 +43,7 @@ const template = `
 <Container class="surface-ground">
   <ContentSection titleTag="h2" position="center" isContentCentralized textCenter :title="args.title" :overline="args.overline">
     <template #content>
-      <ContentLogoBlock :isCentralized="true" :logos="logos" size="default" />
+      <ContentLogoBlock :isCentralized="true" :logos="logos" />
     </template>
   </ContentSection>
 </Container>`


### PR DESCRIPTION
O que foi feito: 

- Arrumado o exemplo de content-bullet-right para icones relacionados.
- Alterado o nome de section-logos para section-investor-logos.
- Alterado o nome do card intercalado e adicionar o background.
- Section-image-right ajustado o conteúdo para um conteúdo real.
- Update de regra de sections
