### PR TITLE
refactor: align segmented-button styling with button pattern

### DIFF
--- a/packages/webkit/src/components/wip/segmented-button/segmented-button.vue
+++ b/packages/webkit/src/components/wip/segmented-button/segmented-button.vue
@@ -1,7 +1,10 @@
 <script setup>
-  import { computed, ref, watch } from 'vue'
+  import { computed, ref, useAttrs, watch } from 'vue'
 
-  defineOptions({ name: 'SegmentedButton' })
+  defineOptions({
+    name: 'SegmentedButton',
+    inheritAttrs: false
+  })
 
   const props = defineProps({
     modelValue: {
@@ -11,14 +14,23 @@
     options: {
       type: Array,
       default: () => []
-    },
-    class: {
-      type: String,
-      default: ''
     }
   })
 
   const emit = defineEmits(['update:modelValue', 'change'])
+
+  const attrs = useAttrs()
+
+  const passthroughAttrs = computed(() => {
+    const rest = { ...attrs }
+
+    delete rest.class
+    delete rest['data-testid']
+
+    return rest
+  })
+
+  const testId = computed(() => attrs['data-testid'] ?? 'segmented-button')
 
   const internalValue = ref(props.modelValue)
 
@@ -126,12 +138,43 @@
     },
     { immediate: true }
   )
+
+  const rootClasses = computed(() => {
+    const classes = [
+      'inline-flex w-fit items-center gap-[var(--spacing-xxs)]',
+      'rounded-[var(--shape-button)] border border-[var(--border-muted)] bg-[var(--bg-surface)] p-[var(--spacing-xxs)]'
+    ]
+
+    if (attrs.class) {
+      classes.push(attrs.class)
+    }
+
+    return classes
+  })
+
+  const sharedOptionClasses = [
+    'relative inline-flex h-7 items-center justify-center whitespace-nowrap',
+    'rounded-[var(--shape-button)] border border-transparent px-[var(--spacing-sm)]',
+    'text-overline-sm',
+    'transition-colors duration-fast-02 ease-productive-entrance motion-reduce:transition-none',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-color)]',
+    'disabled:cursor-not-allowed disabled:opacity-50'
+  ]
+
+  const selectedClasses = 'bg-[var(--bg-canvas)] text-[var(--text-default)]'
+  const unselectedClasses = 'bg-transparent text-[var(--text-muted)]'
+
+  const optionClasses = (option) => [
+    sharedOptionClasses,
+    option.value === selectedValue.value ? selectedClasses : unselectedClasses
+  ]
 </script>
 
 <template>
   <div
-    class="inline-flex w-fit items-center gap-1 rounded-sm border border-solid border-default bg-surface p-1"
-    :class="props.class"
+    v-bind="passthroughAttrs"
+    :class="rootClasses"
+    :data-testid="testId"
     role="radiogroup"
   >
     <button
@@ -139,10 +182,10 @@
       :key="option.value"
       type="button"
       role="radio"
-      :aria-checked="String(option.value === selectedValue)"
+      :aria-checked="option.value === selectedValue"
       :disabled="option.disabled"
-      class="inline-flex h-7 items-center justify-center whitespace-nowrap rounded-sm border border-transparent bg-transparent px-3 font-proto-mono text-overline-sm text-muted transition-colors duration-200 ease-in-out focus-visible:outline-none focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50"
-      :class="option.value === selectedValue ? 'bg-canvas text-default' : ''"
+      :class="optionClasses(option)"
+      :data-testid="`${testId}__option`"
       @click="selectOption(option)"
       @keydown="onOptionKeydown($event, option)"
     >


### PR DESCRIPTION
## What

Refactors `segmented-button.vue` to follow the styling conventions used by the rest of the actions layer (reference: `button.vue`), without changing its public behavior.

## Why

The component diverged from the layer's conventions: raw non-token utilities (`gap-1`, `rounded-sm`, `bg-surface`, `text-muted`, `duration-200 ease-in-out`), the `class` declared inside `defineProps`, an inline ternary for the selected state, and no `useAttrs`/`testId` wiring.

## Changes

- **Design tokens** — raw utilities replaced with `var(--*)` (`--spacing-xxs`/`--spacing-sm`, `--shape-button`, `--border-muted`, `--bg-surface`, `--bg-canvas`, `--text-default`, `--text-muted`, `--ring-color`); typography via the generated `text-overline-sm` class.
- **Semantic transitions** — `duration-200 ease-in-out` → `duration-fast-02 ease-productive-entrance` + `motion-reduce:transition-none`.
- **Class composition** — `rootClasses` computed + `sharedOptionClasses`/`selectedClasses`/`unselectedClasses` presets composed via an `optionClasses(option)` helper, instead of inline ternaries.
- **Attrs** — `useAttrs()` + `inheritAttrs: false`, `passthroughAttrs`, and `class` merged through attrs (removed the `class` prop). Added `data-testid` (`segmented-button` + `__option`).
- Stays plain `<script setup>` (no TypeScript), matching the runtime-`defineProps` style of sibling components like `card-pricing.vue`.

Radiogroup semantics, `v-model`, the `change` event, keyboard navigation, and disabled handling are unchanged.

## Verification

- `pnpm webkit:lint` — pass
- `pnpm webkit:type-check` (vue-tsc) — pass
- `validate-tokens` write hook — pass
- `pnpm storybook:build` — SFC compiles