### PR TITLE
feat: add id prop to ContentSection and HeroBase wrapper components

### DIFF
--- a/src/templates/bannergetstarted/BannerGetStarted.d.ts
+++ b/src/templates/bannergetstarted/BannerGetStarted.d.ts
@@ -30,6 +30,11 @@ type BannerGetStartedItems = {
  * Defines valid properties in AisIndexHit component.
  */
 export interface BannerGetStartedProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   items: BannerGetStartedItems[]
   /**
    * Defines the text to display is centralized.

--- a/src/templates/bannergetstarted/BannerGetStarted.vue
+++ b/src/templates/bannergetstarted/BannerGetStarted.vue
@@ -3,6 +3,7 @@
     :pt="{ content: 'surface-50 py-8 lg:py-16 px-5 lg:px-10 rounded' }"
     :overline="overline"
     titleTag="h2"
+    :id="id"
     position="full"
   >
     <template #title>
@@ -46,6 +47,10 @@
   import Tile from '../tile'
 
   defineProps({
+    id: {
+      type: String,
+      required: false
+    },
     overline: {
       type: String,
       required: false

--- a/src/templates/contentsection/ContentSection.d.ts
+++ b/src/templates/contentsection/ContentSection.d.ts
@@ -12,6 +12,7 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in AisIndexHit component.
  */
 export interface ContentSectionProps {
+  id?: string | undefined
   overline?: string | undefined
   title?: string | undefined
   /**

--- a/src/templates/contentsection/ContentSection.vue
+++ b/src/templates/contentsection/ContentSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="px-container w-full flex flex-col gap-10 md:gap-20">
+  <section class="px-container w-full flex flex-col gap-10 md:gap-20" :id="id">
     <div
       class="flex-col flex w-full gap-10 md:gap-20"
       :class="[
@@ -135,6 +135,10 @@
   import Overline from '../overline/Overline.vue'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/herobase/HeroBase.d.ts
+++ b/src/templates/herobase/HeroBase.d.ts
@@ -12,6 +12,11 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in HeroBase component.
  */
 export interface HeroBaseProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   bannerNews?: object
   overline?: string
   /**

--- a/src/templates/herobase/HeroBase.vue
+++ b/src/templates/herobase/HeroBase.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="flex flex-col gap-10 md:gap-20 2xl:gap-40">
+  <section class="flex flex-col gap-10 md:gap-20 2xl:gap-40" :id="id">
     <div
       class="px-container flex flex-col w-full"
       :class="[
@@ -132,6 +132,10 @@
   import Banner from '../banner'
 
   const props = defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     bannerNews: {
       type: Object
     },

--- a/src/templates/herofeaturedbottom/HeroFeaturedBottom.d.ts
+++ b/src/templates/herofeaturedbottom/HeroFeaturedBottom.d.ts
@@ -34,6 +34,7 @@ interface Card {
  * Defines valid properties in HeroFeaturedBottom component.
  */
 export interface HeroFeaturedBottomProps {
+  id?: string
   overline?: string
   title?: string
   description?: string

--- a/src/templates/herofeaturedbottom/HeroFeaturedBottom.vue
+++ b/src/templates/herofeaturedbottom/HeroFeaturedBottom.vue
@@ -4,6 +4,7 @@
     :overline="overline"
     :title="title"
     :description="description"
+    :id="id"
   >
     <template #actions>
       <LinkButton
@@ -24,6 +25,10 @@
   import FeaturedCards from '../featuredcards'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       required: false

--- a/src/templates/herohome/HeroHome.d.ts
+++ b/src/templates/herohome/HeroHome.d.ts
@@ -30,6 +30,7 @@ interface BannerNews {
 }
 
 export interface HeroHomeProps {
+  id?: string
   overline: string
   titleTag: string
   title: string

--- a/src/templates/herohome/HeroHome.vue
+++ b/src/templates/herohome/HeroHome.vue
@@ -5,6 +5,7 @@
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
     :bannerNews="bannerNews"
+    :id="id"
   >
     <template #title>
       <h1
@@ -37,6 +38,10 @@
   import ContentLogo from '../contentlogo'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     bannerNews: {
       type: Object,
       default: () => {}

--- a/src/templates/herohsformright/HeroHsFormRight.d.ts
+++ b/src/templates/herohsformright/HeroHsFormRight.d.ts
@@ -13,6 +13,7 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  */
 
 export interface HeroHsFormRightProps {
+  id?: string | undefined
   overline: string
   title: string
   description: string

--- a/src/templates/herohsformright/HeroHsFormRight.vue
+++ b/src/templates/herohsformright/HeroHsFormRight.vue
@@ -4,6 +4,7 @@
     :title="props.title"
     :description="props.description"
     :descriptionRawHtml="props.descriptionRawHtml"
+    :id="id"
   >
     <template #content>
       <div class="flex flex-col gap-10 w-full">
@@ -40,6 +41,10 @@
   import UnorderedList from '../listunordered'
 
   const props = defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/heroimagerightlogos/HeroImageRightLogos.d.ts
+++ b/src/templates/heroimagerightlogos/HeroImageRightLogos.d.ts
@@ -30,6 +30,7 @@ interface Logo {
 }
 
 export interface HeroImageRightLogoProps {
+  id?: string
   title: string
   images: Images
   logos: Logo

--- a/src/templates/heroimagerightlogos/HeroImageRightLogos.vue
+++ b/src/templates/heroimagerightlogos/HeroImageRightLogos.vue
@@ -3,6 +3,7 @@
     <HeroBlockBase
       align="center"
       :title="title"
+      :id="id"
     >
       <template #actions>
         <div class="flex flex-col md:flex-row lg:justify-start justify-center gap-2 w-full">
@@ -50,6 +51,10 @@
   import ImageSwitcher from '../themeawareimageswitcher'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     title: {
       type: String,
       required: true

--- a/src/templates/heroproductshorizontal/HeroProductsHorizontal.d.ts
+++ b/src/templates/heroproductshorizontal/HeroProductsHorizontal.d.ts
@@ -1,64 +1,43 @@
 /**
  *
- * LinkButton represents people using links in the page with css buttons look.
+ * HeroProductsHorizontal
  *
  *
- * @module `linkbutton`
+ * @module `heroproductshorizontal`
  */
 import { VNode } from 'vue'
 import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
 
 /**
- * Defines valid properties in LinkButton component.
+ * Defines valid properties in HeroProductsHorizontal component.
  */
-export interface LinkButtonProps {
-  /**
-   * Defines the text to display.
-   */
-  label: string
-  /**
-   * Defines the icon to display.
-   */
-  icon?: string | undefined
-  /**
-   * Defines icon position, options: [left, right]
-   * @defaultValue left
-   */
-  iconPos?: 'left' | 'right' | undefined
-  /**
-   * Defines the href attribute of LinkButton
-   */
-  link?: string | undefined
-  /**
-   * Severity of LinkButton [info, secondary]
-   * @defaultValue info
-   */
-  severity?: 'info' | 'secondary' | undefined
-  /**
-   * Shape of the element.
-   * @defaultValue _self
-   */
-  target?: '_self' | '_blank' | undefined
-  /**
-   * Options [small], apply text-sm class
-   */
-  size?: string | undefined
-  /**
-   * When enabled, it add the borders
-   * @defaultValue false
-   */
-  outlined?: boolean
-  /**
-   * When enabled, it add the borders
-   * @defaultValue false
-   */
-  text?: boolean
+export interface HeroProductsHorizontalProps {
+  id?: string
+  justify?: string
+  overline?: string
+  description?: string
+  descriptionRawHtml?: string
+  buttons?: Array<{
+    label: string
+    link: string
+    outlined?: boolean
+  }>
+  hgroup: {
+    title: string
+    subtitle: string
+  }
+  images: {
+    light: string
+    dark: string
+    alt: string
+  }
+  list: object
 }
 
 /**
- * Defines valid slots in LinkButton component.
+ * Defines valid slots in HeroProductsHorizontal component.
  */
-export interface LinkButtonSlots {
+export interface HeroProductsHorizontalSlots {
   /**
    * Content can easily be customized with the default slot instead of using the built-in modes.
    */
@@ -66,11 +45,11 @@ export interface LinkButtonSlots {
 }
 
 /**
- * Defines valid emits in LinkButton component.
+ * Defines valid emits in HeroProductsHorizontal component.
  */
-export interface LinkButtonEmits {
+export interface HeroProductsHorizontalEmits {
   /**
-   * Triggered when an error occurs while loading an image file.
+   * Triggered when an error occurs
    */
   error(event: Event): void
 }
@@ -78,16 +57,16 @@ export interface LinkButtonEmits {
 /**
  * @group Component
  */
-declare class LinkButton extends ClassComponent<
-  LinkButtonProps,
-  LinkButtonSlots,
-  LinkButtonEmits
+declare class HeroProductsHorizontal extends ClassComponent<
+  HeroProductsHorizontalProps,
+  HeroProductsHorizontalSlots,
+  HeroProductsHorizontalEmits
 > {}
 
 declare module 'vue' {
   export interface GlobalComponents {
-    LinkButton: GlobalComponentConstructor<LinkButton>
+    HeroProductsHorizontal: GlobalComponentConstructor<HeroProductsHorizontal>
   }
 }
 
-export default LinkButton
+export default HeroProductsHorizontal

--- a/src/templates/heroproductshorizontal/HeroProductsHorizontal.vue
+++ b/src/templates/heroproductshorizontal/HeroProductsHorizontal.vue
@@ -4,6 +4,7 @@
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
     :justify="justify"
+    :id="id"
   >
     <template #title>
       <Titlegroup v-bind="hgroup" />
@@ -56,6 +57,10 @@
   import Titlegroup from '../titlegroup'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     justify: {
       type: String,
       options: ['center']

--- a/src/templates/herosimplebasewithlogos/HeroSimpleBaseWithLogos.d.ts
+++ b/src/templates/herosimplebasewithlogos/HeroSimpleBaseWithLogos.d.ts
@@ -9,6 +9,7 @@ import { VNode } from 'vue'
 import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
 
 export interface HeroSimpleBaseWithLogosProps {
+  id?: string
   overline?: string
   titleTag?: string
   title?: string

--- a/src/templates/herosimplebasewithlogos/HeroSimpleBaseWithLogos.vue
+++ b/src/templates/herosimplebasewithlogos/HeroSimpleBaseWithLogos.vue
@@ -5,6 +5,7 @@
     :title="title"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template #content>
       <ContentLogoBlock
@@ -20,6 +21,10 @@
   import ContentLogoBlock from '../contentlogo'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/herothumbbottom/HeroThumbBottom.d.ts
+++ b/src/templates/herothumbbottom/HeroThumbBottom.d.ts
@@ -22,6 +22,7 @@ interface Images {
  * Defines valid properties in HeroButtonBottomn component.
  */
 export interface HeroButtonBottomnProps {
+  id?: string
   overline?: string
   title?: string
   description?: string

--- a/src/templates/herothumbbottom/HeroThumbBottom.vue
+++ b/src/templates/herothumbbottom/HeroThumbBottom.vue
@@ -5,6 +5,7 @@
     :title="title"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template #actions>
       <LinkButton
@@ -45,6 +46,10 @@
   import ImageSwitcher from '../themeawareimageswitcher'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/herovideoright/HeroVideoRight.d.ts
+++ b/src/templates/herovideoright/HeroVideoRight.d.ts
@@ -12,6 +12,7 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in HeroVideoRight component.
  */
 export interface HeroVideoRightProps {
+  id?: string
   overline: string
   titleTag: string
   title: string

--- a/src/templates/herovideoright/HeroVideoRight.vue
+++ b/src/templates/herovideoright/HeroVideoRight.vue
@@ -6,6 +6,7 @@
     :title="title"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template #main>
       <BaseModal backgroundColor="outlined">
@@ -118,6 +119,10 @@
   import Tile from '../tile'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/herovideorightcardbackground/HeroVideoRightCardBackground.d.ts
+++ b/src/templates/herovideorightcardbackground/HeroVideoRightCardBackground.d.ts
@@ -12,6 +12,7 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in HeroVideoRightCardBackground component.
  */
 export interface HeroVideoRightCardBackgroundProps {
+  id?: string
   overline: string
   titleTag: string
   title: string

--- a/src/templates/herovideorightcardbackground/HeroVideoRightCardBackround.vue
+++ b/src/templates/herovideorightcardbackground/HeroVideoRightCardBackround.vue
@@ -6,6 +6,7 @@
     :title="title"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template #main>
       <BaseModal backgroundColor="outlined">
@@ -127,6 +128,10 @@
   import CardDescription from '../carddescription'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/sectionbasecards/SectionBaseCards.ts
+++ b/src/templates/sectionbasecards/SectionBaseCards.ts
@@ -17,6 +17,11 @@ type Cards = Array<{
  * Defines valid properties in seectionbasecards component.
  */
 export interface SectionBaseCardsProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   overline: string
   titleTag: string
   title: string

--- a/src/templates/sectionbasecards/SectionBaseCards.vue
+++ b/src/templates/sectionbasecards/SectionBaseCards.vue
@@ -7,6 +7,7 @@
     :title="title"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template v-slot:content>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 lg:gap-10">
@@ -36,6 +37,10 @@
   import CardDescription from '../carddescription'
 
   const props = defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/sectionbasiccontent/SectionBasicContent.d.ts
+++ b/src/templates/sectionbasiccontent/SectionBasicContent.d.ts
@@ -11,6 +11,7 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in SectionBasicContent component.
  */
 export interface SectionBasicContentProps {
+  id?: string | undefined
   overline: string
   title: string
   titleTag: string

--- a/src/templates/sectionbasiccontent/SectionBasicContent.vue
+++ b/src/templates/sectionbasiccontent/SectionBasicContent.vue
@@ -7,6 +7,7 @@
     :title="title"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template #actions>
       <template
@@ -27,6 +28,10 @@
   import LinkButton from '../linkbutton'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/sectionbignumbers/SectionBigNumbers.d.ts
+++ b/src/templates/sectionbignumbers/SectionBigNumbers.d.ts
@@ -24,6 +24,7 @@ interface DataBlock {
  * Defines valid properties in SectionBigNumbers component.
  */
 export interface SectionBigNumbersProps {
+  id?: string
   title: string
   overline: string
   data: DataBlock

--- a/src/templates/sectionbignumbers/SectionBigNumbers.vue
+++ b/src/templates/sectionbignumbers/SectionBigNumbers.vue
@@ -4,6 +4,7 @@
     :overline="overline"
     :title="title"
     :isContentCentralized="data.justify === 'center' ? true : false"
+    :id="id"
   >
     <template
       v-if="button"
@@ -31,6 +32,10 @@
   import LinkButton from '../linkbutton'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     data: {
       type: Object,
       required: true

--- a/src/templates/sectionbignumberslivemap/SectionBigNumbersLivemap.d.ts
+++ b/src/templates/sectionbignumberslivemap/SectionBigNumbersLivemap.d.ts
@@ -24,6 +24,7 @@ interface DataBlock {
  * Defines valid properties in SectionBigNumbersLivemap component.
  */
 export interface SectionBigNumbersLivemapProps {
+  id?: string
   title: string
   overline: string
   lang: string

--- a/src/templates/sectionbignumberslivemap/SectionBigNumbersLivemap.vue
+++ b/src/templates/sectionbignumberslivemap/SectionBigNumbersLivemap.vue
@@ -5,6 +5,7 @@
     :title="title"
     position="left"
     :isContentCentralized="data.justify === 'center' ? true : false"
+    :id="id"
   >
     <template
       v-if="button"
@@ -43,6 +44,10 @@
   import LinkButton from '../linkbutton'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     data: {
       type: Object,
       required: true

--- a/src/templates/sectionbulletsright/SectionBulletsRight.d.ts
+++ b/src/templates/sectionbulletsright/SectionBulletsRight.d.ts
@@ -25,6 +25,11 @@ interface ContentBlock {
  * Defines valid properties in SectionBulletsRight component.
  */
 export interface SectionBulletsRightProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   overline: string
   titleTag: string
   title: string

--- a/src/templates/sectionbulletsright/SectionBulletsRight.vue
+++ b/src/templates/sectionbulletsright/SectionBulletsRight.vue
@@ -5,6 +5,7 @@
     :overline="overline"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template #actions>
       <template
@@ -33,6 +34,10 @@
   import UnorderedList from '../listunordered'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/sectionbulletsrightwithlogos/SectionBulletsRightWithLogos.d.ts
+++ b/src/templates/sectionbulletsrightwithlogos/SectionBulletsRightWithLogos.d.ts
@@ -12,6 +12,7 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in SectionBulletsRightWithLogos component.
  */
 export interface SectionBulletsRightWithLogosProps {
+  id?: string | undefined
   title: string
   severity: string
   button: {

--- a/src/templates/sectionbulletsrightwithlogos/SectionBulletsRightWithLogos.vue
+++ b/src/templates/sectionbulletsrightwithlogos/SectionBulletsRightWithLogos.vue
@@ -2,6 +2,7 @@
   <ContentSection
     titleTag="h2"
     :title="title"
+    :id="id"
   >
     <template v-slot:actions>
       <template v-if="button && button.label">
@@ -33,6 +34,10 @@
   import UnorderedList from '../listunordered'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     // gap: {
     //   type: String,
     //   default: () => 'default',

--- a/src/templates/sectioncardbackground/SectionCardBackground.d.ts
+++ b/src/templates/sectioncardbackground/SectionCardBackground.d.ts
@@ -8,6 +8,7 @@ import { VNode } from 'vue'
 import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
 
 export interface SectionCardBackgroundProps {
+  id?: string
   overline: string
   titleTag: string
   title: string

--- a/src/templates/sectioncardbackground/SectionCardBackground.vue
+++ b/src/templates/sectioncardbackground/SectionCardBackground.vue
@@ -7,6 +7,7 @@
     :title="props.title"
     :description="props.description"
     :descriptionRawHtml="props.descriptionRawHtml"
+    :id="id"
   >
     <template #actions>
       <template v-if="props.buttons[0] && props.buttons[0].label">
@@ -63,6 +64,10 @@
   import CardDescription from '../carddescription'
 
   const props = defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/sectioncardbackgroundintercalated/SectionCardBackgroundIntercalated.d.ts
+++ b/src/templates/sectioncardbackgroundintercalated/SectionCardBackgroundIntercalated.d.ts
@@ -12,6 +12,7 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in SectionCardBackgroundIntercalated component.
  */
 export interface SectionCardBackgroundIntercalatedProps {
+  id?: string
   overline: string
   titleTag: string
   title: string

--- a/src/templates/sectioncardbackgroundintercalated/SectionCardBackgroundIntercalated.vue
+++ b/src/templates/sectioncardbackgroundintercalated/SectionCardBackgroundIntercalated.vue
@@ -4,6 +4,7 @@
     :title="title"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template #content>
       <div class="m-0 grid grid-cols-1 md:grid-cols-2 gap-10 md:pt-32">
@@ -42,6 +43,10 @@
   import CardBgImage from '../cardbgimage'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/sectioncardcarousel/SectionCardCarousel.vue
+++ b/src/templates/sectioncardcarousel/SectionCardCarousel.vue
@@ -7,6 +7,7 @@
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
     :isContentCentralized="true"
+    :id="id"
   >
     <template #main>
       <Carousel
@@ -54,6 +55,10 @@
   import CardDescription from '../carddescription'
 
   const props = defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/sectioncardexpandable/SectionCardExpandable.d.ts
+++ b/src/templates/sectioncardexpandable/SectionCardExpandable.d.ts
@@ -9,6 +9,11 @@ import { VNode } from 'vue'
 import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
 
 export interface SectionCardExpandableProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   overline: string
   titleTag: string
   title: string

--- a/src/templates/sectioncardexpandable/SectionCardExpandable.vue
+++ b/src/templates/sectioncardexpandable/SectionCardExpandable.vue
@@ -8,6 +8,7 @@
     :overline="overline"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template #main>
       <CardPanelExpandable
@@ -101,6 +102,10 @@
   import LinkButton from '../linkbutton'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/sectioncardnavigation/SectionCardNavigation.d.ts
+++ b/src/templates/sectioncardnavigation/SectionCardNavigation.d.ts
@@ -12,6 +12,11 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in SectionCardNavigation component.
  */
 export interface SectionCardNavigationProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   overline: string
   titleTag: string
   title: string

--- a/src/templates/sectioncardnavigation/SectionCardNavigation.vue
+++ b/src/templates/sectioncardnavigation/SectionCardNavigation.vue
@@ -5,6 +5,7 @@
     :title="title"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template #content>
       <div
@@ -38,6 +39,10 @@
   import LinkButton from '../linkbutton'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/sectioncarousel/SectionCarousel.d.ts
+++ b/src/templates/sectioncarousel/SectionCarousel.d.ts
@@ -25,6 +25,7 @@ type CardsType = {
  * Defines valid properties in SectionCarousels component.
  */
 export interface SectionCarouselsProps {
+  id?: string
   title: string
   overline: string
   description: string

--- a/src/templates/sectioncarousel/SectionCarousel.vue
+++ b/src/templates/sectioncarousel/SectionCarousel.vue
@@ -4,6 +4,7 @@
     :overline="overline"
     :title="title"
     :description="description"
+    :id="id"
   >
     <template
       v-if="button"
@@ -75,6 +76,10 @@
   import Tag from 'primevue/tag'
 
   const props = defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       required: false

--- a/src/templates/sectioncarouselrelease/SectionCarouselRelease.d.ts
+++ b/src/templates/sectioncarouselrelease/SectionCarouselRelease.d.ts
@@ -48,6 +48,7 @@ interface AnalystItem {
  * Defines valid properties in SectionCarouselRelease component.
  */
 export interface SectionCarouselReleaseProps {
+  id?: string
   overline: string
   titleTag: string
   title: string

--- a/src/templates/sectioncarouselrelease/SectionCarouselRelease.vue
+++ b/src/templates/sectioncarouselrelease/SectionCarouselRelease.vue
@@ -6,6 +6,7 @@
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
     :isContentCentralized="true"
+    :id="id"
   >
     <template #principal>
       <div class="relative">
@@ -20,6 +21,10 @@
   import ReleaseCarousel from '../releasecarousel'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/sectioncompliance/SectionCompliance.d.ts
+++ b/src/templates/sectioncompliance/SectionCompliance.d.ts
@@ -26,6 +26,11 @@ interface ButtonProps {
  * Defines valid properties in SectionCompliances component.
  */
 export interface SectionCompliancesProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   overline?: string
   titleTag: string
   title: string

--- a/src/templates/sectioncompliance/SectionCompliance.vue
+++ b/src/templates/sectioncompliance/SectionCompliance.vue
@@ -5,6 +5,7 @@
     :title="title"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template #main>
       <div class="w-full flex lg:justify-end lg:items-end">
@@ -48,6 +49,10 @@
   import Tile from '../tile'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       required: false

--- a/src/templates/sectiongridbento2c5i/SectionGridBento2c5i.d.ts
+++ b/src/templates/sectiongridbento2c5i/SectionGridBento2c5i.d.ts
@@ -25,6 +25,11 @@ type Cards = Array<{
  * Defines valid properties in sectiongridbento2c5i component.
  */
 export interface SectionGridBento2c5iProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   overline: string
   title: string
   description: string

--- a/src/templates/sectiongridbento2c5i/SectionGridBento2c5i.vue
+++ b/src/templates/sectiongridbento2c5i/SectionGridBento2c5i.vue
@@ -5,6 +5,7 @@
     :title="title"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template v-slot:content>
       <GridBentoBlock :gridType="gridType">
@@ -225,6 +226,10 @@
   import Overline from '../overline'
 
   const props = defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/sectiongridhighlight/SectionGridHighlight.d.ts
+++ b/src/templates/sectiongridhighlight/SectionGridHighlight.d.ts
@@ -27,6 +27,7 @@ interface ButtonProps {
  * Defines valid properties in SectionGridHighlight component.
  */
 export interface SectionGridHighlightProps {
+  id?: string
   overline?: string
   title: string
   titleTag: string

--- a/src/templates/sectiongridhighlight/SectionGridHighlight.vue
+++ b/src/templates/sectiongridhighlight/SectionGridHighlight.vue
@@ -7,6 +7,7 @@
     :title="title"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template #main>
       <GridHighlight :cards="cards" />
@@ -18,6 +19,10 @@
   import ContentSection from '../contentsection'
   import GridHighlight from '../gridhighlight'
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       required: false

--- a/src/templates/sectionhorizontalnavigation/SectionHorizontalNavigation.d.ts
+++ b/src/templates/sectionhorizontalnavigation/SectionHorizontalNavigation.d.ts
@@ -12,6 +12,11 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in SectionHorizontalNavitaion component.
  */
 export interface SectionHorizontalNavitaionProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   overline: string
   titleTag: string
   title: string

--- a/src/templates/sectionhorizontalnavigation/SectionHorizontalNavigation.vue
+++ b/src/templates/sectionhorizontalnavigation/SectionHorizontalNavigation.vue
@@ -6,6 +6,7 @@
     :title="props.title"
     :description="props.description"
     :descriptionRawHtml="props.descriptionRawHtml"
+    :id="id"
   >
     <template #actions>
       <LinkButton
@@ -100,7 +101,11 @@
   import LinkButton from '../linkbutton'
   import Menu from 'primevue/menu'
 
-  const props = defineProps({
+  const props = defineProps({ 
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String
     },

--- a/src/templates/sectionimageright/SectionImageRight.d.ts
+++ b/src/templates/sectionimageright/SectionImageRight.d.ts
@@ -12,6 +12,11 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in SectionImageRight component.
  */
 export interface SectionImageRightProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   titleTag: string
   overline: string
   title: string

--- a/src/templates/sectionimageright/SectionImageRight.vue
+++ b/src/templates/sectionimageright/SectionImageRight.vue
@@ -5,6 +5,7 @@
     :title="props.title"
     :description="props.description"
     :descriptionRawHtml="props.descriptionRawHtml"
+    :id="id"
   >
     <template #actions>
       <template
@@ -47,6 +48,10 @@
   import ImageSwitcher from '../themeawareimageswitcher'
 
   const props = defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''

--- a/src/templates/sectionintercalatedcontent/SectionIntercalatedContent.d.ts
+++ b/src/templates/sectionintercalatedcontent/SectionIntercalatedContent.d.ts
@@ -22,6 +22,7 @@ type Items = Array<{
  * Defines valid properties in SectionIntercalatedContent component.
  */
 export interface SectionIntercalatedContentProps {
+  id?: string
   overline: string
   titleTag: string
   title: string

--- a/src/templates/sectionintercalatedcontent/SectionIntercalatedContent.vue
+++ b/src/templates/sectionintercalatedcontent/SectionIntercalatedContent.vue
@@ -7,6 +7,7 @@
         :overline="overline"
         :titleTag="titleTag"
         :title="title"
+        :id="id"
       />
     </template>
 
@@ -21,6 +22,7 @@
         :title="item.title"
         :descriptionRawHtml="item.descriptionRawHtml"
         :position="item.position || 'left'"
+        :id="id"
       >
         <template v-slot:main>
           <div class="w-full flex justify-center">
@@ -56,6 +58,10 @@
   import ImageSwitcher from '../themeawareimageswitcher'
 
   const props = defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String
     },

--- a/src/templates/sectioninvestorlogos/SectionInvestorsLogos.d.ts
+++ b/src/templates/sectioninvestorlogos/SectionInvestorsLogos.d.ts
@@ -12,6 +12,11 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in SectionInvestorLogos component.
  */
 export interface SectionInvestorLogosProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   logos: string[]
   title: string
   overline: string

--- a/src/templates/sectioninvestorlogos/SectionInvestorsLogos.vue
+++ b/src/templates/sectioninvestorlogos/SectionInvestorsLogos.vue
@@ -6,6 +6,7 @@
     textCenter
     :title="title"
     :overline="overline"
+    :id="id"
   >
     <template #content>
       <div class="flex items-center flex-col md:flex-row justify-center gap-8">
@@ -23,7 +24,11 @@
 <script setup>
   import ContentSection from '../contentsection'
 
-  defineProps({
+  defineProps({ 
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       required: false

--- a/src/templates/sectionlistavatars/SectionListAvatars.d.ts
+++ b/src/templates/sectionlistavatars/SectionListAvatars.d.ts
@@ -16,6 +16,11 @@ type Avatars = Array<{
 }>
 
 export interface SectionListAvatarsProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   titleTag: string
   image: string
   title: string

--- a/src/templates/sectionlistavatars/SectionListAvatars.vue
+++ b/src/templates/sectionlistavatars/SectionListAvatars.vue
@@ -6,6 +6,7 @@
     :overline="props.overline"
     :titleTag="props.titleTag"
     :title="props.title"
+    :id="id"
   >
     <template #main>
       <div class="flex flex-wrap gap-2 gap-y-4 w-full justify-center">
@@ -38,6 +39,10 @@
   import ContentSection from '../contentsection'
 
   const props = defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     titleTag: {
       type: String,
       default() {

--- a/src/templates/sectionlistproducts/SectionListProducts.d.ts
+++ b/src/templates/sectionlistproducts/SectionListProducts.d.ts
@@ -9,6 +9,7 @@ import { VNode } from 'vue'
 import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
 
 export interface SectionListProductsProps {
+  id?: string
   overline: string
   titleTag: string
   title: string

--- a/src/templates/sectionlistproducts/SectionListProducts.vue
+++ b/src/templates/sectionlistproducts/SectionListProducts.vue
@@ -6,6 +6,7 @@
     :title="props.title"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
   >
     <template #main>
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 place-content-center m-0">
@@ -30,6 +31,10 @@
   import ProductCard from '../productcard'
 
   const props = defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String
     },

--- a/src/templates/sectionmapedgenetwork/SectionMapEdgeNetwork.d.ts
+++ b/src/templates/sectionmapedgenetwork/SectionMapEdgeNetwork.d.ts
@@ -12,6 +12,11 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in SectionMapOurNetwork component.
  */
 export interface SectionMapOurNetworkProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   overline: string
   title: string
   description: string

--- a/src/templates/sectionmapedgenetwork/SectionMapEdgeNetwork.vue
+++ b/src/templates/sectionmapedgenetwork/SectionMapEdgeNetwork.vue
@@ -4,6 +4,7 @@
     :titleTag="titleTag"
     :title="title"
     :description="description"
+    :id="id"
     isContentCentralized
   >
     <template #content>
@@ -108,6 +109,10 @@
   // import Badge from 'primevue/badge'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String
     },

--- a/src/templates/sectionnumberedcards/SectionNumberedCards.d.ts
+++ b/src/templates/sectionnumberedcards/SectionNumberedCards.d.ts
@@ -7,6 +7,11 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in SectionNumberedCards component.
  */
 export interface SectionNumberedCardsProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   overline?: string
   title: string
   titleTag: string

--- a/src/templates/sectionnumberedcards/SectionNumberedCards.vue
+++ b/src/templates/sectionnumberedcards/SectionNumberedCards.vue
@@ -7,6 +7,7 @@
     :overline="overline"
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
+    :id="id"
     textCenter
   >
     <template #main>
@@ -55,6 +56,10 @@
   import LinkButton from '../linkbutton'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       required: false

--- a/src/templates/sectionoverview/SectionOverview.d.ts
+++ b/src/templates/sectionoverview/SectionOverview.d.ts
@@ -25,6 +25,7 @@ interface ContentBlock {
  * Defines valid properties in SectionOverview component.
  */
 export interface SectionOverviewProps {
+  id?: string
   overline: string
   title: string
   description: string

--- a/src/templates/sectionoverview/SectionOverview.vue
+++ b/src/templates/sectionoverview/SectionOverview.vue
@@ -6,6 +6,7 @@
     :description="description"
     :descriptionRawHtml="descriptionRawHtml"
     :isSticky="isSticky"
+    :id="id"
   >
     <template #actions>
       <LinkButton
@@ -31,6 +32,10 @@
   import DescriptionUnorderedList from '../listdescriptionunordered'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     isSticky: {
       type: Boolean,
       default: () => true

--- a/src/templates/sectionpriceandpartner/SectionPriceAndPartner.d.ts
+++ b/src/templates/sectionpriceandpartner/SectionPriceAndPartner.d.ts
@@ -12,6 +12,7 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in SectionPriceAndPartner component.
  */
 export interface SectionPriceAndPartnerProps {
+  id?: string
   overline?: string
   title: string
   description: string

--- a/src/templates/sectionpriceandpartner/SectionPriceAndPartner.vue
+++ b/src/templates/sectionpriceandpartner/SectionPriceAndPartner.vue
@@ -7,6 +7,7 @@
     :isSticky="isSticky"
     position="center"
     isContentCentralized
+    :id="id"
   >
     <template #main>
       <div class="flex justify-center">
@@ -21,6 +22,10 @@
   import ContentSection from '../contentsection'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     isSticky: {
       type: Boolean,
       default() {

--- a/src/templates/sectionsticky/SectionSticky.d.ts
+++ b/src/templates/sectionsticky/SectionSticky.d.ts
@@ -36,6 +36,7 @@ type Sections = {
  * Defines valid properties in SectionStickys component.
  */
 export interface SectionStickysProps {
+  id?: string
   title: string
   overline: string
   sections: Sections[]

--- a/src/templates/sectionsticky/SectionSticky.vue
+++ b/src/templates/sectionsticky/SectionSticky.vue
@@ -5,6 +5,7 @@
         :overline="overline"
         :titleTag="titleTag"
         :title="title"
+        :id="id"
       />
     </div>
     <div class="flex flex-col gap-20 lg:gap-40 xl:gap-60 2xl:gap-80">
@@ -23,6 +24,7 @@
           :title="title"
           :description="description"
           :descriptionRawHtml="descriptionRawHtml"
+          :id="id"
         >
           <template #actions>
             <template
@@ -71,6 +73,10 @@
   import ImageSwitcher from '../themeawareimageswitcher'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       required: false

--- a/src/templates/sectionsuccesscases/SectionSuccessCases.d.ts
+++ b/src/templates/sectionsuccesscases/SectionSuccessCases.d.ts
@@ -24,6 +24,11 @@ type ButtonType = {}
  * Defines valid properties in SectionSuccessCases component.
  */
 export interface SectionSuccessCasesProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   button: ButtonType
   title: string
   overline: string

--- a/src/templates/sectionsuccesscases/SectionSuccessCases.vue
+++ b/src/templates/sectionsuccesscases/SectionSuccessCases.vue
@@ -3,6 +3,7 @@
     :overline="overline"
     :title="title"
     titleTag="h2"
+    :id="id"
   >
     <template
       #main
@@ -62,6 +63,10 @@
   import Tag from 'primevue/tag'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       required: false

--- a/src/templates/sectionvideoright/SectionVideoRight.d.ts
+++ b/src/templates/sectionvideoright/SectionVideoRight.d.ts
@@ -12,6 +12,11 @@ import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers'
  * Defines valid properties in SectionVideoRight component.
  */
 export interface SectionVideoRightProps {
+  id?: string | undefined
+  /**
+   * Defines the id of the section
+   * @defaultValue ''
+   */
   overline: string
   titleTag: string
   title: string

--- a/src/templates/sectionvideoright/SectionVideoRight.vue
+++ b/src/templates/sectionvideoright/SectionVideoRight.vue
@@ -5,7 +5,8 @@
     :titleTag="titleTag"
     :title="title"
     :description="description"
-    :descriptionRawHtml="descriptionRawHtml"
+    :descriptionRawHtml="descriptionRawHtml"  
+    :id="id"
   >
     <template #main>
       <BaseModal backgroundColor="outlined">
@@ -118,6 +119,10 @@
   import Tile from '../tile'
 
   defineProps({
+    id: {
+      type: String,
+      default: () => ''
+    },
     overline: {
       type: String,
       default: () => ''


### PR DESCRIPTION
- Add id prop to all Section components that use ContentSection
- Add id prop to all Hero components that use HeroBase/HeroBlockBase
- Update Vue components to accept and forward id prop to base components
- Update TypeScript definitions to include optional id property
- Fix HeroProductsHorizontal.d.ts with correct component interface

Section components affected:
- SectionBasicContent, SectionBaseCards, SectionCardBackground
- SectionCardBackgroundIntercalated, SectionBigNumbers, SectionBigNumbersLivemap
- SectionCarousel, SectionCarouselRelease, SectionGridHighlight
- SectionIntercalatedContent, SectionListProducts, SectionOverview
- SectionPriceAndPartner, SectionSticky

Hero components affected:
- HeroHome, HeroFeaturedBottom, HeroVideoRight, HeroProductsHorizontal
- HeroImageRightLogos, HeroSimpleBaseWithLogos, HeroThumbBottom
- HeroVideoRightCardBackground

This allows setting custom IDs on both section and hero components for better accessibility, styling targeting, and navigation purposes. The id prop is properly forwarded from wrapper components to their base ContentSection and HeroBase components.