### PR TITLE
fix: corrige popularText e ajustes de tipografia/sufixo em pricing-card e toggle

### DIFF
--- a/packages/webkit/src/components/pricing-card/pricing-card.vue
+++ b/packages/webkit/src/components/pricing-card/pricing-card.vue
@@ -73,7 +73,12 @@
 
   const normalizedCurrentPrice = computed(() => currentPrice.value || '')
 
-  const currentPeriodSuffix = computed(() => (props.currentPeriod === 'annual' ? '/yr' : '/mo'))
+  const currentPeriodSuffix = computed(() => {
+    if (currentPrice.value === '$0') {
+      return '/forever'
+    }
+    return props.currentPeriod === 'annual' ? '/yr' : '/mo'
+  })
 
   const isHorizontal = computed(() => props.orientation === 'horizontal')
 </script>
@@ -110,7 +115,7 @@
         >
           <span
             v-if="feature?.icon"
-            :class="['pi', feature.icon, 'text-primary']"
+            :class="[feature.icon, 'text-primary']"
           />
           <p class="font-sora text-body-sm">{{ feature?.label }}</p>
         </li>
@@ -135,7 +140,7 @@
       <template v-if="!customPrice">
         <div class="flex items-end text-body-sm font-proto-mono">
           <span v-if="normalizedCurrentPrice.startsWith('$')">$</span>
-          <h4 class="text-big-number-md leading-[3.5rem] tracking-tighter font-proto-mono">
+          <h4 class="text-big-number-md tracking-tighter font-proto-mono">
             {{ normalizedCurrentPrice.replace('$', '') }}
           </h4>
           <span class="font-proto-mono">{{ currentPeriodSuffix }}</span>

--- a/packages/webkit/src/components/pricing-card/pricing-card.vue
+++ b/packages/webkit/src/components/pricing-card/pricing-card.vue
@@ -8,7 +8,7 @@
       type: Boolean,
       default: false
     },
-    pupularText: {
+    popularText: {
       type: String,
       default: 'Popular'
     },
@@ -100,7 +100,7 @@
           v-if="popular"
           class="h-fit text-body-xs flex font-proto-mono justify-center items-center bg-violet-500 text-neutral-900 px-2 py-1 rounded"
         >
-          {{ pupularText }}
+          {{ popularText }}
         </span>
       </div>
       <p class="text-body-sm text-muted">{{ subtitle }}</p>
@@ -140,7 +140,7 @@
       <template v-if="!customPrice">
         <div class="flex items-end text-body-sm font-proto-mono">
           <span v-if="normalizedCurrentPrice.startsWith('$')">$</span>
-          <h4 class="text-big-number-md tracking-tighter font-proto-mono">
+          <h4 class="text-big-number-lg leading-none tracking-tighter font-proto-mono">
             {{ normalizedCurrentPrice.replace('$', '') }}
           </h4>
           <span class="font-proto-mono">{{ currentPeriodSuffix }}</span>
@@ -148,7 +148,7 @@
       </template>
 
       <template v-else>
-        <span class="text-heading-md w-full flex items-end text-left font-sora">
+        <span class="text-heading-md w-full flex items-end text-left font-proto-mono">
           {{ customPrice }}
         </span>
       </template>

--- a/packages/webkit/src/components/toggle/toggle.vue
+++ b/packages/webkit/src/components/toggle/toggle.vue
@@ -89,7 +89,7 @@
           @keydown.space.prevent="selectOption('main')"
           :class="[
             'whitespace-nowrap relative z-10 px-3 py-1 rounded-md transition-all duration-300 ease-in-out',
-            'font-proto-mono tracking-tight uppercase cursor-pointer text-center',
+            'font-proto-mono tracking-tight uppercase cursor-pointer text-center text-body-xs',
             selectedOption === 'main' ? 'text-neutral-900' : 'text-muted hover:text-default'
           ]"
         >
@@ -102,7 +102,7 @@
           @keydown.space.prevent="selectOption('alternative')"
           :class="[
             'whitespace-nowrap relative z-10 px-3 py-1 rounded-md transition-all duration-300 ease-in-out',
-            'font-proto-mono tracking-tight uppercase cursor-pointer text-center',
+            'font-proto-mono tracking-tight uppercase cursor-pointer text-center text-body-xs',
             selectedOption === 'alternative' ? 'text-neutral-900' : 'text-muted hover:text-default'
           ]"
         >


### PR DESCRIPTION
## Bug fix

### What was the problem?

O componente `pricing-card` tinha inconsistencias que afetavam a API e a exibicao visual:
- prop escrita incorretamente como `pupularText`;
- sufixo de periodo nao contemplava preco gratuito (`$0`);
- combinacao de classes de tipografia e icone fora do padrao esperado.

No `toggle`, os labels nao aplicavam a escala tipografica esperada para o texto das opcoes.

### Expected behavior

- A prop de destaque deve ser `popularText`.
- Cartoes com preco `$0` devem exibir sufixo `/forever`.
- Tipografia e classes visuais devem seguir o padrao do design system em `pricing-card` e `toggle`.

### How was it solved

- Renomeada a prop `pupularText` para `popularText` em `pricing-card`.
- Atualizada a computacao de `currentPeriodSuffix` para retornar `/forever` quando `currentPrice === '$0'`.
- Ajustadas classes de estilo no `pricing-card`:
  - icone de feature usa apenas `feature.icon` + `text-primary`;
  - valor principal alterado para `text-big-number-lg` com `leading-none`;
  - `customPrice` usa `font-proto-mono`.
- Ajustadas classes no `toggle` para incluir `text-body-xs` nos labels das opcoes.

### How to test

1. Executar `pnpm webkit:lint` na raiz do projeto e confirmar que nao ha erros.
2. No Storybook ou ambiente de desenvolvimento, validar `pricing-card` com:
   - `popular` ativo e `popularText` personalizado;
   - `currentPeriod` em `monthly` e `annual`;
   - `monthlyPrice` ou `annualPrice` igual a `$0` (deve mostrar `/forever`);
   - `customPrice` preenchido.
3. Validar `toggle` e confirmar que os labels das opcoes exibem tipografia `text-body-xs` e mantem estado selecionado corretamente.

### Files changed

- `packages/webkit/src/components/pricing-card/pricing-card.vue`
- `packages/webkit/src/components/toggle/toggle.vue`
