### PR TITLE
docs(monorepo): improve root onboarding and add agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,118 @@
+# AGENTS.md
+
+Guidelines for contributors and coding agents working in the Azion Webkit monorepo.
+
+## 1) Monorepo context
+
+This repository is a `pnpm` workspace with two top-level domains:
+
+- `apps/*`: runnable applications (for documentation and tooling)
+- `packages/*`: publishable/shared libraries used by Azion products
+
+Current main workspaces:
+
+- `apps/storybook`: visual documentation and component development environment
+- `apps/icons-gallery`: icon browsing/validation app
+- `packages/webkit`: reusable Vue component library (`@aziontech/webkit`)
+- `packages/theme`: tokens, theme, and styling foundations (`@aziontech/theme`)
+- `packages/icons`: icon font pipeline and package (`@aziontech/icons`)
+
+## 2) Core principles
+
+1. Preserve consistency with existing patterns before introducing new ones.
+2. Make the smallest safe change that solves the problem.
+3. Keep docs and stories updated when behavior or API changes.
+4. Prefer semantic design tokens over hardcoded visual values.
+5. Keep workspace commands reproducible from repository root.
+
+## 3) Environment and tooling
+
+- Node.js: `>= 22.18.0`
+- Package manager: `pnpm` (workspace-first)
+- Install dependencies from root only:
+
+```bash
+pnpm install
+```
+
+Prefer root scripts when available:
+
+```bash
+pnpm storybook:dev
+pnpm storybook:build
+pnpm storybook:preview
+pnpm icons:build
+pnpm webkit:build:dts
+```
+
+## 4) Where to change what
+
+- Webkit components: `packages/webkit/src/**`
+- Theme tokens/styles: `packages/theme/**`
+- Icons and generation pipeline: `packages/icons/**`
+- Storybook stories/docs: `apps/storybook/src/stories/**`
+
+When changing UI components in `packages/webkit`, update or add stories in Storybook in the same branch.
+
+## 5) Component and styling standards
+
+For `@aziontech/webkit` and Storybook content:
+
+- Reuse established component patterns and naming conventions.
+- Keep props semantic and explicit (avoid cryptic booleans when possible).
+- Maintain backward-compatible defaults unless a breaking change is intentional.
+- Use `@aziontech/theme` tokens/classes for colors, text, and surfaces.
+- Avoid hardcoded hex colors in components when semantic tokens exist.
+- Keep accessibility in mind (labels, states, disabled/readability, keyboard behavior).
+
+## 6) Storybook standards
+
+- Storybook is the source of truth for component behavior.
+- Add clear examples for new states/props.
+- Prefer docs-first pages for onboarding and conceptual guidance.
+- Keep story titles and grouping consistent with existing sidebar taxonomy.
+- For foundations docs, keep content practical and copy-paste friendly.
+
+## 7) Git workflow and commits
+
+- Create focused branches by context (examples: `feat/...`, `fix/...`, `docs/...`).
+- Use conventional commit messages when possible:
+  - `feat(...)`: new feature/enhancement
+  - `fix(...)`: bug fix
+  - `docs(...)`: documentation changes
+  - `chore(...)`: maintenance
+- Keep commits scoped and coherent (one context per commit).
+- Never rewrite unrelated changes in a dirty working tree.
+
+## 8) Validation checklist before push
+
+Run the minimum relevant validations for the scope of your change.
+
+- Storybook/docs change:
+  - `pnpm storybook:build`
+- Icons change:
+  - `pnpm icons:build`
+- Webkit typings/API surface change:
+  - `pnpm webkit:build:dts`
+
+If a full validation is too expensive, run targeted checks and document what was/was not validated.
+
+## 9) Documentation expectations
+
+When behavior changes, update docs close to the code:
+
+- Root overview: `README.md`
+- Storybook app docs: `apps/storybook/README.md`
+- Package-level docs in each `packages/*/README.md`
+
+For onboarding content, prioritize Storybook docs pages under `Foundations`.
+
+## 10) Safety rules
+
+- Do not commit secrets, credentials, or environment-specific private data.
+- Do not perform destructive git operations without explicit approval.
+- Avoid broad refactors during targeted fixes unless required for correctness.
+
+---
+
+If in doubt, follow existing code style in the touched files, keep the change minimal, and leave the repository in a buildable and documented state.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,100 @@
-# Webkit
+<h1 align="center">Azion Webkit Monorepo</h1>
 
-Central Front-End repository for Azion, containing shared components, styles, and utilities used across multiple projects. 
+Central front-end repository for Azion, containing reusable UI components, design tokens, icons, and documentation apps used across multiple products.
 
+## What is in this repository
 
-## Apps
+- `@aziontech/webkit`: Vue component library and UI building blocks.
+- `@aziontech/theme`: design token system, CSS variables, and Tailwind integration.
+- `@aziontech/icons`: Azion + Prime icon fonts as CSS/woff2 assets.
+- Storybook app for documentation and visual validation.
+- Icons Gallery app for icon exploration and QA.
 
-| App | Description | Deploy |
-|-----|-------------|--------|
-| [icons-gallery](./apps/icons-gallery) | Interactive gallery for Azion and Primevue Icons. | [![App Icons Gallery](https://github.com/aziontech/webkit/actions/workflows/app-icons-gallery.yml/badge.svg?branch=main)](https://github.com/aziontech/webkit/actions/workflows/app-icons-gallery.yml?query=branch%3Amain) |
-| [storybook](./apps/storybook) | Storybook documentation for @aziontech/webkit component library. | - |
+## Workspace structure
 
+```text
+webkit/
+|- apps/
+|  |- storybook/      # Component docs and development playground
+|  \- icons-gallery/  # Interactive icon browser
+|- packages/
+|  |- webkit/         # Reusable Vue components
+|  |- theme/          # Tokens and theme styles
+|  \- icons/          # Icon generation and distribution
+|- package.json       # Root workspace scripts
+\- pnpm-workspace.yaml
+```
 
 ## Packages
 
-| Package | Description | Deploy | Version |
-|---------|-------------|--------|---------|
-| [@aziontech/icons](https://www.npmjs.com/package/@aziontech/icons) | Azion and Primevue Icons used across Azion projects. | [![Package Icons](https://github.com/aziontech/webkit/actions/workflows/package-icons.yml/badge.svg?branch=main)](https://github.com/aziontech/webkit/actions/workflows/package-icons.yml?query=branch%3Amain) | [![npm version](https://img.shields.io/npm/v/@aziontech/icons.svg)](https://www.npmjs.com/package/@aziontech/icons) |
-| [@aziontech/theme](https://www.npmjs.com/package/@aziontech/theme) | Theme configuration and styling for Azion projects. | [![Package Theme](https://github.com/aziontech/webkit/actions/workflows/package-theme.yml/badge.svg?branch=main)](https://github.com/aziontech/webkit/actions/workflows/package-theme.yml?query=branch%3Amain) | [![npm version](https://img.shields.io/npm/v/@aziontech/theme.svg)](https://www.npmjs.com/package/@aziontech/theme) |
-| [@aziontech/webkit](https://www.npmjs.com/package/@aziontech/webkit) | Reusable UI components and design system utilities for building Azion web interfaces. | [![Package Webkit](https://github.com/aziontech/webkit/actions/workflows/package-webkit.yml/badge.svg?branch=main)](https://github.com/aziontech/webkit/actions/workflows/package-webkit.yml?query=branch%3Amain) | [![npm version](https://img.shields.io/npm/v/@aziontech/webkit.svg)](https://www.npmjs.com/package/@aziontech/webkit) |
+| Package                                                              | Description                                                    | CI                                                                                                                                                                                                                | Version                                                                                                               |
+| -------------------------------------------------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| [@aziontech/icons](https://www.npmjs.com/package/@aziontech/icons)   | Azion and Prime icon fonts used across products.               | [![Package Icons](https://github.com/aziontech/webkit/actions/workflows/package-icons.yml/badge.svg?branch=main)](https://github.com/aziontech/webkit/actions/workflows/package-icons.yml?query=branch%3Amain)    | [![npm version](https://img.shields.io/npm/v/@aziontech/icons.svg)](https://www.npmjs.com/package/@aziontech/icons)   |
+| [@aziontech/theme](https://www.npmjs.com/package/@aziontech/theme)   | Theme configuration, semantic tokens, and styling foundations. | [![Package Theme](https://github.com/aziontech/webkit/actions/workflows/package-theme.yml/badge.svg?branch=main)](https://github.com/aziontech/webkit/actions/workflows/package-theme.yml?query=branch%3Amain)    | [![npm version](https://img.shields.io/npm/v/@aziontech/theme.svg)](https://www.npmjs.com/package/@aziontech/theme)   |
+| [@aziontech/webkit](https://www.npmjs.com/package/@aziontech/webkit) | Reusable UI components and design system utilities.            | [![Package Webkit](https://github.com/aziontech/webkit/actions/workflows/package-webkit.yml/badge.svg?branch=main)](https://github.com/aziontech/webkit/actions/workflows/package-webkit.yml?query=branch%3Amain) | [![npm version](https://img.shields.io/npm/v/@aziontech/webkit.svg)](https://www.npmjs.com/package/@aziontech/webkit) |
+
+## Apps
+
+| App                                   | Description                                      | CI                                                                                                                                                                                                                         |
+| ------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [storybook](./apps/storybook)         | Storybook documentation for `@aziontech/webkit`. | -                                                                                                                                                                                                                          |
+| [icons-gallery](./apps/icons-gallery) | Interactive gallery for Azion and Prime icons.   | [![App Icons Gallery](https://github.com/aziontech/webkit/actions/workflows/app-icons-gallery.yml/badge.svg?branch=main)](https://github.com/aziontech/webkit/actions/workflows/app-icons-gallery.yml?query=branch%3Amain) |
+
+## Getting started
+
+### Prerequisites
+
+- Node.js `>= 22.18.0`
+- pnpm `10.x`
+
+### Install dependencies
+
+From the repository root:
+
+```bash
+pnpm install
+```
+
+### Most used commands
+
+```bash
+# Start Storybook (builds icons first)
+pnpm storybook:dev
+
+# Build Storybook static output
+pnpm storybook:build
+
+# Preview Storybook build
+pnpm storybook:preview
+
+# Build icon package artifacts
+pnpm icons:build
+
+# Generate declaration files for @aziontech/webkit
+pnpm webkit:build:dts
+```
+
+## Development flow
+
+1. Create or update code in the proper package under `packages/*`.
+2. Add or adjust stories under `apps/storybook/src/stories`.
+3. Validate changes locally with `pnpm storybook:dev`.
+4. Commit using conventional commits.
+5. Push your branch and open a pull request.
+
+## Storybook
+
+- Local docs app: `apps/storybook`
+- The project includes a `Foundations/Get Started` documentation page with onboarding details.
+- Use Storybook as the source of truth for component API and expected visual behavior.
+
+## Related docs
+
+- Root Storybook app guide: `apps/storybook/README.md`
+- Theme package guide: `packages/theme/README.md`
+- Icons package guide: `packages/icons/README.md`
+- Webkit package guide: `packages/webkit/README.md`
+
+## License
+
+MIT © Azion Technologies


### PR DESCRIPTION
Expand the root README with workspace structure, setup, development commands, and contribution flow. Add AGENTS.md with monorepo best practices aligned with current Azion Webkit standards for contributors and coding agents.