### PR TITLE
fix: [UXE-6786] added w-full on herobase principal slot

### DIFF
--- a/src/templates/herobase/HeroBase.vue
+++ b/src/templates/herobase/HeroBase.vue
@@ -109,7 +109,7 @@
       </template>
     </div>
     <template v-if="$slots.principal">
-      <div class="px-container">
+      <div class="px-container w-full">
         <slot name="principal" />
       </div>
     </template>


### PR DESCRIPTION
Percebi que era o px-container que estava causando o problema, pq não foi passado o w-full no HeroBase daí ele tava empurrando os lados com mx-auto, passando o w-full funcionou.

Antes:
![image](https://github.com/user-attachments/assets/7c670cf5-d42f-4a67-b67d-c881d68d2b6d)


Depois:
![image](https://github.com/user-attachments/assets/7c670cf5-d42f-4a67-b67d-c881d68d2b6d)
