### PR TITLE
feat: change brand primary color

### DIFF
--- a/packages/webkit/src/components/overline/overline.vue
+++ b/packages/webkit/src/components/overline/overline.vue
@@ -36,7 +36,7 @@
       {{ prefix }}
     </span>
     <span
-      class="font-proto-mono text-pretty text-brand-primary-400 font-medium leading-1 tracking-tightest uppercase text-overline-md"
+      class="font-proto-mono text-pretty text-brand-primary-500 font-medium leading-1 tracking-tightest uppercase text-overline-md"
       :class="{ 'whitespace-nowrap': singleLine }"
     >
       <slot />

--- a/packages/webkit/src/core/card/card-content/card-content.vue
+++ b/packages/webkit/src/core/card/card-content/card-content.vue
@@ -151,7 +151,7 @@
       :class="contentInnerClass"
     >
       <p
-        class="font-proto-mono text-overline-sm text-brand-primary-400"
+        class="font-proto-mono text-overline-sm text-brand-primary-500"
         v-if="overline"
       >
         {{ overline }}
@@ -160,7 +160,7 @@
       <span
         v-if="icon"
         :class="icon"
-        class="text-brand-primary-400 text-heading-sm"
+        class="text-brand-primary-500 text-heading-sm"
       ></span>
 
       <h3


### PR DESCRIPTION
  - Updated brand primary color usage from text-brand-primary-400 to text-brand-primary-500 in overline and card-content components to align with the updated brand palette.

  Changes

  - packages/webkit/src/components/overline/overline.vue: overline text token bumped to brand-primary-500.
  - packages/webkit/src/core/card/card-content/card-content.vue: overline text and icon tokens bumped to brand-primary-500.

  Test plan

  - Visually verify overline component renders with the new primary shade across light/dark themes.
  - Visually verify card-content overline text and icon render with the new primary shade.
  - Confirm no regressions in components that compose overline or card-content (e.g., cards, list items).
  - Run existing unit/visual tests for the affected components.