### PR TITLE
[ENG-37265] refactor: remove default vertical scroll from list data table

### DIFF
--- a/packages/webkit/src/core/list-data-table/components/list-data-table/list-data-table.vue
+++ b/packages/webkit/src/core/list-data-table/components/list-data-table/list-data-table.vue
@@ -151,11 +151,11 @@
     },
     scrollable: {
       type: Boolean,
-      default: true
+      default: false
     },
     scrollHeight: {
       type: String,
-      default: 'calc(100vh - 300px)'
+      default: undefined
     },
     showLastModifiedColumn: {
       type: Boolean,
@@ -414,6 +414,8 @@
       columnResizeMode="fit"
       @columnResizeEnd="applyDirtyColumnResizeFix"
       :frozenValue="frozenValue"
+      :scrollable="scrollable"
+      :scrollHeight="scrollable ? scrollHeight : undefined"
       paginatorTemplate="CurrentPageReport FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown JumpToPageInput"
       currentPageReportTemplate="Showing {first} to {last} of {totalRecords} entries"
     >

--- a/packages/webkit/src/core/list-data-table/components/list-data-table/list-data-table.vue
+++ b/packages/webkit/src/core/list-data-table/components/list-data-table/list-data-table.vue
@@ -155,7 +155,7 @@
     },
     scrollHeight: {
       type: String,
-      default: undefined
+      default: ''
     },
     showLastModifiedColumn: {
       type: Boolean,
@@ -415,7 +415,7 @@
       @columnResizeEnd="applyDirtyColumnResizeFix"
       :frozenValue="frozenValue"
       :scrollable="scrollable"
-      :scrollHeight="scrollable ? scrollHeight : undefined"
+      :scrollHeight="scrollable ? scrollHeight : ''"
       paginatorTemplate="CurrentPageReport FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown JumpToPageInput"
       currentPageReportTemplate="Showing {first} to {last} of {totalRecords} entries"
     >


### PR DESCRIPTION
## Summary
- Change `ListDataTable` defaults so it does not scroll internally by default: `scrollable` from `true` to `false`, and `scrollHeight` default removed (empty string).
- Bind `:scrollable` and `:scrollHeight` to the underlying `PrimeDataTable` (they were declared as props but not actually wired to the inner component, so callers couldn't enable scroll even when they tried).

## Root cause
The wrapper exposed `scrollable`/`scrollHeight` props but never bound them to `PrimeDataTable`. The defaults still suggested an internal scroll, leaving consumers in an inconsistent state.

## Changes
- `packages/webkit/src/core/list-data-table/components/list-data-table/list-data-table.vue`
  - Defaults: `scrollable: false`, `scrollHeight: ''`
  - Template: bind `:scrollable="scrollable"` and `:scrollHeight="scrollable ? scrollHeight : ''"` on `PrimeDataTable`

> Companion change in console-kit: aziontech/azion-console-kit#3505, where call sites that explicitly passed `scrollHeight` were also cleaned up.

## Test plan
- [ ] Storybook `ListDataTable.stories.js` default story shows no internal scroll.
- [ ] Setting `:scrollable="true"` on a story explicitly re-enables scroll (default `scrollHeight` no longer hidden).
- [ ] No regression on existing `ListDataTable` consumers in storybook.