### PR TITLE
fix(theme): add semantic big number size variants

### DIFF
--- a/packages/theme/src/tailwind/semantic-texts-plugin.js
+++ b/packages/theme/src/tailwind/semantic-texts-plugin.js
@@ -112,10 +112,18 @@ export const semanticTexts = () => {
 
     const texts = {
       '.text-big-number-md': {
-        fontSize: '4.5rem', // 7xl
+        fontSize: '2.25rem', // 7xl
         lineHeight: '1.20',
       },
-        '.text-heading-2xl': {
+      '.text-big-number-sm': {
+        fontSize: '1.25rem', // 7xl
+        lineHeight: '1.20',
+      },
+      '.text-big-number-lg': {
+        fontSize: '3.75rem', // 7xl
+        lineHeight: '1.20',
+      },
+      '.text-heading-2xl': {
         fontSize: '3.75rem', // text-6xl
         lineHeight: '1.2',
       },
@@ -178,7 +186,15 @@ export const semanticTexts = () => {
     const responsiveTexts = {
       [`@media (max-width: ${theme('screens.md', '768px')})`]: {
         '.text-big-number-md': {
-          fontSize: '3rem',
+          fontSize: '1.5rem',
+          lineHeight: '1.20',
+        },
+        '.text-big-number-sm': {
+          fontSize: '1.25rem', // 7xl
+          lineHeight: '1.20',
+        },
+        '.text-big-number-lg': {
+          fontSize: '2.25rem', // 7xl
           lineHeight: '1.20',
         },
         '.text-heading-2xl': {
@@ -223,7 +239,15 @@ export const semanticTexts = () => {
       },
       [`@media (max-width: ${theme('screens.sm', '640px')})`]: {
         '.text-big-number-md': {
-          fontSize: '3rem',
+          fontSize: '1.25rem',
+          lineHeight: '1.20',
+        },
+        '.text-big-number-sm': {
+          fontSize: '1rem', // 7xl
+          lineHeight: '1.20',
+        },
+        '.text-big-number-lg': {
+          fontSize: '1.5rem', // 7xl
           lineHeight: '1.20',
         },
         '.text-heading-2xl': {


### PR DESCRIPTION
## Summary
- Adds `.text-big-number-sm` and `.text-big-number-lg` semantic text classes in the theme Tailwind plugin.
- Rebalances `.text-big-number-md` sizing for desktop and mobile breakpoints to keep numeric emphasis consistent.
- Keeps responsive behavior aligned across `md` and `sm` media queries for all big-number variants.

## Why
- We need explicit semantic size variants for big numbers so components can pick a tokenized size instead of relying on ad-hoc font classes.
- Updating the existing medium size avoids oversized typography in constrained viewports and improves visual hierarchy.