### PR TITLE
fix(theme): use tailwind tokens directly in semantic texts

### DIFF
--- a/packages/theme/src/tailwind/semantic-texts-plugin.js
+++ b/packages/theme/src/tailwind/semantic-texts-plugin.js
@@ -8,14 +8,9 @@ const plugin = (() => {
 
 export const semanticTexts = () => {
   return plugin(({ addComponents, theme }) => {
-    const getFontSize = (token, fallback) => {
-      const value = theme(`fontSize.${token}`, fallback);
-      return Array.isArray(value) ? value[0] : value;
-    };
-
     const deprecatedTexts = {
       '.display-1': {
-        fontSize: getFontSize('5xl', '3rem'),
+        fontSize: theme('fontSize.5xl')[0],
         lineHeight: '1.10',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
@@ -33,13 +28,13 @@ export const semanticTexts = () => {
         letterSpacing: '-.05rem',
       },
       '.display-4': {
-        fontSize: getFontSize('2xl', '1.5rem'),
+        fontSize: theme('fontSize.2xl')[0],
         lineHeight: '1.3',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
       },
       '.display-5': {
-        fontSize: getFontSize('xl', '1.25rem'),
+        fontSize: theme('fontSize.xl')[0],
         lineHeight: '1.4',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
@@ -52,7 +47,7 @@ export const semanticTexts = () => {
         letterSpacing: '-.05rem',
       },
       '.display-2-mobile': {
-        fontSize: getFontSize('3xl', '1.875rem'),
+        fontSize: theme('fontSize.3xl')[0],
         lineHeight: '1.20',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
@@ -64,26 +59,26 @@ export const semanticTexts = () => {
         letterSpacing: '-.05rem',
       },
       '.display-4-mobile': {
-        fontSize: getFontSize('xl', '1.25rem'),
+        fontSize: theme('fontSize.xl')[0],
         lineHeight: '1.35',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
       },
       '.display-5-mobile': {
-        fontSize: getFontSize('lg', '1.125rem'),
+        fontSize: theme('fontSize.lg')[0],
         lineHeight: '1.35',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
       },
 
       '.body-1': {
-        fontSize: getFontSize('base', '1rem'),
+        fontSize: theme('fontSize.base')[0],
         lineHeight: '1.4rem',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
       },
       '.body-2': {
-        fontSize: getFontSize('sm', '.875rem'),
+        fontSize: theme('fontSize.sm')[0],
         lineHeight: '1.4rem',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
@@ -92,51 +87,51 @@ export const semanticTexts = () => {
 
     const texts = {
       '.text-big-number-md': {
-        fontSize: getFontSize('4xl', '2.25rem'),
+        fontSize: theme('fontSize.4xl')[0],
         lineHeight: '1.20',
       },
       '.text-big-number-sm': {
-        fontSize: getFontSize('xl', '1.25rem'),
+        fontSize: theme('fontSize.xl')[0],
         lineHeight: '1.20',
       },
       '.text-big-number-lg': {
-        fontSize: getFontSize('6xl', '3.75rem'),
+        fontSize: theme('fontSize.6xl')[0],
         lineHeight: '1.20',
       },
       '.text-heading-2xl': {
-        fontSize: getFontSize('6xl', '3.75rem'),
+        fontSize: theme('fontSize.6xl')[0],
         lineHeight: '1.2',
       },
       '.text-heading-xl': {
-        fontSize: getFontSize('4xl', '2.25rem'),
+        fontSize: theme('fontSize.4xl')[0],
         lineHeight: '1.2',
       },
       '.text-heading-lg': {
-        fontSize: getFontSize('3xl', '1.875rem'),
+        fontSize: theme('fontSize.3xl')[0],
         lineHeight: '1.2',
       },
       '.text-heading-md': {
-        fontSize: getFontSize('2xl', '1.5rem'),
+        fontSize: theme('fontSize.2xl')[0],
         lineHeight: '1.2',
       },
       '.text-heading-sm': {
-        fontSize: getFontSize('lg', '1.125rem'),
+        fontSize: theme('fontSize.lg')[0],
         lineHeight: '1.2',
       },
       '.text-body-lg': {
-        fontSize: getFontSize('lg', '18px'),
+        fontSize: theme('fontSize.lg')[0],
         lineHeight: '1.5',
       },
       '.text-body-md': {
-        fontSize: getFontSize('base', '16px'),
+        fontSize: theme('fontSize.base')[0],
         lineHeight: '1.5',
       },
       '.text-body-sm': {
-        fontSize: getFontSize('sm', '14px'),
+        fontSize: theme('fontSize.sm')[0],
         lineHeight: '1.5',
       },
       '.text-body-xs': {
-        fontSize: getFontSize('xs', '12px'),
+        fontSize: theme('fontSize.xs')[0],
         lineHeight: '1.5',
       },
       '.text-body-xss': {
@@ -144,13 +139,13 @@ export const semanticTexts = () => {
         lineHeight: '1.5',
       },
       '.text-overline-md': {
-        fontSize: getFontSize('sm', '14px'),
+        fontSize: theme('fontSize.sm')[0],
         lineHeight: '1.4',
         letterSpacing: '0.08em',
         textTransform: 'uppercase',
       },
       '.text-overline-sm': {
-        fontSize: getFontSize('xs', '12px'),
+        fontSize: theme('fontSize.xs')[0],
         lineHeight: '1.4',
         letterSpacing: '0.08em',
         textTransform: 'uppercase',
@@ -166,52 +161,52 @@ export const semanticTexts = () => {
     const responsiveTexts = {
       [`@media (max-width: ${theme('screens.md', '768px')})`]: {
         '.text-big-number-md': {
-          fontSize: getFontSize('2xl', '1.5rem'),
+          fontSize: theme('fontSize.2xl')[0],
           lineHeight: '1.20',
         },
         '.text-big-number-sm': {
-          fontSize: getFontSize('xl', '1.25rem'),
+          fontSize: theme('fontSize.xl')[0],
           lineHeight: '1.20',
         },
         '.text-big-number-lg': {
-          fontSize: getFontSize('4xl', '2.25rem'),
+          fontSize: theme('fontSize.4xl')[0],
           lineHeight: '1.20',
         },
         '.text-heading-2xl': {
-          fontSize: getFontSize('5xl', '3rem'),
+          fontSize: theme('fontSize.5xl')[0],
         },
         '.text-heading-xl': {
-          fontSize: getFontSize('3xl', '1.875rem'),
+          fontSize: theme('fontSize.3xl')[0],
         },
         '.text-heading-lg': {
-          fontSize: getFontSize('lg', '1.125rem'),
+          fontSize: theme('fontSize.lg')[0],
         },
         '.text-heading-md': {
-          fontSize: getFontSize('xl', '1.25rem'),
+          fontSize: theme('fontSize.xl')[0],
         },
         '.text-heading-sm': {
-          fontSize: getFontSize('base', '1rem'),
+          fontSize: theme('fontSize.base')[0],
         },
         '.text-body-lg': {
-          fontSize: getFontSize('base', '16px'),
+          fontSize: theme('fontSize.base')[0],
         },
         '.text-body-md': {
-          fontSize: getFontSize('base', '16px'),
+          fontSize: theme('fontSize.base')[0],
         },
         '.text-body-sm': {
-          fontSize: getFontSize('sm', '14px'),
+          fontSize: theme('fontSize.sm')[0],
         },
         '.text-body-xs': {
-          fontSize: getFontSize('xs', '12px'),
+          fontSize: theme('fontSize.xs')[0],
         },
         '.text-body-xss': {
           fontSize: '10px',
         },
         '.text-overline-md': {
-          fontSize: getFontSize('sm', '14px'),
+          fontSize: theme('fontSize.sm')[0],
         },
         '.text-overline-sm': {
-          fontSize: getFontSize('xs', '12px'),
+          fontSize: theme('fontSize.xs')[0],
         },
         '.text-overline-xs': {
           fontSize: '10px',
@@ -219,52 +214,52 @@ export const semanticTexts = () => {
       },
       [`@media (max-width: ${theme('screens.sm', '640px')})`]: {
         '.text-big-number-md': {
-          fontSize: getFontSize('xl', '1.25rem'),
+          fontSize: theme('fontSize.xl')[0],
           lineHeight: '1.20',
         },
         '.text-big-number-sm': {
-          fontSize: getFontSize('base', '1rem'),
+          fontSize: theme('fontSize.base')[0],
           lineHeight: '1.20',
         },
         '.text-big-number-lg': {
-          fontSize: getFontSize('2xl', '1.5rem'),
+          fontSize: theme('fontSize.2xl')[0],
           lineHeight: '1.20',
         },
         '.text-heading-2xl': {
-          fontSize: getFontSize('3xl', '1.875rem'),
+          fontSize: theme('fontSize.3xl')[0],
         },
         '.text-heading-xl': {
-          fontSize: getFontSize('xl', '1.25rem'),
+          fontSize: theme('fontSize.xl')[0],
         },
         '.text-heading-lg': {
-          fontSize: getFontSize('lg', '1.125rem'),
+          fontSize: theme('fontSize.lg')[0],
         },
         '.text-heading-md': {
-          fontSize: getFontSize('base', '1rem'),
+          fontSize: theme('fontSize.base')[0],
         },
         '.text-heading-sm': {
-          fontSize: getFontSize('sm', '0.875rem'),
+          fontSize: theme('fontSize.sm')[0],
         },
         '.text-body-lg': {
-          fontSize: getFontSize('base', '16px'),
+          fontSize: theme('fontSize.base')[0],
         },
         '.text-body-md': {
-          fontSize: getFontSize('base', '16px'),
+          fontSize: theme('fontSize.base')[0],
         },
         '.text-body-sm': {
-          fontSize: getFontSize('sm', '14px'),
+          fontSize: theme('fontSize.sm')[0],
         },
         '.text-body-xs': {
-          fontSize: getFontSize('xs', '12px'),
+          fontSize: theme('fontSize.xs')[0],
         },
         '.text-body-xss': {
           fontSize: '10px',
         },
         '.text-overline-md': {
-          fontSize: getFontSize('xs', '12px'),
+          fontSize: theme('fontSize.xs')[0],
         },
         '.text-overline-sm': {
-          fontSize: getFontSize('xs', '12px'),
+          fontSize: theme('fontSize.xs')[0],
         },
         '.text-overline-xs': {
           fontSize: '10px',

--- a/packages/theme/src/tailwind/semantic-texts-plugin.js
+++ b/packages/theme/src/tailwind/semantic-texts-plugin.js
@@ -1,3 +1,4 @@
+// Tailwind plugin that registers semantic typography utility classes.
 const plugin = (() => {
   try {
     return require('tailwindcss/plugin');

--- a/packages/theme/src/tailwind/semantic-texts-plugin.js
+++ b/packages/theme/src/tailwind/semantic-texts-plugin.js
@@ -10,7 +10,7 @@ export const semanticTexts = () => {
   return plugin(({ addComponents, theme }) => {
     const deprecatedTexts = {
       '.display-1': {
-        fontSize: theme('fontSize.5xl')[0],
+        fontSize: '3rem',
         lineHeight: '1.10',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
@@ -28,13 +28,13 @@ export const semanticTexts = () => {
         letterSpacing: '-.05rem',
       },
       '.display-4': {
-        fontSize: theme('fontSize.2xl')[0],
+        fontSize: '1.5rem',
         lineHeight: '1.3',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
       },
       '.display-5': {
-        fontSize: theme('fontSize.xl')[0],
+        fontSize: '1.25rem',
         lineHeight: '1.4',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
@@ -47,7 +47,7 @@ export const semanticTexts = () => {
         letterSpacing: '-.05rem',
       },
       '.display-2-mobile': {
-        fontSize: theme('fontSize.3xl')[0],
+        fontSize: '1.875rem',
         lineHeight: '1.20',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
@@ -59,26 +59,26 @@ export const semanticTexts = () => {
         letterSpacing: '-.05rem',
       },
       '.display-4-mobile': {
-        fontSize: theme('fontSize.xl')[0],
+        fontSize: '1.25rem',
         lineHeight: '1.35',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
       },
       '.display-5-mobile': {
-        fontSize: theme('fontSize.lg')[0],
+        fontSize: '1.125rem',
         lineHeight: '1.35',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
       },
 
       '.body-1': {
-        fontSize: theme('fontSize.base')[0],
+        fontSize: '1rem',
         lineHeight: '1.4rem',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
       },
       '.body-2': {
-        fontSize: theme('fontSize.sm')[0],
+        fontSize: '0.875rem',
         lineHeight: '1.4rem',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
@@ -87,71 +87,71 @@ export const semanticTexts = () => {
 
     const texts = {
       '.text-big-number-md': {
-        fontSize: theme('fontSize.4xl')[0],
+        fontSize: '2.25rem',
         lineHeight: '1.20',
       },
       '.text-big-number-sm': {
-        fontSize: theme('fontSize.xl')[0],
+        fontSize: '1.25rem',
         lineHeight: '1.20',
       },
       '.text-big-number-lg': {
-        fontSize: theme('fontSize.6xl')[0],
+        fontSize: '3.75rem',
         lineHeight: '1.20',
       },
       '.text-heading-2xl': {
-        fontSize: theme('fontSize.6xl')[0],
+        fontSize: '3.75rem',
         lineHeight: '1.2',
       },
       '.text-heading-xl': {
-        fontSize: theme('fontSize.4xl')[0],
+        fontSize: '2.25rem',
         lineHeight: '1.2',
       },
       '.text-heading-lg': {
-        fontSize: theme('fontSize.3xl')[0],
+        fontSize: '1.875rem',
         lineHeight: '1.2',
       },
       '.text-heading-md': {
-        fontSize: theme('fontSize.2xl')[0],
+        fontSize: '1.5rem',
         lineHeight: '1.2',
       },
       '.text-heading-sm': {
-        fontSize: theme('fontSize.lg')[0],
+        fontSize: '1.125rem',
         lineHeight: '1.2',
       },
       '.text-body-lg': {
-        fontSize: theme('fontSize.lg')[0],
+        fontSize: '1.125rem',
         lineHeight: '1.5',
       },
       '.text-body-md': {
-        fontSize: theme('fontSize.base')[0],
+        fontSize: '1rem',
         lineHeight: '1.5',
       },
       '.text-body-sm': {
-        fontSize: theme('fontSize.sm')[0],
+        fontSize: '0.875rem',
         lineHeight: '1.5',
       },
       '.text-body-xs': {
-        fontSize: theme('fontSize.xs')[0],
+        fontSize: '0.75rem',
         lineHeight: '1.5',
       },
       '.text-body-xss': {
-        fontSize: '10px',
+        fontSize: '0.625rem',
         lineHeight: '1.5',
       },
       '.text-overline-md': {
-        fontSize: theme('fontSize.sm')[0],
+        fontSize: '0.875rem',
         lineHeight: '1.4',
         letterSpacing: '0.08em',
         textTransform: 'uppercase',
       },
       '.text-overline-sm': {
-        fontSize: theme('fontSize.xs')[0],
+        fontSize: '0.75rem',
         lineHeight: '1.4',
         letterSpacing: '0.08em',
         textTransform: 'uppercase',
       },
       '.text-overline-xs': {
-        fontSize: '10px',
+        fontSize: '0.625rem',
         lineHeight: '1.4',
         letterSpacing: '0.08em',
         textTransform: 'uppercase',
@@ -161,108 +161,108 @@ export const semanticTexts = () => {
     const responsiveTexts = {
       [`@media (max-width: ${theme('screens.md', '768px')})`]: {
         '.text-big-number-md': {
-          fontSize: theme('fontSize.2xl')[0],
+          fontSize: '1.5rem',
           lineHeight: '1.20',
         },
         '.text-big-number-sm': {
-          fontSize: theme('fontSize.xl')[0],
+          fontSize: '1.25rem',
           lineHeight: '1.20',
         },
         '.text-big-number-lg': {
-          fontSize: theme('fontSize.4xl')[0],
+          fontSize: '2.25rem',
           lineHeight: '1.20',
         },
         '.text-heading-2xl': {
-          fontSize: theme('fontSize.5xl')[0],
+          fontSize: '3rem',
         },
         '.text-heading-xl': {
-          fontSize: theme('fontSize.3xl')[0],
+          fontSize: '1.875rem',
         },
         '.text-heading-lg': {
-          fontSize: theme('fontSize.lg')[0],
+          fontSize: '1.125rem',
         },
         '.text-heading-md': {
-          fontSize: theme('fontSize.xl')[0],
+          fontSize: '1.25rem',
         },
         '.text-heading-sm': {
-          fontSize: theme('fontSize.base')[0],
+          fontSize: '1rem',
         },
         '.text-body-lg': {
-          fontSize: theme('fontSize.base')[0],
+          fontSize: '1rem',
         },
         '.text-body-md': {
-          fontSize: theme('fontSize.base')[0],
+          fontSize: '1rem',
         },
         '.text-body-sm': {
-          fontSize: theme('fontSize.sm')[0],
+          fontSize: '0.875rem',
         },
         '.text-body-xs': {
-          fontSize: theme('fontSize.xs')[0],
+          fontSize: '0.75rem',
         },
         '.text-body-xss': {
-          fontSize: '10px',
+          fontSize: '0.625rem',
         },
         '.text-overline-md': {
-          fontSize: theme('fontSize.sm')[0],
+          fontSize: '0.875rem',
         },
         '.text-overline-sm': {
-          fontSize: theme('fontSize.xs')[0],
+          fontSize: '0.75rem',
         },
         '.text-overline-xs': {
-          fontSize: '10px',
+          fontSize: '0.625rem',
         },
       },
       [`@media (max-width: ${theme('screens.sm', '640px')})`]: {
         '.text-big-number-md': {
-          fontSize: theme('fontSize.xl')[0],
+          fontSize: '1.25rem',
           lineHeight: '1.20',
         },
         '.text-big-number-sm': {
-          fontSize: theme('fontSize.base')[0],
+          fontSize: '1rem',
           lineHeight: '1.20',
         },
         '.text-big-number-lg': {
-          fontSize: theme('fontSize.2xl')[0],
+          fontSize: '1.5rem',
           lineHeight: '1.20',
         },
         '.text-heading-2xl': {
-          fontSize: theme('fontSize.3xl')[0],
+          fontSize: '1.875rem',
         },
         '.text-heading-xl': {
-          fontSize: theme('fontSize.xl')[0],
+          fontSize: '1.25rem',
         },
         '.text-heading-lg': {
-          fontSize: theme('fontSize.lg')[0],
+          fontSize: '1.125rem',
         },
         '.text-heading-md': {
-          fontSize: theme('fontSize.base')[0],
+          fontSize: '1rem',
         },
         '.text-heading-sm': {
-          fontSize: theme('fontSize.sm')[0],
+          fontSize: '0.875rem',
         },
         '.text-body-lg': {
-          fontSize: theme('fontSize.base')[0],
+          fontSize: '1rem',
         },
         '.text-body-md': {
-          fontSize: theme('fontSize.base')[0],
+          fontSize: '1rem',
         },
         '.text-body-sm': {
-          fontSize: theme('fontSize.sm')[0],
+          fontSize: '0.875rem',
         },
         '.text-body-xs': {
-          fontSize: theme('fontSize.xs')[0],
+          fontSize: '0.75rem',
         },
         '.text-body-xss': {
-          fontSize: '10px',
+          fontSize: '0.625rem',
         },
         '.text-overline-md': {
-          fontSize: theme('fontSize.xs')[0],
+          fontSize: '0.75rem',
         },
         '.text-overline-sm': {
-          fontSize: theme('fontSize.xs')[0],
+          fontSize: '0.75rem',
         },
         '.text-overline-xs': {
-          fontSize: '10px',
+          fontSize: '0.625rem',
         },
       },
 

--- a/packages/theme/src/tailwind/semantic-texts-plugin.js
+++ b/packages/theme/src/tailwind/semantic-texts-plugin.js
@@ -1,21 +1,3 @@
-/**
- * Tailwind plugin to expose semantic text styles (typography).
- *
- * This adds typography components like display-1, body-1, etc.
- *
- * Usage in tailwind.config.js:
- * ```javascript
- * import { theme } from '@aziontech/theme/tailwind/tailwind-theme.js';
- * import semanticTexts from '@aziontech/theme/tailwind/semantic-texts-plugin';
- *
- * export default {
- *   theme,
- *   plugins: [semanticTexts()],
- * };
- * ```
- */
-
-// Lazy-require to avoid hard dependency for consumers
 const plugin = (() => {
   try {
     return require('tailwindcss/plugin');
@@ -24,16 +6,16 @@ const plugin = (() => {
   }
 })();
 
-/**
- * Generate semantic text style components
- * @returns {import('tailwindcss/plugin').Plugin}
- */
 export const semanticTexts = () => {
   return plugin(({ addComponents, theme }) => {
+    const getFontSize = (token, fallback) => {
+      const value = theme(`fontSize.${token}`, fallback);
+      return Array.isArray(value) ? value[0] : value;
+    };
+
     const deprecatedTexts = {
-      // Display styles - Desktop
       '.display-1': {
-        fontSize: '3rem',
+        fontSize: getFontSize('5xl', '3rem'),
         lineHeight: '1.10',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
@@ -51,19 +33,18 @@ export const semanticTexts = () => {
         letterSpacing: '-.05rem',
       },
       '.display-4': {
-        fontSize: '1.5rem',
+        fontSize: getFontSize('2xl', '1.5rem'),
         lineHeight: '1.3',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
       },
       '.display-5': {
-        fontSize: '1.25rem',
+        fontSize: getFontSize('xl', '1.25rem'),
         lineHeight: '1.4',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
       },
 
-      // Display styles - Mobile
       '.display-1-mobile': {
         fontSize: '2.5rem',
         lineHeight: '1.15',
@@ -71,7 +52,7 @@ export const semanticTexts = () => {
         letterSpacing: '-.05rem',
       },
       '.display-2-mobile': {
-        fontSize: '1.875rem',
+        fontSize: getFontSize('3xl', '1.875rem'),
         lineHeight: '1.20',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
@@ -83,27 +64,26 @@ export const semanticTexts = () => {
         letterSpacing: '-.05rem',
       },
       '.display-4-mobile': {
-        fontSize: '1.25rem',
+        fontSize: getFontSize('xl', '1.25rem'),
         lineHeight: '1.35',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
       },
       '.display-5-mobile': {
-        fontSize: '1.125rem',
+        fontSize: getFontSize('lg', '1.125rem'),
         lineHeight: '1.35',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
       },
 
-      // Body styles
       '.body-1': {
-        fontSize: '1rem',
+        fontSize: getFontSize('base', '1rem'),
         lineHeight: '1.4rem',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
       },
       '.body-2': {
-        fontSize: '.875rem',
+        fontSize: getFontSize('sm', '.875rem'),
         lineHeight: '1.4rem',
         fontFamily: 'Sora',
         letterSpacing: '-.05rem',
@@ -112,51 +92,51 @@ export const semanticTexts = () => {
 
     const texts = {
       '.text-big-number-md': {
-        fontSize: '2.25rem', // 7xl
+        fontSize: getFontSize('4xl', '2.25rem'),
         lineHeight: '1.20',
       },
       '.text-big-number-sm': {
-        fontSize: '1.25rem', // 7xl
+        fontSize: getFontSize('xl', '1.25rem'),
         lineHeight: '1.20',
       },
       '.text-big-number-lg': {
-        fontSize: '3.75rem', // 7xl
+        fontSize: getFontSize('6xl', '3.75rem'),
         lineHeight: '1.20',
       },
       '.text-heading-2xl': {
-        fontSize: '3.75rem', // text-6xl
+        fontSize: getFontSize('6xl', '3.75rem'),
         lineHeight: '1.2',
       },
       '.text-heading-xl': {
-        fontSize: '2.25rem', // text-4xl
+        fontSize: getFontSize('4xl', '2.25rem'),
         lineHeight: '1.2',
       },
       '.text-heading-lg': {
-        fontSize: '1.875rem', // text-3xl
+        fontSize: getFontSize('3xl', '1.875rem'),
         lineHeight: '1.2',
       },
       '.text-heading-md': {
-        fontSize: '1.5rem', // text-2xl
+        fontSize: getFontSize('2xl', '1.5rem'),
         lineHeight: '1.2',
       },
       '.text-heading-sm': {
-        fontSize: '1.125rem', // text-lg
+        fontSize: getFontSize('lg', '1.125rem'),
         lineHeight: '1.2',
       },
-        '.text-body-lg': {
-        fontSize: '18px', // text-lg
+      '.text-body-lg': {
+        fontSize: getFontSize('lg', '18px'),
         lineHeight: '1.5',
       },
       '.text-body-md': {
-        fontSize: '16px', // text-base
+        fontSize: getFontSize('base', '16px'),
         lineHeight: '1.5',
       },
       '.text-body-sm': {
-        fontSize: '14px', // text-sm
+        fontSize: getFontSize('sm', '14px'),
         lineHeight: '1.5',
       },
       '.text-body-xs': {
-        fontSize: '12px', // text-xs
+        fontSize: getFontSize('xs', '12px'),
         lineHeight: '1.5',
       },
       '.text-body-xss': {
@@ -164,13 +144,13 @@ export const semanticTexts = () => {
         lineHeight: '1.5',
       },
       '.text-overline-md': {
-        fontSize: '14px', // text-sm
+        fontSize: getFontSize('sm', '14px'),
         lineHeight: '1.4',
         letterSpacing: '0.08em',
         textTransform: 'uppercase',
       },
       '.text-overline-sm': {
-        fontSize: '12px', // text-xs
+        fontSize: getFontSize('xs', '12px'),
         lineHeight: '1.4',
         letterSpacing: '0.08em',
         textTransform: 'uppercase',
@@ -186,52 +166,52 @@ export const semanticTexts = () => {
     const responsiveTexts = {
       [`@media (max-width: ${theme('screens.md', '768px')})`]: {
         '.text-big-number-md': {
-          fontSize: '1.5rem',
+          fontSize: getFontSize('2xl', '1.5rem'),
           lineHeight: '1.20',
         },
         '.text-big-number-sm': {
-          fontSize: '1.25rem', // 7xl
+          fontSize: getFontSize('xl', '1.25rem'),
           lineHeight: '1.20',
         },
         '.text-big-number-lg': {
-          fontSize: '2.25rem', // 7xl
+          fontSize: getFontSize('4xl', '2.25rem'),
           lineHeight: '1.20',
         },
         '.text-heading-2xl': {
-          fontSize: '3rem', // text-5xl
+          fontSize: getFontSize('5xl', '3rem'),
         },
         '.text-heading-xl': {
-          fontSize: '1.875rem', // text-3xl
+          fontSize: getFontSize('3xl', '1.875rem'),
         },
         '.text-heading-lg': {
-          fontSize: '1.125rem', // text-lg
+          fontSize: getFontSize('lg', '1.125rem'),
         },
         '.text-heading-md': {
-          fontSize: '1.25rem', // text-xl
+          fontSize: getFontSize('xl', '1.25rem'),
         },
         '.text-heading-sm': {
-          fontSize: '1rem', // text-base
+          fontSize: getFontSize('base', '1rem'),
         },
         '.text-body-lg': {
-          fontSize: '16px', // text-base
+          fontSize: getFontSize('base', '16px'),
         },
         '.text-body-md': {
-          fontSize: '16px', // mantém
+          fontSize: getFontSize('base', '16px'),
         },
         '.text-body-sm': {
-          fontSize: '14px',
+          fontSize: getFontSize('sm', '14px'),
         },
         '.text-body-xs': {
-          fontSize: '12px',
+          fontSize: getFontSize('xs', '12px'),
         },
         '.text-body-xss': {
           fontSize: '10px',
         },
         '.text-overline-md': {
-          fontSize: '14px',
+          fontSize: getFontSize('sm', '14px'),
         },
         '.text-overline-sm': {
-          fontSize: '12px',
+          fontSize: getFontSize('xs', '12px'),
         },
         '.text-overline-xs': {
           fontSize: '10px',
@@ -239,52 +219,52 @@ export const semanticTexts = () => {
       },
       [`@media (max-width: ${theme('screens.sm', '640px')})`]: {
         '.text-big-number-md': {
-          fontSize: '1.25rem',
+          fontSize: getFontSize('xl', '1.25rem'),
           lineHeight: '1.20',
         },
         '.text-big-number-sm': {
-          fontSize: '1rem', // 7xl
+          fontSize: getFontSize('base', '1rem'),
           lineHeight: '1.20',
         },
         '.text-big-number-lg': {
-          fontSize: '1.5rem', // 7xl
+          fontSize: getFontSize('2xl', '1.5rem'),
           lineHeight: '1.20',
         },
         '.text-heading-2xl': {
-          fontSize: '1.875rem',
+          fontSize: getFontSize('3xl', '1.875rem'),
         },
         '.text-heading-xl': {
-          fontSize: '1.25rem',
+          fontSize: getFontSize('xl', '1.25rem'),
         },
         '.text-heading-lg': {
-          fontSize: '1.125rem',
+          fontSize: getFontSize('lg', '1.125rem'),
         },
         '.text-heading-md': {
-          fontSize: '1rem',
+          fontSize: getFontSize('base', '1rem'),
         },
         '.text-heading-sm': {
-          fontSize: '0.875rem',
+          fontSize: getFontSize('sm', '0.875rem'),
         },
         '.text-body-lg': {
-          fontSize: '16px',
+          fontSize: getFontSize('base', '16px'),
         },
         '.text-body-md': {
-          fontSize: '16px',
+          fontSize: getFontSize('base', '16px'),
         },
         '.text-body-sm': {
-          fontSize: '14px',
+          fontSize: getFontSize('sm', '14px'),
         },
         '.text-body-xs': {
-          fontSize: '12px',
+          fontSize: getFontSize('xs', '12px'),
         },
         '.text-body-xss': {
           fontSize: '10px',
         },
         '.text-overline-md': {
-          fontSize: '12px',
+          fontSize: getFontSize('xs', '12px'),
         },
         '.text-overline-sm': {
-          fontSize: '12px',
+          fontSize: getFontSize('xs', '12px'),
         },
         '.text-overline-xs': {
           fontSize: '10px',


### PR DESCRIPTION
## Summary
- Replaces hardcoded semantic text font sizes with direct Tailwind token lookups using `theme('fontSize.*')[0]`.
- Removes the helper abstraction and keeps token usage explicit in each semantic text class.
- Preserves fixed values only where no matching token exists (for example `10px`).

## Why
- Keeping token access inline makes the mapping clearer and easier to audit per class.
- This aligns semantic text utilities with Tailwind theme values while keeping fallback-free behavior explicit.