### PR TITLE
feat(overline): make no-wrap behavior configurable

### DIFF
--- a/packages/webkit/src/components/overline/overline.vue
+++ b/packages/webkit/src/components/overline/overline.vue
@@ -1,23 +1,28 @@
 <script>
-// Using hex escape sequences for angle brackets to avoid Vue template parser issues
-// \x3C = < (less than), \x3E = > (greater than), \x2F = / (slash)
-const ANGLE_OPEN = '\x3C'
-const ANGLE_CLOSE = '\x3E'
-const SLASH = '\x2F'
+  // Using hex escape sequences for angle brackets to avoid Vue template parser issues
+  // \x3C = < (less than), \x3E = > (greater than), \x2F = / (slash)
+  const ANGLE_OPEN = '\x3C'
+  const ANGLE_CLOSE = '\x3E'
+  const SLASH = '\x2F'
 
-export default {
-  props: {
-    showCursor: {
-      type: Boolean,
-      default: false
-    },
-    prefix: {
-      type: String,
-      default: '',
-      validator: (value) => ['', '//', ANGLE_OPEN + ANGLE_CLOSE, ANGLE_OPEN + SLASH + ANGLE_CLOSE].includes(value)
+  export default {
+    props: {
+      singleLine: {
+        type: Boolean,
+        default: true
+      },
+      showCursor: {
+        type: Boolean,
+        default: false
+      },
+      prefix: {
+        type: String,
+        default: '',
+        validator: (value) =>
+          ['', '//', ANGLE_OPEN + ANGLE_CLOSE, ANGLE_OPEN + SLASH + ANGLE_CLOSE].includes(value)
+      }
     }
   }
-}
 </script>
 
 <template>
@@ -27,15 +32,20 @@ export default {
   >
     <span
       v-if="prefix"
-      class="font-proto-mono text-default font-medium leading-1 tracking-tightest whitespace-nowrap text-overline-md"
-      >
+      class="font-proto-mono text-default font-medium leading-1 tracking-tightest text-overline-md"
+      :class="{ 'whitespace-nowrap': singleLine }"
+    >
       {{ prefix }}
     </span>
     <span
-      class="font-proto-mono text-brand-primary-400 font-medium leading-1 tracking-tightest whitespace-nowrap uppercase text-overline-md"
+      class="font-proto-mono text-brand-primary-400 font-medium leading-1 tracking-tightest uppercase text-overline-md"
+      :class="{ 'whitespace-nowrap': singleLine }"
     >
       <slot />
     </span>
-    <span v-if="showCursor" class="w-1 h-5 shrink-0 relative bg-brand-accent-400 animate-blink" />
+    <span
+      v-if="showCursor"
+      class="w-1 h-5 shrink-0 relative bg-brand-accent-400 animate-blink"
+    />
   </div>
 </template>


### PR DESCRIPTION
Add a semantic singleLine prop to control whitespace-nowrap while keeping single-line rendering as the default behavior.