### PR TITLE
fix: improve responsive typography and spacing

### DIFF
--- a/src/blocks/Hero2Column/Hero2Column.vue
+++ b/src/blocks/Hero2Column/Hero2Column.vue
@@ -8,7 +8,7 @@
       class="flex flex-col md:flex-row items-center max-w-xl xxxl:max-w-xxl mx-auto relative z-10 p-6 md:p-0"
     >
       <div
-        class="flex w-full md:w-1/2 pb-6 p-6 md:p-12 flex-col gap-3 md:gap-4 lg:gap-5 text-center lg:text-left"
+        class="flex w-full md:w-1/2 pb-6 md:p-12 flex-col gap-3 md:gap-4 lg:gap-5 text-center lg:text-left"
       >
         <div class="flex flex-col gap-2 md:gap-3">
           <p
@@ -43,7 +43,7 @@
         </div>
       </div>
       <div
-        class="relative flex w-full md:w-1/2 p-6 md:p-12 items-center justify-center"
+        class="relative flex w-full md:w-1/2 md:p-12 items-center justify-center"
       >
         <div
           v-if="image"

--- a/src/blocks/SectionCardCarousel/SectionCardCarousel.vue
+++ b/src/blocks/SectionCardCarousel/SectionCardCarousel.vue
@@ -56,7 +56,7 @@
               </span>
             </div>
             
-            <h3 class="display-3-mobile md:display-3 text-white font-sora">
+            <h3 class="display-5-mobile md:display-5 text-white font-sora">
               {{ card.title }}
             </h3>
             

--- a/src/blocks/SectionCards3Column/SectionCards3Column.vue
+++ b/src/blocks/SectionCards3Column/SectionCards3Column.vue
@@ -26,7 +26,7 @@
         >
           <div class="flex items-center gap-2">
             <span :class="card.icon" class="text-orange-500 text-xl flex-shrink-0"></span>
-            <h3 class="display-3-mobile md:display-3 text-white font-sora">{{ card.title }}</h3>
+            <h3 class="display-5-mobile md:display-5 text-white font-sora">{{ card.title }}</h3>
           </div>
           <div 
             class="body-2 text-neutral-400 leading-relaxed font-sora"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -103,7 +103,7 @@ module.exports = {
           letterSpacing: '-.05rem',
         },
         '.body-2': {
-          fontSize: '.75rem',
+          fontSize: '.875rem',
           lineHeight: '1.4rem',
           fontFamily: 'Sora',
           letterSpacing: '-.05rem',


### PR DESCRIPTION
- Updated heading styles in card components from display-3 to display-5 for better visual hierarchy
- Increased body-2 font size from 0.75rem to 0.875rem for improved readability
- Removed redundant padding in Hero2Column mobile view while preserving desktop spacing
- Standardized card title typography across SectionCardCarousel and SectionCards3Column components