### PR TITLE
fix(tag): adjust icon alignment and spacing

### DIFF
--- a/packages/webkit/src/components/tag/tag.vue
+++ b/packages/webkit/src/components/tag/tag.vue
@@ -89,7 +89,7 @@
 
   const rootClass = computed(() => {
     const classes = [
-      'inline-flex h-6 items-center justify-center gap-1 overflow-hidden border px-2',
+      'inline-flex h-6 items-center justify-center gap-2 overflow-hidden border px-2',
       'font-proto-mono text-xs font-normal leading-none',
       currentSeverityStyle.value.container,
       props.rounded ? 'rounded-full' : (currentSeverityStyle.value.roundedOff ?? 'rounded')
@@ -102,7 +102,11 @@
     return classes
   })
 
-  const iconClass = computed(() => [props.icon, 'shrink-0', currentSeverityStyle.value.icon])
+  const iconClass = computed(() => [
+    props.icon,
+    'shrink-0 flex items-center',
+    currentSeverityStyle.value.icon
+  ])
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- Ajusta o espaçamento entre ícone e texto no componente `Tag` (`gap-1` → `gap-2`)
- Adiciona `flex items-center` à classe do ícone para garantir o alinhamento vertical correto

## Contexto
O ícone customizado dentro do componente `Tag` estava com espaçamento muito apertado em relação ao texto e desalinhado verticalmente em alguns casos. O ajuste deixa o layout mais respirável e consistente entre as variantes (`success`, `info`, `warning`, `danger`).

## Antes / Depois

**Antes:**
<img width="1043" height="176" alt="image" src="https://github.com/user-attachments/assets/6c8ad560-407b-48aa-977b-a13b6318662c" />

**Depois:**
<img width="1049" height="191" alt="image" src="https://github.com/user-attachments/assets/6ca53be8-9534-487f-976c-4413166d0d9d" />

## Test plan
- [ ] Abrir o Storybook do `Tag` e validar a story "With Custom Icon"
- [ ] Verificar que ícone e texto possuem espaçamento adequado em todas as severidades
- [ ] Validar que o ícone está alinhado verticalmente ao centro do texto
- [ ] Conferir que o componente `PricingCard` (que consome `Tag`) não regrediu
