### PR TITLE
feat(theme): add motion tokens and popup-scale animation

### DIFF
--- a/packages/theme/src/tokens/primitives/animations/animate.js
+++ b/packages/theme/src/tokens/primitives/animations/animate.js
@@ -1,8 +1,26 @@
+export const curve = {
+  'productive-entrance': 'cubic-bezier(0.39, 0.57, 0.56, 1)',
+  'productive-exit': 'cubic-bezier(0.55, 0.09, 0.68, 0.53)',
+  'expressive-entrance': 'cubic-bezier(0.17, 0.84, 0.44, 1)',
+  'expressive-exit': 'cubic-bezier(0.95, 0.05, 0.8, 0.04)',
+};
+
+export const duration = {
+  'fast-01': '70ms',
+  'fast-02': '110ms',
+  'moderate-01': '150ms',
+  'moderate-02': '240ms',
+  'slow-01': '400ms',
+  'slow-02': '700ms',
+};
+
 export const animate = {
   spin: 'spin 1s linear infinite',
   ping: 'ping 1s cubic-bezier(0, 0, 0.2, 1) infinite',
   pulse: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
   bounce: 'bounce 1s infinite',
+  'popup-scale-in': `popupScaleIn ${duration['moderate-01']} ${curve['productive-entrance']}`,
+  'popup-scale-out': `popupScaleOut ${duration['fast-02']} ${curve['productive-exit']}`,
 };
 
-export default { animate };
+export default { animate, curve, duration };

--- a/packages/theme/src/tokens/semantic/animations.js
+++ b/packages/theme/src/tokens/semantic/animations.js
@@ -29,6 +29,14 @@ export const animations = () => {
       '.animate-highlight-fade': {
         animation: 'highlight ease-in forwards',
       },
+      '.animate-popup-scale-in': {
+        animation: 'popupScaleIn 150ms cubic-bezier(0.39, 0.57, 0.56, 1)',
+        transformOrigin: 'var(--popup-origin, center)',
+      },
+      '.animate-popup-scale-out': {
+        animation: 'popupScaleOut 110ms cubic-bezier(0.55, 0.09, 0.68, 0.53)',
+        transformOrigin: 'var(--popup-origin, center)',
+      },
     };
 
     // Keyframes components
@@ -52,6 +60,14 @@ export const animations = () => {
       '@keyframes highlight': {
         '0%': { backgroundColor: 'var(--surface-hover)', fontWeight: '500' },
         '100%': { backgroundColor: 'var(--surface-hover)', fontWeight: '500' },
+      },
+      '@keyframes popupScaleIn': {
+        '0%': { opacity: '0', transform: 'scale(0.95)' },
+        '100%': { opacity: '1', transform: 'scale(1)' },
+      },
+      '@keyframes popupScaleOut': {
+        '0%': { opacity: '1', transform: 'scale(1)' },
+        '100%': { opacity: '0', transform: 'scale(0.95)' },
       },
     };
 


### PR DESCRIPTION
## Summary
- Introduce primitive motion tokens (`curve` and `duration`) in `packages/theme/src/tokens/primitives/animations/animate.js`, matching the Motion design tokens (productive/expressive entrance & exit curves; fast/moderate/slow durations).
- Compose new `popup-scale-in` / `popup-scale-out` animations from those tokens.
- Expose `.animate-popup-scale-in` and `.animate-popup-scale-out` semantic utilities with `popupScaleIn` / `popupScaleOut` keyframes (opacity + scale 0.95 → 1), with a configurable `--popup-origin` transform origin.

## Tokens

### Curves
| Token | Value |
|---|---|
| `curve-productive-entrance` | `cubic-bezier(0.39, 0.57, 0.56, 1)` |
| `curve-productive-exit` | `cubic-bezier(0.55, 0.09, 0.68, 0.53)` |
| `curve-expressive-entrance` | `cubic-bezier(0.17, 0.84, 0.44, 1)` |
| `curve-expressive-exit` | `cubic-bezier(0.95, 0.05, 0.8, 0.04)` |

### Durations
| Token | Value |
|---|---|
| `duration-fast-01` | 70ms |
| `duration-fast-02` | 110ms |
| `duration-moderate-01` | 150ms |
| `duration-moderate-02` | 240ms |
| `duration-slow-01` | 400ms |
| `duration-slow-02` | 700ms |

## Test plan
- [ ] Theme builds without errors (`pnpm --filter @azion/theme build`)
- [ ] `.animate-popup-scale-in` / `.animate-popup-scale-out` are emitted in the generated CSS
- [ ] Popup/menu components animate using the new utility without regressions
- [ ] `--popup-origin` overrides the transform origin as expected