### PR TITLE
feat(pricing-card): use Tag component for popular badge

### DIFF
--- a/apps/storybook/src/stories/core/PricingCard.stories.js
+++ b/apps/storybook/src/stories/core/PricingCard.stories.js
@@ -30,7 +30,7 @@ export default {
       control: 'boolean',
       description: 'Displays the Popular badge'
     },
-    pupularText: {
+    popularText: {
       control: 'text',
       description: 'Popular badge label'
     },
@@ -78,7 +78,7 @@ export default {
 export const Default = {
   args: {
     popular: false,
-    pupularText: 'Popular',
+    popularText: 'Popular',
     title: 'Pro',
     subtitle: 'For teams scaling edge applications fast.',
     features: defaultFeatures,

--- a/packages/webkit/src/components/pricing-card/pricing-card.vue
+++ b/packages/webkit/src/components/pricing-card/pricing-card.vue
@@ -1,6 +1,8 @@
 <script setup>
   import { computed } from 'vue'
 
+  import Tag from '../tag/tag.vue'
+
   defineOptions({ name: 'PricingCard' })
 
   const props = defineProps({
@@ -97,14 +99,13 @@
     <div :class="isHorizontal ? 'md:w-1/3 md:min-w-56' : 'pb-5'">
       <div class="flex gap-4 pb-4 items-center">
         <h3 class="text-heading-lg font-sora font-bold">{{ title }}</h3>
-        <span
+        <Tag
           v-if="popular"
-          class="h-fit text-body-xs flex font-proto-mono justify-center items-center bg-violet-500 text-neutral-900 px-2 py-1 rounded"
-        >
-          {{ popularText }}
-        </span>
+          severity="primary"
+          :value="popularText"
+        />
       </div>
-      <p class="text-body-sm text-muted">{{ subtitle }}</p>
+      <p class="text-body-xs">{{ subtitle }}</p>
     </div>
 
     <div :class="isHorizontal ? 'flex-1' : 'h-[13rem]'">
@@ -118,7 +119,12 @@
             v-if="feature?.icon"
             :class="[feature.icon, 'text-primary']"
           />
-          <p class="font-sora text-body-sm">{{ feature?.label }}</p>
+          <p
+            class="text-body-sm"
+            :class="!feature.icon ? 'font-proto-mono text-muted' : 'font-sora'"
+          >
+            {{ feature?.label }}
+          </p>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- replace the PricingCard popular badge inline span with the shared Webkit `Tag` component to keep badge styling consistent with the design system
- keep `popular` and `popularText` behavior unchanged while simplifying badge rendering in the component
- fix Storybook PricingCard args typo (`pupularText` -> `popularText`) so controls map correctly to the component prop

## Commits
- feat(pricing-card): use Tag component for popular badge
- fix(storybook): correct PricingCard popularText arg name