### PR TITLE
fix: replace Overline component with direct styling

### DIFF
--- a/src/blocks/SectionCallToAction/SectionCallToAction.vue
+++ b/src/blocks/SectionCallToAction/SectionCallToAction.vue
@@ -9,7 +9,7 @@
       class="lg:col-span-3 w-full flex flex-col justify-between gap-6 bg-neutral-900 rounded-md p-6 md:p-12"
     >
       <div class="flex flex-col gap-3">
-        <Overline color="orange"> {{ content.overline }} </Overline>
+        <p class="text-orange-500 text-xs font-proto-mono uppercase tracking-wide">{{ content.overline }}</p>
         <h2 class="text-2xl text-neutral-200 font-sora">{{ content.title }}</h2>
         <p
           class="text-neutral-400 font-sora"
@@ -33,7 +33,7 @@
         class="flex gap-3"
         :class="type.includes('short') ? 'flex flex-col md:flex-row justify-between' : 'flex-col'"
       >
-        <Overline color="black"> {{ cta.overline }} </Overline>
+        <p class="text-neutral-900 text-xs font-proto-mono uppercase tracking-wide">{{ cta.overline }}</p>
         <p
           class="max-w-sm text-balance font-sora text-xl text-neutral-900"
           v-html="parseMarkdown(cta.descriptionRawMarkdown)"
@@ -58,7 +58,6 @@
 
 <script setup lang="ts">
   import Button from '../../components/Button/Button.vue'
-  import Overline from '../../components/overline/Overline.vue'
   import { parseMarkdown } from '../../src/services/markdown-service'
   import { computed } from 'vue'
 


### PR DESCRIPTION
- Removed Overline component dependency and replaced with inline styled paragraph tags
- Applied equivalent text styling (color, font, tracking, etc.) directly in template
- Removed unused Overline component import
- Maintained same visual appearance while reducing component complexity