### PR TITLE
fix: hero hs form list not required

### DIFF
--- a/src/templates/herohsformright/HeroHsFormRight.vue
+++ b/src/templates/herohsformright/HeroHsFormRight.vue
@@ -5,7 +5,7 @@
     :description="props.description"
     :descriptionRawHtml="props.descriptionRawHtml"
   >
-    <template #content>
+    <template v-if="props.list.length" #content>
       <div class="flex flex-col gap-10 w-full">
         <UnorderedList :data="props.list" />
       </div>


### PR DESCRIPTION
This PR fixes an issue with the Hero HS Form component where the list field was empty and the component was rendered.