### PR TITLE
fix: update markdown service import paths

### DIFF
--- a/src/blocks/Hero2Column/Hero2Column.vue
+++ b/src/blocks/Hero2Column/Hero2Column.vue
@@ -70,7 +70,7 @@
 <script setup lang="ts">
   import { computed } from 'vue'
   import Button from '../../components/Button/Button.vue'
-  import { parseMarkdown } from 'src/services/markdown-service'
+  import { parseMarkdown } from '../../src/services/markdown-service'
 
   export interface Hero2ColumnButtonProps {
     label: string

--- a/src/blocks/SectionCardCarousel/SectionCardCarousel.vue
+++ b/src/blocks/SectionCardCarousel/SectionCardCarousel.vue
@@ -87,7 +87,7 @@
   import Button from '../../components/Button/Button.vue'
   import 'swiper/css'
   import 'swiper/css/navigation'
-  import { parseMarkdown } from 'src/services/markdown-service'
+  import { parseMarkdown } from '../../src/services/markdown-service'
 
   export interface CarouselCard {
     tag?: string

--- a/src/blocks/SectionCards3Column/SectionCards3Column.vue
+++ b/src/blocks/SectionCards3Column/SectionCards3Column.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script setup lang="ts">
-  import { parseMarkdown } from 'src/services/markdown-service'
+  import { parseMarkdown } from '../../src/services/markdown-service'
 
   export interface Card3Column {
     icon: string

--- a/src/blocks/SectionImageContent2Column/SectionImageContent2Column.vue
+++ b/src/blocks/SectionImageContent2Column/SectionImageContent2Column.vue
@@ -100,7 +100,7 @@
 
 <script setup>
   import { computed } from 'vue'
-  import { parseMarkdown } from 'src/services/markdown-service'
+  import { parseMarkdown } from '../../src/services/markdown-service'
 
   const props = defineProps({
     title: {


### PR DESCRIPTION
- Fixed incorrect import paths for markdown-service across multiple components
- Changed from absolute path 'src/services/markdown-service' to relative path '../../src/services/markdown-service'
- Updated imports in Hero2Column, SectionCardCarousel, SectionCards3Column, and SectionImageContent2Column components