### PR TITLE
feat: redesign call-to-action section with split layout

### DIFF
--- a/src/blocks/SectionCallToAction/SectionCallToAction.vue
+++ b/src/blocks/SectionCallToAction/SectionCallToAction.vue
@@ -1,26 +1,36 @@
 <template>
   <section
     :id="id"
-    class="text-white relative max-w-xl xxxl:max-w-xxl mx-auto md:p-12 p-6 mb-40"
+    class="flex flex-wrap md:flex-nowrap relative max-w-xl xxxl:max-w-xxl mx-auto gap-2 md:p-12 p-6 mb-40"
   >
-    <div class="flex flex-col items-start text-left gap-8 md:gap-12">
-      <div class="flex flex-col gap-10">
-        <h2 v-if="title" class="display-1 font-normal tracking-tight text-orange-500">
-          {{ title }}
-        </h2>
-      </div>
+    <div class="flex w-full md:w-1/3 md:flex-wrap items-start flex-col bg-neutral-900 rounded-md justify-between text-left">
+      <div class="p-12 ">
+        <div class="flex flex-col">
+          <span v-if="cta.overline" class="text-xs font-proto-mono uppercase text-balance text-orange-500 w-full pb-3">{{ cta.overline }}</span>
+          <h2 v-if="cta.title" class="display-3 font-normal tracking-tight text-neutral-100">
+            {{ cta.title }}
+          </h2>
+          <div v-html="cta.descriptionRawMarkdown" class="text-balance text-neutral-400 text-base mt-3 font-sora"></div>
+        </div>
 
-      <div v-if="buttons && buttons.length > 0" class="flex flex-row gap-4">
-        <Button
-          v-for="(button, index) in buttons"
-          :key="index"
-          :href="button.href"
-          :label="button.label"
-          :type="'primary'"
-          size="small"
-          :theme="button.theme || 'dark'"
-        />
+        <div v-if="cta.link && cta.linkLabel" class="flex flex-row gap-4 mt-44">
+          <Button
+            :href="cta.link"
+            :label="cta.linkLabel"
+            :type="'linkSecondary'"
+            size="small"
+            theme="dark"
+            customClass="px-0 py-0"
+          />
+        </div>
       </div>
+    </div>
+    <div class="flex w-full md:w-2/3 p-12 flex-col justify-between bg-orange-500 md:bg-neutral-800 hover:bg-orange-500 transition-colors duration-150 rounded-md flex-wrap">
+      <div class="w-full flex-col gap-3 flex">
+        <span v-if="content.overline" class="text-xs font-proto-mono uppercase text-balance text-neutral-950 w-full">{{ content.overline }}</span>
+        <div v-html="content.descriptionRawMarkdown" class="text-balance text-neutral-950 font-sora mb-12 md:mb-0"></div>
+      </div>
+      <h3 v-if="content.title" class="text-neutral-950 font-bold font-sora display-1">{{ content.title }}</h3>
     </div>
   </section>
 </template>
@@ -36,12 +46,23 @@
   }
 
   interface SectionCallToActionProps {
-    title?: string
-    buttons?: CallToActionButton[]
-    id?: string
+    id?: string,
+    cta?: {
+      overline?: string,
+      title?: string,
+      descriptionRawMarkdown?: string,
+      linkLabel?: string,
+      link?: string
+    },
+    content?: {
+      overline?: string,
+      descriptionRawMarkdown?: string,
+      title?: string
+    }
   }
 
   const props = withDefaults(defineProps<SectionCallToActionProps>(), {
-    buttons: () => []
+    cta: () => ({}),
+    content: () => ({})
   })
 </script>


### PR DESCRIPTION
- Restructured CTA section to use a split layout with left sidebar (1/3) and main content (2/3)
- Added new styling with distinct background colors and hover effects
- Updated props interface to support separate CTA and content sections with overlines, titles and descriptions
- Implemented responsive design with flex-wrap on mobile and flex-nowrap on desktop
- Added support for markdown content in both CTA and main content sections
- Enhance