### PR TITLE
skills(theme): add Azion theme migration skill

### DIFF
--- a/docs/MIGRACAO_AZION_THEME.md
+++ b/docs/MIGRACAO_AZION_THEME.md
@@ -1,0 +1,245 @@
+# Guia de Migracao para `@aziontech/theme`
+
+Este documento descreve como migrar componentes que hoje usam:
+
+- classes padrao do Tailwind (`text-gray-...`, `bg-neutral-...`, etc.);
+- cores hardcoded em HEX (`#f3652b`, `#ef4444`, etc.);
+
+para os tokens semanticos do `@aziontech/theme`, com fallback para o valor mais proximo quando nao existir token semantico equivalente.
+
+---
+
+## Objetivo da migracao
+
+Padronizar o visual com tokens de design, garantindo:
+
+- consistencia entre componentes;
+- suporte a light/dark mode via tema;
+- manutencao mais simples (evitar "hex espalhado").
+
+---
+
+## Estrategia recomendada
+
+1. Preferir token semantico (`text-base`, `bg-surface`, `border-subtle`, etc.).
+2. Se nao existir token semantico para o caso, usar token primitivo (`orange-500`, `neutral-700`, etc.).
+3. Se ainda nao houver token adequado, usar valor aproximado temporario e abrir tarefa de tokenizacao.
+4. Evitar novos hex hardcoded em componentes.
+
+---
+
+## Pre-requisitos
+
+- Tema carregado no app:
+  - `import '@aziontech/theme'`
+- Root com classe do tema:
+  - `<div class="azion">...</div>`
+- Para dark mode:
+  - `.azion.azion-dark` e/ou `.dark`
+
+---
+
+## Opcoes de integracao com Tailwind
+
+## 1) Preset (cores via `colors.text.*`, `colors.background.*`, `colors.border.*`)
+
+```js
+import { preset } from '@aziontech/theme/tokens';
+
+export default {
+  presets: [preset],
+  darkMode: 'class',
+};
+```
+
+Exemplo de uso (com prefixo de grupo de cor):
+
+- `text-text-default`
+- `bg-background-surface`
+- `border-border-subtle`
+
+## 2) Plugin de utilitarios semanticos diretos (recomendado para migracao)
+
+```js
+import { tokenUtilities } from '@aziontech/theme/tokens';
+
+export default {
+  plugins: [
+    tokenUtilities({
+      darkSelector: '.dark',
+      extraDarkSelectors: ['.azion.azion-dark'],
+    }),
+  ],
+};
+```
+
+Exemplo de uso (classes diretas):
+
+- `text-base`, `text-muted`, `text-link`
+- `bg-surface`, `bg-canvas`, `bg-primary`
+- `border-base`, `border-subtle`, `border-danger`
+
+> Observacao: o repositorio tambem expoe plugin com classes como `text-default`/`bg-surface`. Mantenha um padrao unico no projeto para evitar mistura.
+
+---
+
+## Mapeamento pratico (Tailwind padrao -> Azion Theme)
+
+## Texto
+
+- `text-gray-900`, `text-neutral-900` -> `text-base` (ou `text-default` no padrao alternativo)
+- `text-gray-600`, `text-neutral-600` -> `text-muted`
+- `text-blue-600` -> `text-link`
+- `text-orange-500` -> `text-primary`
+- `hover:text-orange-600` -> `hover:text-primary-hover`
+- `text-red-600` -> `text-danger`
+- `text-green-600` -> `text-success`
+- `text-yellow-600` -> `text-warning`
+
+## Background
+
+- `bg-white` -> `bg-surface`
+- `bg-gray-50`, `bg-neutral-50` -> `bg-surface-overlay`
+- `bg-gray-100`, `bg-neutral-100` -> `bg-canvas`
+- `bg-orange-500` -> `bg-primary`
+- `hover:bg-orange-600` -> `hover:bg-primary-hover`
+- `bg-red-200` -> `bg-danger`
+- `bg-green-200` -> `bg-success`
+- `bg-yellow-200` -> `bg-warning`
+
+## Border
+
+- `border-gray-200`, `border-neutral-200` -> `border-subtle`
+- `border-gray-100`, `border-neutral-100` -> `border-base`
+- `border-black` -> `border-strong`
+- `border-orange-500` -> `border-primary`
+- `hover:border-orange-600` -> `hover:border-primary-hover`
+- `border-red-600` -> `border-danger`
+- `border-green-600` -> `border-success`
+- `border-yellow-600` -> `border-warning`
+
+---
+
+## Mapeamento de HEX comum -> tokens sugeridos
+
+- `#fe601f` / `#f3652b` -> `orange-500` (preferir semantico `text-primary`, `bg-primary`, `border-primary`)
+- `#d95522` / `#d94a03` -> `orange-600` (preferir `*-primary-hover`)
+- `#ef4444` -> `red-500` (ou semantico de danger)
+- `#dc2626` -> `red-600` (ou semantico de danger)
+- `#22c55e` -> `green-500` (ou semantico de success)
+- `#16a34a` -> `green-600` (ou semantico de success)
+- `#eab308` -> `yellow-500` (ou semantico de warning)
+- `#ca8a04` -> `yellow-600` (ou semantico de warning)
+- `#13131a` -> `slate-950` (avaliar `bg-canvas`/`bg-surface` no contexto)
+- `#353040` -> `slate-900` (avaliar `border-subtle` no contexto)
+- `#b5b1f4` -> `violet-300`
+- `#8a84ec` -> `violet-500`
+
+> Regra: quando for estado semantico (erro/sucesso/aviso/primario/link), prefira token semantico; para branding/ilustracao, primitivo pode ser aceitavel.
+
+---
+
+## Processo de migracao por componente
+
+1. Identificar classes e hex no componente.
+2. Classificar cada cor por intencao:
+   - base/muted/link/primary/danger/success/warning/surface/canvas/border.
+3. Substituir por token semantico.
+4. Se nao houver equivalente, usar primitivo mais proximo.
+5. Validar light/dark.
+6. Atualizar Storybook com estados relevantes.
+
+---
+
+## Exemplo de migracao
+
+## Antes
+
+```vue
+<button
+  class="bg-[#f3652b] hover:bg-[#d95522] text-white border border-[#353040]"
+>
+  Acao
+</button>
+```
+
+## Depois (semantico)
+
+```vue
+<button
+  class="bg-primary hover:bg-primary-hover text-base border border-subtle"
+>
+  Acao
+</button>
+```
+
+## Depois (fallback primitivo, se semantico nao cobrir)
+
+```vue
+<button
+  class="bg-orange-500 hover:bg-orange-600 text-base border border-slate-900"
+>
+  Acao
+</button>
+```
+
+---
+
+## Casos especiais
+
+- SVGs/ilustracoes de marca: nem toda cor deve virar token semantico; branding pode ficar em token primitivo.
+- Markdown renderizado (string HTML): evitar hex embutido em string; extrair para classe utilitaria.
+- Estados de validacao: usar `danger/success/warning` semantico, nao `red-*` direto.
+- Componentes legados com muita variacao: migrar por prioridade visual (botoes, inputs, alertas, superficies).
+
+---
+
+## Criterio para "token mais semelhante"
+
+Quando nao houver token semantico:
+
+1. Mantem tonalidade (ex.: orange -> orange).
+2. Mantem contraste no contexto (texto/borda/fundo).
+3. Mantem hierarquia de estado (hover geralmente +1 shade no escuro ou no claro conforme padrao do tema).
+4. Garante legibilidade WCAG minima para texto.
+
+---
+
+## Checklist de validacao
+
+- [ ] Sem hex hardcoded novo em `.vue/.ts/.scss` (exceto assets/ilustracoes justificadas).
+- [ ] Estados hover/focus/disabled usam token.
+- [ ] Light mode validado.
+- [ ] Dark mode validado (`.dark` e/ou `.azion.azion-dark`).
+- [ ] Storybook atualizado para estados principais.
+- [ ] Sem regressao visual em componentes criticos.
+
+---
+
+## Auditoria rapida (comandos uteis)
+
+```bash
+# Encontrar hex hardcoded
+rg "#[0-9a-fA-F]{3,8}" packages/webkit/src
+
+# Encontrar classes Tailwind de cor legadas comuns
+rg "text-(gray|neutral|red|green|yellow|orange|blue)-|bg-(gray|neutral|red|green|yellow|orange|blue)-|border-(gray|neutral|red|green|yellow|orange|blue)-" packages/webkit/src
+```
+
+---
+
+## Plano sugerido de rollout
+
+1. Fase 1 (alto impacto): botoes, inputs, alertas, badges.
+2. Fase 2: tabelas, cards, paineis e componentes de layout.
+3. Fase 3: markdown renderizado e componentes especiais.
+4. Fase 4: limpeza final + lint/auditoria + stories.
+
+---
+
+## Convencao final recomendada
+
+- Para UI de produto: token semantico primeiro.
+- Para branding/arte: primitivo controlado.
+- Evitar duplicidade de abordagem dentro do mesmo componente.
+- Documentar excecoes no Storybook.

--- a/packages/webkit/src/components/toggle/toggle.vue
+++ b/packages/webkit/src/components/toggle/toggle.vue
@@ -90,9 +90,7 @@
           :class="[
             'whitespace-nowrap relative z-10 px-3 py-1 rounded-md transition-all duration-300 ease-in-out',
             'font-proto-mono tracking-tight uppercase cursor-pointer text-center',
-            selectedOption === 'main'
-              ? 'text-neutral-900'
-              : 'text-muted hover:text-default'
+            selectedOption === 'main' ? 'text-neutral-900' : 'text-muted hover:text-default'
           ]"
         >
           {{ mainLabel }}
@@ -105,9 +103,7 @@
           :class="[
             'whitespace-nowrap relative z-10 px-3 py-1 rounded-md transition-all duration-300 ease-in-out',
             'font-proto-mono tracking-tight uppercase cursor-pointer text-center',
-            selectedOption === 'alternative'
-              ? 'text-neutral-900'
-              : 'text-muted hover:text-default'
+            selectedOption === 'alternative' ? 'text-neutral-900' : 'text-muted hover:text-default'
           ]"
         >
           {{ alternativeLabel }}

--- a/packages/webkit/src/components/toggle/toggle.vue
+++ b/packages/webkit/src/components/toggle/toggle.vue
@@ -72,13 +72,13 @@
 
 <template>
   <div class="flex flex-col items-center gap-3">
-    <div class="flex items-center rounded-lg justify-center bg-[#13131A] w-fit p-2 px-3">
+    <div class="flex items-center rounded-lg justify-center bg-surface w-fit p-2 px-3">
       <div class="flex items-center relative">
         <div
           ref="backgroundElement"
           :class="[
             'absolute top-1 bottom-1 rounded-sm transition-all duration-300 ease-out',
-            'bg-[#B5B1F4]'
+            'bg-violet-300'
           ]"
           :style="backgroundStyle"
         ></div>
@@ -92,7 +92,7 @@
             'font-proto-mono tracking-tight uppercase cursor-pointer text-center',
             selectedOption === 'main'
               ? 'text-neutral-900'
-              : 'text-neutral-400 hover:text-neutral-200'
+              : 'text-muted hover:text-default'
           ]"
         >
           {{ mainLabel }}
@@ -107,7 +107,7 @@
             'font-proto-mono tracking-tight uppercase cursor-pointer text-center',
             selectedOption === 'alternative'
               ? 'text-neutral-900'
-              : 'text-neutral-400 hover:text-neutral-200'
+              : 'text-muted hover:text-default'
           ]"
         >
           {{ alternativeLabel }}
@@ -116,7 +116,7 @@
     </div>
     <p
       v-if="description"
-      class="text-xs font-sora text-neutral-100 text-center mt-3 mb-[3.75rem]"
+      class="text-xs font-sora text-default text-center mt-3 mb-[3.75rem]"
     >
       {{ description }}
     </p>

--- a/skills/CONTRIBUTING.md
+++ b/skills/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing Skills
+
+Guia para criacao e manutencao de skills em `skills/`.
+
+## Objetivo
+
+Garantir que todas as skills tenham formato consistente, regras claras e resultado auditavel.
+
+## Regras obrigatorias
+
+- Usar `skills/_template.md` como estrutura base.
+- Definir entradas e saidas de forma objetiva.
+- Declarar guardrails explicitos (o que a skill nunca deve fazer).
+- Incluir criterio de conclusao verificavel (Definition of Done).
+- Evitar acoplamento com arquivo unico; usar escopo por diretorio/glob.
+
+## Processo recomendado
+
+1. Criar a skill a partir do template.
+2. Revisar se as secoes obrigatorias foram preenchidas.
+3. Validar se a skill aponta para fontes de verdade (docs, guias, padroes do repo).
+4. Incluir ao menos um exemplo de uso.
+5. Atualizar `skills/README.md` com a descricao curta no catalogo.
+
+## Checklist de revisao
+
+- [ ] Nome e objetivo claros.
+- [ ] Entradas e saidas bem definidas.
+- [ ] Workflow sequencial sem ambiguidades.
+- [ ] Regras de decisao e fallback documentadas.
+- [ ] Guardrails cobrindo operacoes de risco.
+- [ ] Definition of Done mensuravel.
+- [ ] Exemplo de uso incluso.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,20 @@
+# Skills
+
+Colecao de skills operacionais para acelerar tarefas recorrentes no monorepo.
+
+## Quando usar
+
+- Quando uma tarefa for repetitiva e exigir as mesmas decisoes de implementacao.
+- Quando for importante padronizar formato de saida, checklist e criterio de conclusao.
+- Quando houver risco de divergencia entre PRs para o mesmo tipo de mudanca.
+
+## Convencoes
+
+- Cada skill deve viver em um arquivo unico em `skills/*.md`.
+- Cada skill deve seguir o formato padrao descrito em `skills/_template.md`.
+- Toda nova skill ou atualizacao deve seguir `skills/CONTRIBUTING.md`.
+- Skills devem ser orientadas por escopo (diretorio/glob), nunca por arquivo fixo.
+
+## Catalogo
+
+- `migracao-azion-theme`: migra estilos legados (Tailwind padrao + HEX hardcoded) para tokens do `@aziontech/theme`, com foco em semantica, consistencia visual e suporte a light/dark mode.

--- a/skills/_template.md
+++ b/skills/_template.md
@@ -1,0 +1,55 @@
+# Skill: <nome-da-skill>
+
+## Metadata
+
+- `name`: `<nome-da-skill>`
+- `version`: `1.0.0`
+- `owner`: `<time-ou-area>`
+- `status`: `draft|active|deprecated`
+- `last_updated`: `YYYY-MM-DD`
+
+## Purpose
+
+Descricao curta do objetivo da skill em 1-2 frases.
+
+## Inputs
+
+- Escopo aceito (diretorio/glob/conjunto de arquivos).
+- Restricoes relevantes.
+- Dependencias de contexto (docs, configuracoes, padroes).
+
+## Outputs
+
+- Formato de saida esperado.
+- Artefatos que devem ser gerados (ex.: relatorio, diff, checklist).
+
+## Workflow
+
+1. Passo 1.
+2. Passo 2.
+3. Passo 3.
+
+## Rules
+
+- Regra de priorizacao principal.
+- Regras de decisao para casos comuns.
+
+## Guardrails
+
+- O que nunca deve ser feito.
+- Limites de alteracao aceitaveis.
+
+## Fallbacks
+
+- O que fazer quando nao houver mapeamento direto.
+- Como registrar pendencias e excecoes.
+
+## Definition of Done
+
+- [ ] Criterio objetivo 1.
+- [ ] Criterio objetivo 2.
+- [ ] Criterio objetivo 3.
+
+## Example
+
+Exemplo de invocacao e resultado esperado.

--- a/skills/migracao-azion-theme.md
+++ b/skills/migracao-azion-theme.md
@@ -1,0 +1,115 @@
+# Skill: migracao-azion-theme
+
+## Metadata
+
+- `name`: `migracao-azion-theme`
+- `version`: `1.0.0`
+- `owner`: `webkit-design-system`
+- `status`: `active`
+- `last_updated`: `2026-04-24`
+
+## Purpose
+
+Migrar estilos legados para `@aziontech/theme`, removendo HEX hardcoded e classes Tailwind nao semanticas quando aplicavel.
+
+## Inputs
+
+- Escopo de migracao em diretorio, glob ou conjunto de arquivos.
+- Exemplo de escopos validos:
+  - `packages/webkit/src/components/**`
+  - `packages/webkit/src/core/**`
+  - qualquer escopo informado pelo usuario
+- Fonte de verdade obrigatoria:
+  - `docs/MIGRACAO_AZION_THEME.md`
+
+Importante: nao assumir arquivo especifico fixo.
+
+## Outputs
+
+- Diff com alteracoes aplicadas no escopo informado.
+- Relatorio curto contendo:
+  - resumo da migracao
+  - tabela `antes -> depois` por tipo (`text`, `bg`, `border`)
+  - lista de excecoes justificadas
+  - pendencias de tokenizacao
+  - checklist de validacao preenchido
+
+## Workflow
+
+1. Auditar o escopo:
+   - localizar HEX hardcoded
+   - localizar classes Tailwind legadas de cor
+
+2. Classificar intencao visual de cada ocorrencia:
+   - texto, fundo, borda
+   - estado semantico (`primary`, `danger`, `success`, `warning`, `link`)
+   - superficie/canvas
+
+3. Aplicar substituicoes:
+   - semantico primeiro
+   - primitivo como fallback
+
+4. Validar o resultado:
+   - sem regressao de estados (`hover`, `focus`, `disabled`, `active`)
+   - aderencia a light/dark mode
+   - ausencia de novos HEX desnecessarios
+
+5. Reportar resultados:
+   - arquivos alterados
+   - mapeamentos aplicados
+   - pendencias e excecoes
+
+## Rules
+
+1. Prioridade de substituicao:
+   1. token semantico (`text-default`, `text-muted`, `bg-surface`, `bg-primary`, `border-subtle`, etc.)
+   2. token primitivo mais proximo (`orange-500`, `violet-300`, `slate-900`, etc.)
+   3. se nao houver match adequado, registrar pendencia de tokenizacao
+
+2. Mapeamento base (resumo):
+   - `#fe601f` / `#f3652b` -> `primary` (ou `orange-500`)
+   - `#d95522` / `#d94a03` -> `primary-hover` (ou `orange-600`)
+   - `#ef4444` / `#dc2626` -> `danger` (ou `red-500`/`red-600`)
+   - `#22c55e` / `#16a34a` -> `success` (ou `green-500`/`green-600`)
+   - `#eab308` / `#ca8a04` -> `warning` (ou `yellow-500`/`yellow-600`)
+   - `#13131a` -> `slate-950` (avaliar `bg-surface`/`bg-canvas`)
+   - `#353040` -> `slate-900` (avaliar `border-subtle`)
+   - `#b5b1f4` -> `violet-300`
+   - `#8a84ec` -> `violet-500`
+
+3. Preservar:
+   - estrutura, eventos, props e logica existente
+   - acessibilidade e comportamento interativo
+   - consistencia com padrao dominante no projeto
+
+## Guardrails
+
+- Nao introduzir novos HEX hardcoded sem justificativa.
+- Nao alterar comportamento funcional para resolver apenas estilo.
+- Nao misturar padroes de nomenclatura no mesmo componente sem motivo claro.
+- Nao assumir equivalencias semanticas sem validar intencao visual.
+
+## Fallbacks
+
+- Se nao houver token semantico equivalente, usar token primitivo mais proximo.
+- Se nao houver primitivo adequado, manter valor atual temporariamente e registrar pendencia.
+- Em casos de branding/ilustracao (ex.: SVGs de marca), excecao pode ser aceita com justificativa no relatorio.
+
+## Definition of Done
+
+- [ ] Nenhum novo HEX hardcoded foi introduzido no escopo alterado.
+- [ ] Estados visuais e interativos foram preservados.
+- [ ] Tokens semanticos foram priorizados sobre primitivos quando possivel.
+- [ ] Todo fallback primitivo foi usado apenas quando necessario e documentado.
+- [ ] Pendencias de tokenizacao foram registradas quando aplicavel.
+
+## Example
+
+Input:
+
+- Escopo: `packages/webkit/src/components/**`
+
+Output esperado:
+
+- Arquivos migrados dentro do escopo com substituicao de HEX/classes legadas.
+- Relatorio com `antes -> depois`, excecoes e checklist final.


### PR DESCRIPTION
## Summary
- add a detailed migration guide in `docs/MIGRACAO_AZION_THEME.md` for moving from Tailwind default classes and hardcoded hex colors to `@aziontech/theme` tokens
- include migration strategy, practical mapping tables, fallback criteria, rollout plan, and validation checklist
- provide command snippets for auditing legacy color usage and tracking migration progress