### PR TITLE
docs(storybook): prioriza Get Started na navegacao

### DIFF
--- a/apps/storybook/.storybook/preview.js
+++ b/apps/storybook/.storybook/preview.js
@@ -1,11 +1,11 @@
-import { setup } from '@storybook/vue3';
-import PrimeVue from 'primevue/config';
-import Tooltip from 'primevue/tooltip';
+import { setup } from '@storybook/vue3'
+import PrimeVue from 'primevue/config'
+import Tooltip from 'primevue/tooltip'
 import { withThemeByClassName } from '@storybook/addon-themes'
 import { injectCssVars } from '@aziontech/theme/tokens'
 
 import 'primeflex/primeflex.css'
-import '../src/styles/preview.css';
+import '../src/styles/preview.css'
 import '@aziontech/theme'
 import '@aziontech/icons'
 import '@aziontech/webkit/styles/country-flags'
@@ -16,10 +16,10 @@ injectCssVars()
 setup((app) => {
   app.use(PrimeVue, {
     ripple: false
-  });
+  })
 
-  app.directive('tooltip', Tooltip);
-});
+  app.directive('tooltip', Tooltip)
+})
 
 export const parameters = {
   controls: {
@@ -75,18 +75,25 @@ export const parameters = {
   },
   options: {
     storySort: {
-      order: ['Foundations', ['Colors', 'Spacing', 'Typography', 'Icons'], 'Primevue', 'Primevue', 'Components', 'Site']
+      order: [
+        'Get Started',
+        'Foundations',
+        ['Colors', 'Spacing', 'Typography', 'Icons'],
+        'Primevue',
+        'Primevue',
+        'Components',
+        'Site'
+      ]
     }
   }
-};
+}
 
 export const decorators = [
   withThemeByClassName({
     themes: {
       light: 'azion azion-light',
-      dark: 'azion azion-dark',
+      dark: 'azion azion-dark'
     },
-    defaultTheme: 'dark',
+    defaultTheme: 'dark'
   })
 ]
-


### PR DESCRIPTION
## Summary
- ajusta a ordenação do Storybook para exibir **Get Started** antes de **Foundations**, melhorando o onboarding inicial
- mantém a configuração existente de temas e controles, alterando apenas a seção `options.storySort.order` em `apps/storybook/.storybook/preview.js`
- aplica padronização de estilo no arquivo (remoção de `;`) alinhada ao formato já usado no projeto

## Why
- facilitar o primeiro contato com o Design System, destacando o guia de entrada como ponto inicial da navegação

## Validation
- validação manual da diff e estrutura de ordenação no arquivo de preview
- sem execução de build/testes nesta alteração (mudança restrita a configuração de ordenação do Storybook)

## Checklist
- [x] commit semântico (`docs(...)`)
- [x] branch criada a partir da `main`
- [x] alterações publicadas no remoto