### PR TITLE
fix: enhance link styling in markdown parser

### DIFF
--- a/src/services/markdown-service.js
+++ b/src/services/markdown-service.js
@@ -48,7 +48,7 @@ export const parseMarkdown = (markdown) => {
     .replace(/_([^_\n]+(?:\n[^_\n]*)*?)_/gs, '<em class="font-sora">$1</em>')
   
   text = text
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a class="font-sora text-violet-500 underline hover:text-violet-400 transition-colors" href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a class="font-sora underline transition-colors" style="color: #8B5CF6; text-decoration-color: #8B5CF6;" onmouseover="this.style.color=\'#7C3AED\'; this.style.textDecorationColor=\'#7C3AED\';" onmouseout="this.style.color=\'#8B5CF6\'; this.style.textDecorationColor=\'#8B5CF6\';" href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
   
   const blocks = text.split(/\n\s*\n/)
   


### PR DESCRIPTION
- Replaced Tailwind classes with inline styles for link color and hover effects
- Set explicit violet color (#8B5CF6) and hover color (#7C3AED) for consistent link styling
- Added text-decoration-color to match link color for better visual cohesion
- Implemented hover effects using onmouseover/onmouseout events instead of CSS transitions