### PR TITLE
chore: removing the createPagePath prop to EmptyResultsBlock and List…

### DIFF
--- a/packages/webkit/src/core/list-data-table/components/list-data-table/list-data-table.vue
+++ b/packages/webkit/src/core/list-data-table/components/list-data-table/list-data-table.vue
@@ -122,7 +122,6 @@
         :title="emptyBlock.title"
         :description="emptyBlock.description"
         :createButtonLabel="emptyBlock.createButtonLabel"
-        :createPagePath="emptyBlock.createPagePath"
         :onClickCreate="emptyBlock.onClickCreate"
         :documentationService="emptyBlock.documentationService"
         :pt="pt.emptyState"
@@ -289,7 +288,6 @@
         title: 'No data has been created',
         description: 'No data has been created.',
         createButtonLabel: 'Create',
-        createPagePath: null,
         documentationService: null
       })
     },


### PR DESCRIPTION
Removed the createPagePath prop used to apply the router and it is no make sense.


The right usage is to listener the `@click-to-create` event.

Intercepting in the view or the parent component can be trigger to the next parent or make the necessary action/routine/etc.

