### PR TITLE
fix(pricing-card): update suffix and button visibility for free tier

### DIFF
--- a/packages/webkit/src/components/pricing-card/pricing-card.vue
+++ b/packages/webkit/src/components/pricing-card/pricing-card.vue
@@ -75,7 +75,7 @@
 
   const currentPeriodSuffix = computed(() => {
     if (normalizedCurrentPrice.value === '$0') {
-      return 'Forever'
+      return '/forever'
     }
 
     return '/mo'
@@ -157,7 +157,7 @@
 
     <div
       v-if="!buttonHidden"
-      class="pb-4 hidden md:flex"
+      class="pb-4 flex"
     >
       <slot name="button" />
     </div>


### PR DESCRIPTION
## Summary
- ajusta o sufixo exibido no `pricing-card` quando o preco e zero, mantendo consistencia na comunicacao do plano gratuito
- corrige a visibilidade do botao para refletir corretamente o estado esperado no card

## Test Plan
- nao executado (nao solicitado)