### PR TITLE
fix: adjust readme to bump version

### DIFF
--- a/packages/webkit/README.md
+++ b/packages/webkit/README.md
@@ -45,4 +45,4 @@ import ListDataTable from '@aziontech/webkit/list-data-table'
 
 ## License
 
-MIT
+Licence: MIT


### PR DESCRIPTION
## Summary
- Minor README tweak in `packages/webkit/README.md` to trigger a semantic-release version bump so the starter-bundle exports (`./content/*`, `./data/*`, `./feedback/*`, `./inputs/*`, `./layout/*`, `./navigation/*`, `./overlay/*`, `./templates/*`) registered after the `3.0.0` tag get published to npm.

## Test plan
- [ ] CI green
- [ ] semantic-release picks up the `fix:` commit and publishes the new patch version
- [ ] Published tarball's `package.json#exports` includes the starter-bundle entries