### PR TITLE
fix: Update SectionListProducts to use ProductCard

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,9 @@
 <template>
   <Container class="surface-ground">
-    <ProductCard v-bind="FEATURE" />
     <div class="px-container flex flex-row gap-3">
       <ProductCard v-bind="FEATURE2" />
       <ProductCard v-bind="FEATURE" />
       <ProductCard v-bind="FEATURE2" />
-
     </div>
   </Container>
 </template>
@@ -22,7 +20,7 @@ const FEATURE = {
     { label: 'Docs', link: '#', icon: '' },
     { label: 'Get started', link: '#', icon: 'pi pi-arrow-right' }
   ],
-  // addons: true
+  addons: false
 }
 
 const FEATURE2 = {

--- a/src/stories/templates/sections/section-list-products.stories.js
+++ b/src/stories/templates/sections/section-list-products.stories.js
@@ -47,8 +47,9 @@ Default.args = {
       title: 'Edge Application',
       description:
         'Enables the development of web applications to run on the Azion Edge Computing Platform.',
-      link: 'https://www.azion.com/en/products/edge-application/',
-      addons: [
+      // link: 'https://www.azion.com/en/products/edge-application/',
+      addons: true,
+      links: [
         {
           label: 'Application Accelerator',
           link: 'https://www.azion.com/en/products/application-accelerator/'
@@ -64,6 +65,29 @@ Default.args = {
       ]
     },
     {
+      icon: 'ai ai-edge-storage',
+      title: 'Edge Storage',
+      description:
+        'Facilitates low-latency storage and retrieval of objects anywhere, with no vendor lock-in via an S3-compatible API.',
+      link: 'https://www.azion.com/en/products/edge-storage/',
+      addons: true,
+      links: [
+        {
+          label: 'Application Accelerator',
+          link: 'https://www.azion.com/en/products/application-accelerator/'
+        }
+      ]
+    },
+    {
+      addons: false,
+      icon: 'ai ai-edge-storage',
+      title: 'Edge Storage',
+      description:
+        'Facilitates low-latency storage and retrieval of objects anywhere, with no vendor lock-in via an S3-compatible API.',
+      link: 'https://www.azion.com/en/products/edge-storage/'
+    },
+    {
+      addons: false,
       icon: 'ai ai-edge-storage',
       title: 'Edge Storage',
       description:

--- a/src/templates/sectionlistproducts/SectionListProducts.d.ts
+++ b/src/templates/sectionlistproducts/SectionListProducts.d.ts
@@ -8,44 +8,28 @@
 import { VNode } from 'vue'
 import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
 
-type List = {
-  icon: string
-  title: string
-  description: string
-  link?: string
-  addons?: Array<{
-    label: string
-    link: string
-  }>
-}
-
-/**
- * Defines valid properties in SectionListProducts component.
- */
 export interface SectionListProductsProps {
+  overline: string
   titleTag: string
   title: string
-  overline: string
-  list: List[]
+  list: Array<{
+    icon: string
+    title: string
+    description: string
+    link?: string
+    links?: Array<{
+      label: string
+      link: string
+    }>
+  }>
+  grid: boolean
 }
 
-/**
- * Defines valid slots in SectionListProducts component.
- */
 export interface SectionListProductsSlots {
-  /**
-   * Content can easily be customized with the default slot instead of using the built-in modes.
-   */
   default(): VNode[]
 }
 
-/**
- * Defines valid emits in SectionListProducts component.
- */
 export interface SectionListProductsEmits {
-  /**
-   * Triggered when an error occurs
-   */
   error(event: Event): void
 }
 

--- a/src/templates/sectionlistproducts/SectionListProducts.d.ts
+++ b/src/templates/sectionlistproducts/SectionListProducts.d.ts
@@ -12,6 +12,11 @@ type List = {
   icon: string
   title: string
   description: string
+  link?: string
+  addons?: Array<{
+    label: string
+    link: string
+  }>
 }
 
 /**
@@ -21,7 +26,7 @@ export interface SectionListProductsProps {
   titleTag: string
   title: string
   overline: string
-  list: List
+  list: List[]
 }
 
 /**

--- a/src/templates/sectionlistproducts/SectionListProducts.vue
+++ b/src/templates/sectionlistproducts/SectionListProducts.vue
@@ -7,23 +7,18 @@
   >
     <template #main>
       <div
-        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 grid place-content-center m-0"
+        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 place-content-center m-0"
       >
         <ProductCard
-          v-for="{ title, icon, description, link, addons } in props.list"
+          v-for="{ title, icon, description, link, addons, links } in props.list"
           :key="title"
           :title="title"
           :icon="icon"
           :description="description"
           :link="link"
-          :links="addons || []"
-          :addons="addons && addons.length > 0"
-          backgroundColor="default"
-          :class="[
-            addons &&
-              addons.some((addon) => addon.label && addon.label.trim() !== '') &&
-              'row-span-2'
-          ]"
+          :links="links"
+          :addons="addons"
+          :class="[!grid && addons && 'row-span-2']"
         />
       </div>
     </template>
@@ -35,6 +30,9 @@
   import ProductCard from '../productcard'
 
   const props = defineProps({
+    overline: {
+      type: String
+    },
     titleTag: {
       type: String,
       default() {
@@ -44,9 +42,6 @@
         return ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(value)
       }
     },
-    overline: {
-      type: String
-    },
     title: {
       type: String,
       required: true
@@ -54,6 +49,10 @@
     list: {
       type: Array,
       default: () => []
+    },
+    grid:{
+      type: Boolean,
+      default: () => false
     }
   })
 </script>

--- a/src/templates/sectionlistproducts/SectionListProducts.vue
+++ b/src/templates/sectionlistproducts/SectionListProducts.vue
@@ -9,50 +9,22 @@
       <div
         class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 grid place-content-center m-0"
       >
-        <CardBase
+        <ProductCard
           v-for="{ title, icon, description, link, addons } in props.list"
-          spacing="compact"
+          :key="title"
+          :title="title"
+          :icon="icon"
+          :description="description"
+          :link="link"
+          :links="addons || []"
+          :addons="addons && addons.length > 0"
           backgroundColor="default"
           :class="[
             addons &&
               addons.some((addon) => addon.label && addon.label.trim() !== '') &&
               'row-span-2'
           ]"
-        >
-          <template #content>
-            <div class="flex flex-col w-full gap-2 justify-end">
-              <IconTextSegment
-                class="h-full"
-                :href="link"
-                :title="title"
-                :description="description"
-                :icon="icon"
-                severity="primary"
-              />
-
-              <template
-                v-if="addons && addons.some((addon) => addon.label && addon.label.trim() !== '')"
-              >
-                <div class="ml-12">
-                  <Overline label="Add-ons" />
-                  <div class="flex flex-col gap-2 pt-3 -ml-4">
-                    <LinkButton
-                      v-for="{ label, link } in addons.filter(
-                        (addon) => addon.label && addon.label.trim() !== ''
-                      )"
-                      text
-                      :label="label"
-                      :link="link"
-                      class="max-w-fit"
-                      icon="pi pi-arrow-right"
-                      iconPos="right"
-                    />
-                  </div>
-                </div>
-              </template>
-            </div>
-          </template>
-        </CardBase>
+        />
       </div>
     </template>
   </ContentSection>
@@ -60,10 +32,7 @@
 
 <script setup>
   import ContentSection from '../contentsection'
-  import LinkButton from '../linkbutton'
-  import CardBase from '../cardbase'
-  import IconTextSegment from '../icontextsegment'
-  import Overline from '../overline'
+  import ProductCard from '../productcard'
 
   const props = defineProps({
     titleTag: {


### PR DESCRIPTION
## Summary

- use `ProductCard` inside `SectionListProducts`
- update type definitions for new card props

## Prompt

```
In the SectionListProducts we will make an update replacing the card used for and we will start use the ProductCard.
```
------
https://chatgpt.com/codex/tasks/task_e_685f5f6380cc8321bd9ec42154f71dee