### PR TITLE
feat: add orientation prop to PricingCard component and update layout…

### DIFF
--- a/apps/storybook/src/stories/core/PricingCard.stories.js
+++ b/apps/storybook/src/stories/core/PricingCard.stories.js
@@ -1,11 +1,11 @@
-import PricingCard from '@aziontech/webkit/pricing-card';
+import PricingCard from '@aziontech/webkit/pricing-card'
 
 const defaultFeatures = [
   { icon: 'pi-check', label: 'Unlimited rules engine' },
   { icon: 'pi-check', label: 'Global edge deployment' },
   { icon: 'pi-check', label: 'Advanced observability' },
   { icon: 'pi-check', label: '24/7 support' }
-];
+]
 
 export default {
   title: 'Core/PricingCard',
@@ -69,9 +69,14 @@ export default {
     buttonHidden: {
       control: 'boolean',
       description: 'Hides the CTA area'
+    },
+    orientation: {
+      control: 'select',
+      options: ['vertical', 'horizontal'],
+      description: 'Card layout orientation'
     }
   }
-};
+}
 
 export const Default = {
   args: {
@@ -88,9 +93,10 @@ export const Default = {
     buttonLink: '#',
     buttonTarget: '_self',
     customPrice: '',
-    buttonHidden: false
+    buttonHidden: false,
+    orientation: 'vertical'
   }
-};
+}
 
 export const Popular = {
   args: {
@@ -98,14 +104,14 @@ export const Popular = {
     popular: true,
     title: 'Business'
   }
-};
+}
 
 export const AnnualBilling = {
   args: {
     ...Default.args,
     currentPeriod: 'annual'
   }
-};
+}
 
 export const CustomPrice = {
   args: {
@@ -114,11 +120,26 @@ export const CustomPrice = {
     customPrice: 'Contact us',
     buttonLabel: 'Talk to Sales'
   }
-};
+}
 
 export const WithoutButton = {
   args: {
     ...Default.args,
     buttonHidden: true
   }
-};
+}
+
+export const Horizontal = {
+  args: {
+    ...Default.args,
+    orientation: 'horizontal'
+  }
+}
+
+export const HorizontalWithoutButton = {
+  args: {
+    ...Default.args,
+    buttonHidden: true,
+    orientation: 'horizontal'
+  }
+}

--- a/packages/webkit/src/components/pricing-card/pricing-card.vue
+++ b/packages/webkit/src/components/pricing-card/pricing-card.vue
@@ -61,6 +61,11 @@
     buttonHidden: {
       type: Boolean,
       default: false
+    },
+    orientation: {
+      type: String,
+      default: 'vertical',
+      validator: (value) => ['vertical', 'horizontal'].includes(value)
     }
   })
 
@@ -71,16 +76,21 @@
   const normalizedCurrentPrice = computed(() => currentPrice.value || '')
 
   const currentPeriodSuffix = computed(() => (props.currentPeriod === 'annual' ? '/yr' : '/mo'))
+
+  const isHorizontal = computed(() => props.orientation === 'horizontal')
 </script>
 
 <template>
   <div
     :class="[
-      'p-6 flex flex-col justify-between h-full w-full md:w-[20rem] border-default border text-default bg-surface',
+      'border-default border text-default bg-surface',
+      isHorizontal
+        ? 'p-5 flex flex-col md:flex-row gap-5 h-full w-full'
+        : 'p-6 flex flex-col justify-between h-full w-full md:w-[20rem]',
       !buttonHidden ? 'rounded-xl pb-2' : 'rounded-t-xl lg:rounded-xl'
     ]"
   >
-    <div class="pb-5">
+    <div :class="isHorizontal ? 'md:w-1/3 md:min-w-56' : 'pb-5'">
       <div class="flex gap-4 pb-4 items-center">
         <h3 class="text-heading-lg font-sora font-bold">{{ title }}</h3>
         <span
@@ -93,8 +103,8 @@
       <p class="text-body-sm text-muted">{{ subtitle }}</p>
     </div>
 
-    <div class="h-[13rem]">
-      <ul class="mb-10">
+    <div :class="isHorizontal ? 'flex-1' : 'h-[13rem]'">
+      <ul :class="isHorizontal ? 'mb-0' : 'mb-10'">
         <li
           v-for="(feature, index) in features"
           :key="`${feature?.label || 'feature'}-${index}`"
@@ -111,7 +121,8 @@
 
     <div
       :class="[
-        'h-24 flex mb-2 justify-between flex-wrap font-proto-mono',
+        'flex mb-2 justify-between flex-wrap font-proto-mono',
+        isHorizontal ? 'md:w-44 md:min-w-44 md:self-stretch' : 'h-24',
         !buttonHidden ? 'pb-2' : 'pb-0',
         customPrice ? 'items-end' : 'items-center'
       ]"


### PR DESCRIPTION
## Feature

### Description

Este PR adiciona suporte à orientação horizontal no componente `PricingCard` por meio da nova prop `orientation` (`vertical` | `horizontal`), mantendo `vertical` como padrão para compatibilidade.

Também foram atualizadas as stories do Storybook para expor o novo controle e demonstrar os cenários horizontal com e sem botão.

### How to test

1. Execute `pnpm storybook:dev` na raiz do repositório.
2. Acesse `Core/PricingCard` no Storybook.
3. Valide o comportamento padrão com `orientation: vertical`.
4. Troque para `orientation: horizontal` e confirme:
   - reorganização do layout em colunas no desktop;
   - manutenção da responsividade em telas menores;
   - alinhamento de preço, lista de features e CTA.
5. Valide os estados `Horizontal` e `HorizontalWithoutButton`.

### UI Changes (if applicable)

- Novo layout horizontal para `PricingCard` quando `orientation="horizontal"`.
- Novas stories para facilitar validação visual:
  - `Horizontal`
  - `HorizontalWithoutButton`

### Files changed

- `packages/webkit/src/components/pricing-card/pricing-card.vue`
- `apps/storybook/src/stories/core/PricingCard.stories.js`
