### PR TITLE
fix: hubspot form checkbox alignment

### DIFF
--- a/src/assets/styles/hsform.css
+++ b/src/assets/styles/hsform.css
@@ -170,3 +170,9 @@ strong {
 .form-columns-2 > .hs-form-field:first-of-type > .input {
   margin-right: 24px;
 }
+
+.hs-form-checkbox-display {
+  display: flex !important;
+  align-items: center !important;
+  gap: 0.25rem !important;
+}


### PR DESCRIPTION
This PR fixes the alignment issue with checkboxes in HubSpot forms by adding proper CSS styling to ensure consistent visual alignment and spacing.