### PR TITLE
feat(webkit): add PricingCard component and Storybook docs

### DIFF
--- a/apps/storybook/src/stories/core/PricingCard.stories.js
+++ b/apps/storybook/src/stories/core/PricingCard.stories.js
@@ -1,0 +1,124 @@
+import PricingCard from '@aziontech/webkit/pricing-card';
+
+const defaultFeatures = [
+  { icon: 'pi-check', label: 'Unlimited rules engine' },
+  { icon: 'pi-check', label: 'Global edge deployment' },
+  { icon: 'pi-check', label: 'Advanced observability' },
+  { icon: 'pi-check', label: '24/7 support' }
+];
+
+export default {
+  title: 'Core/PricingCard',
+  component: PricingCard,
+  tags: ['autodocs'],
+  argTypes: {
+    popular: {
+      control: 'boolean',
+      description: 'Displays the Popular badge'
+    },
+    pupularText: {
+      control: 'text',
+      description: 'Popular badge label'
+    },
+    title: {
+      control: 'text',
+      description: 'Main plan title'
+    },
+    subtitle: {
+      control: 'text',
+      description: 'Plan description'
+    },
+    features: {
+      control: 'object',
+      description: 'Feature list with icon and label'
+    },
+    monthlyPrice: {
+      control: 'text',
+      description: 'Monthly billing price'
+    },
+    annualPrice: {
+      control: 'text',
+      description: 'Annual billing price'
+    },
+    currentPeriod: {
+      control: 'select',
+      options: ['monthly', 'annual'],
+      description: 'Current billing period'
+    },
+    priceLabel: {
+      control: 'text',
+      description: 'Price helper text'
+    },
+    customPrice: {
+      control: 'text',
+      description: 'Custom text replacing numeric price'
+    },
+    buttonLabel: {
+      control: 'text',
+      description: 'Call-to-action label'
+    },
+    buttonLink: {
+      control: 'text',
+      description: 'CTA destination URL'
+    },
+    buttonTarget: {
+      control: 'select',
+      options: ['_self', '_blank'],
+      description: 'CTA target behavior'
+    },
+    buttonHidden: {
+      control: 'boolean',
+      description: 'Hides the CTA area'
+    }
+  }
+};
+
+export const Default = {
+  args: {
+    popular: false,
+    pupularText: 'Popular',
+    title: 'Pro',
+    subtitle: 'For teams scaling edge applications fast.',
+    features: defaultFeatures,
+    monthlyPrice: '$49',
+    annualPrice: '$39',
+    currentPeriod: 'monthly',
+    priceLabel: 'start at',
+    buttonLabel: 'Get Started',
+    buttonLink: '#',
+    buttonTarget: '_self',
+    customPrice: '',
+    buttonHidden: false
+  }
+};
+
+export const Popular = {
+  args: {
+    ...Default.args,
+    popular: true,
+    title: 'Business'
+  }
+};
+
+export const AnnualBilling = {
+  args: {
+    ...Default.args,
+    currentPeriod: 'annual'
+  }
+};
+
+export const CustomPrice = {
+  args: {
+    ...Default.args,
+    title: 'Enterprise',
+    customPrice: 'Contact us',
+    buttonLabel: 'Talk to Sales'
+  }
+};
+
+export const WithoutButton = {
+  args: {
+    ...Default.args,
+    buttonHidden: true
+  }
+};

--- a/apps/storybook/tailwind.config.js
+++ b/apps/storybook/tailwind.config.js
@@ -72,6 +72,7 @@ export default {
         roboto: ['Roboto'],
         robotomono: ['Roboto Mono'],
         sora: ['Sora'],
+        'proto-mono': ['Proto Mono'],
         protomono: ['Proto Mono'],
         mono: ['Proto Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'Monaco', 'Cascadia Code', 'Roboto Mono', 'Courier New', 'monospace']
       }

--- a/packages/webkit/package.json
+++ b/packages/webkit/package.json
@@ -81,6 +81,7 @@
     "./empty-results-block": "./src/components/empty-results-block/empty-results-block.vue",
     "./resizable-splitter": "./src/components/resizable-splitter/resizable-splitter.vue",
     "./overline": "./src/components/overline/overline.vue",
+    "./pricing-card": "./src/components/pricing-card/pricing-card.vue",
     "./accordion": "./src/core/primevue/accordion/accordion.vue",
     "./accordion-tab": "./src/core/primevue/accordion-tab/accordion-tab.vue",
     "./avatar": "./src/core/primevue/avatar/avatar.vue",

--- a/packages/webkit/src/components/pricing-card/package.json
+++ b/packages/webkit/src/components/pricing-card/package.json
@@ -1,0 +1,11 @@
+{
+  "main": "./pricing-card.vue",
+  "module": "./pricing-card.vue",
+  "types": "./pricing-card.vue.d.ts",
+  "browser": {
+    "./sfc": "./pricing-card.vue"
+  },
+  "sideEffects": [
+    "*.vue"
+  ]
+}

--- a/packages/webkit/src/components/pricing-card/pricing-card.vue
+++ b/packages/webkit/src/components/pricing-card/pricing-card.vue
@@ -1,0 +1,155 @@
+<script setup>
+  import { computed } from 'vue'
+  import Button from '../site/button/button.vue'
+
+  defineOptions({ name: 'PricingCard' })
+
+  const props = defineProps({
+    popular: {
+      type: Boolean,
+      default: false
+    },
+    pupularText: {
+      type: String,
+      default: 'Popular'
+    },
+    title: {
+      type: String,
+      default: ''
+    },
+    subtitle: {
+      type: String,
+      default: ''
+    },
+    features: {
+      type: Array,
+      default: () => []
+    },
+    monthlyPrice: {
+      type: String,
+      default: ''
+    },
+    annualPrice: {
+      type: String,
+      default: ''
+    },
+    currentPeriod: {
+      type: String,
+      default: 'monthly'
+    },
+    priceLabel: {
+      type: String,
+      default: 'start at'
+    },
+    buttonLabel: {
+      type: String,
+      default: ''
+    },
+    buttonLink: {
+      type: String,
+      default: ''
+    },
+    buttonTarget: {
+      type: String,
+      default: '_self'
+    },
+    customPrice: {
+      type: String,
+      default: ''
+    },
+    buttonHidden: {
+      type: Boolean,
+      default: false
+    }
+  })
+
+  const currentPrice = computed(() =>
+    props.currentPeriod === 'monthly' ? props.monthlyPrice : props.annualPrice
+  )
+
+  const normalizedCurrentPrice = computed(() => currentPrice.value || '')
+
+  const currentPeriodSuffix = computed(() =>
+    props.currentPeriod === 'annual' ? '/yr' : '/mo'
+  )
+</script>
+
+<template>
+  <div
+    :class="[
+      'p-6 flex flex-col justify-between h-full w-full md:w-[20rem] border-default border text-default bg-surface',
+      !buttonHidden ? 'rounded-xl pb-2' : 'rounded-t-xl lg:rounded-xl'
+    ]"
+  >
+    <div class="pb-5">
+      <div class="flex gap-4 pb-4 items-center">
+        <h3 class="text-heading-lg font-sora font-bold">{{ title }}</h3>
+        <span
+          v-if="popular"
+          class="h-fit text-body-xs flex font-proto-mono justify-center items-center bg-violet-500 text-neutral-900 px-2 py-1 rounded"
+        >
+          {{ pupularText }}
+        </span>
+      </div>
+      <p class="text-body-sm text-muted">{{ subtitle }}</p>
+    </div>
+
+    <div class="h-[13rem]">
+      <ul class="mb-10">
+        <li
+          v-for="(feature, index) in features"
+          :key="`${feature?.label || 'feature'}-${index}`"
+          class="flex items-center gap-2 mb-2"
+        >
+          <span
+            v-if="feature?.icon"
+            :class="['pi', feature.icon, 'text-primary']"
+          />
+          <p class="font-sora text-body-sm">{{ feature?.label }}</p>
+        </li>
+      </ul>
+    </div>
+
+    <div
+      :class="[
+        'h-24 flex mb-2 justify-between flex-wrap font-proto-mono',
+        !buttonHidden ? 'pb-2' : 'pb-0',
+        customPrice ? 'items-end' : 'items-center'
+      ]"
+    >
+      <span
+        v-if="!customPrice"
+        class="text-body-xs w-full mb-2 text-left font-proto-mono"
+      >
+        {{ priceLabel }}
+      </span>
+
+      <template v-if="!customPrice">
+        <div class="flex items-end text-body-sm font-proto-mono">
+          <span v-if="normalizedCurrentPrice.startsWith('$')">$</span>
+          <h4 class="text-big-number-md leading-[3.5rem] tracking-tighter font-proto-mono">
+            {{ normalizedCurrentPrice.replace('$', '') }}
+          </h4>
+          <span class="font-proto-mono">{{ currentPeriodSuffix }}</span>
+        </div>
+      </template>
+
+      <template v-else>
+        <span class="text-heading-md w-full flex items-end text-left font-sora">
+          {{ customPrice }}
+        </span>
+      </template>
+    </div>
+
+    <div class="pb-4 hidden md:flex">
+      <Button
+        :icon="'pi pi-chevron-right'"
+        :label="buttonLabel"
+        :type="'primary'"
+        :href="buttonLink"
+        :target="buttonTarget"
+        size="small"
+      />
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- add a new `PricingCard` component to `@aziontech/webkit` with plan title/subtitle, features list, monthly/annual pricing, custom price text, CTA support, and configurable popular badge text (`pupularText`)
- export the component through `packages/webkit/package.json` and add local component package metadata at `packages/webkit/src/components/pricing-card/package.json`
- add Storybook stories under `Core/PricingCard` covering default, popular, annual billing, custom price, and hidden button scenarios
- align Storybook Tailwind font aliases by adding `proto-mono` mapping so `font-proto-mono` utilities used by components render correctly in Storybook

## Validation
- branch pushed successfully to remote
- no automated checks were run in this PR flow