### PR TITLE
fix: correct image vertical positioning in 2-column section

### DIFF
--- a/src/blocks/SectionImageContent2Column/SectionImageContent2Column.vue
+++ b/src/blocks/SectionImageContent2Column/SectionImageContent2Column.vue
@@ -46,7 +46,7 @@
                   />
                   </div>  
                   <div v-if="image"
-                    class="absolute left-1/2 bottom-1/2 -translate-x-1/2 translate-y-1 rounded-lg overflow-hidden h-4/5 w-11/12"
+                    class="absolute left-1/2 bottom-1/2 -translate-x-1/2 translate-y-1/2 rounded-lg overflow-hidden h-4/5 w-11/12"
                   >
                     <img
                       :src="image"


### PR DESCRIPTION
- Fixed vertical alignment by changing translate-y-1 to translate-y-1/2 to properly center the image
- Ensures image is vertically centered within its container using Tailwind's translate utilities