### PR TITLE
fix(button): remove hardcoded line-height classes from label

### DIFF
--- a/packages/webkit/src/components/site/button/button.vue
+++ b/packages/webkit/src/components/site/button/button.vue
@@ -76,8 +76,7 @@
   })
 
   const labelClasses = computed(() => {
-    const sizeClasses =
-      props.size === 'small' ? 'text-xs leading-[1rem]' : 'text-sm leading-[1.5rem]'
+    const sizeClasses = props.size === 'small' ? 'text-xs' : 'text-sm'
     return `${variantClasses[props.type].label} ${sizeClasses}`
   })
 


### PR DESCRIPTION
## Summary
- remove fixed `leading-*` classes from `button.vue` label sizing
- keep only text-size classes so line-height can follow theme defaults/tokens
- preserve existing button variants and size behavior while avoiding hardcoded typography