### PR TITLE
fix: add markdown parsing to call-to-action section

### DIFF
--- a/src/blocks/SectionCallToAction/SectionCallToAction.vue
+++ b/src/blocks/SectionCallToAction/SectionCallToAction.vue
@@ -10,7 +10,7 @@
           <h2 v-if="cta.title" class="display-3 font-normal tracking-tight text-neutral-100">
             {{ cta.title }}
           </h2>
-          <div v-html="cta.descriptionRawMarkdown" class="text-balance text-neutral-400 text-base mt-3 font-sora"></div>
+          <div v-html="parseMarkdown(cta.descriptionRawMarkdown)" class="text-balance text-neutral-400 text-base mt-3 font-sora"></div>
         </div>
 
         <div v-if="cta.link && cta.linkLabel" class="flex flex-row gap-4 mt-44">
@@ -28,7 +28,7 @@
     <div class="flex w-full md:w-2/3 p-12 flex-col justify-between bg-orange-500 md:bg-neutral-800 hover:bg-orange-500 transition-colors duration-150 rounded-md flex-wrap">
       <div class="w-full flex-col gap-3 flex">
         <span v-if="content.overline" class="text-xs font-proto-mono uppercase text-balance text-neutral-950 w-full">{{ content.overline }}</span>
-        <div v-html="content.descriptionRawMarkdown" class="text-balance text-neutral-950 font-sora mb-12 md:mb-0"></div>
+        <div v-html="parseMarkdown(content.descriptionRawMarkdown)" class="text-balance text-neutral-950 font-sora mb-12 md:mb-0"></div>
       </div>
       <h3 v-if="content.title" class="text-neutral-950 font-bold font-sora display-1">{{ content.title }}</h3>
     </div>
@@ -37,6 +37,7 @@
 
 <script setup lang="ts">
   import Button from '../../components/Button'
+  import { parseMarkdown } from '../../src/services/markdown-service'
 
   export interface CallToActionButton {
     label: string


### PR DESCRIPTION
- Added parseMarkdown function to handle raw markdown content in CTA descriptions
- Imported markdown-service utility to process markdown text safely
- Applied markdown parsing to both main CTA and content area descriptions