### PR TITLE
chore(specs): align story pattern with Button.stories.js + folder-per-subcomponent layout

### DIFF
--- a/.claude/docs/COMPONENT_REQUIREMENTS.md
+++ b/.claude/docs/COMPONENT_REQUIREMENTS.md
@@ -1024,19 +1024,55 @@ When the component justifies Composition Pattern, ship the **complete anatomy** 
 - **DropdownMenu:** `DropdownMenu` + `DropdownMenuTrigger` + `DropdownMenuContent` + `DropdownMenuItem` + `DropdownMenuSeparator` + `DropdownMenuLabel`.
 - **Card:** `Card` + `CardHeader` + `CardTitle` + `CardDescription` + `CardContent` + `CardFooter`.
 
+#### Folder layout — canonical (applies to every new composition component)
+
+One folder per sub-component, file name preserves the full prefix, one `package.json` per folder, and the shared `injection-key.ts` lives at the root of the component (sibling of the root `.vue`).
+
+```
+packages/webkit/src/components/webkit/overlay/dialog/
+├── dialog.vue
+├── package.json
+├── injection-key.ts
+├── dialog-trigger/
+│   ├── dialog-trigger.vue
+│   └── package.json
+├── dialog-portal/
+│   ├── dialog-portal.vue
+│   └── package.json
+├── dialog-overlay/
+│   ├── dialog-overlay.vue
+│   └── package.json
+├── dialog-content/
+│   ├── dialog-content.vue
+│   └── package.json
+├── dialog-title/
+│   ├── dialog-title.vue
+│   └── package.json
+├── dialog-description/
+│   ├── dialog-description.vue
+│   └── package.json
+└── dialog-close/
+    ├── dialog-close.vue
+    └── package.json
+```
+
+> Existing composition components (`dialog`, `drawer`, `navigation-menu`, `dropdown-menu`, `breadcrumb`) still use the legacy **flat** layout, where every sub-component `.vue` sits directly under the component root. They are not migrated as part of new-component work — migration would require moving files and updating every `packages/webkit/package.json#exports` right-hand path, plus every consumer import path in console-kit, which is out of scope. The new layout above applies only to components scaffolded going forward.
+
 Conventions:
 
-- Sibling files in the same directory: `dialog.vue`, `dialog-trigger.vue`, `dialog-portal.vue`, `dialog-overlay.vue`, `dialog-content.vue`, `dialog-title.vue`, `dialog-description.vue`, `dialog-close.vue`.
-- Shared `InjectionKey<T>` and TypeScript types in a sibling `injection-key.ts` or `types.ts` to avoid circular imports.
-- Each public sub-component receives an entry in `package.json#exports` (`./overlay/dialog`, `./overlay/dialog-trigger`, …) and a Storybook story (the `WithComposition` story shows the full anatomy).
-- `as-child` enabled on `Trigger` and `Close` variants.
-- `data-state` exposed on Root + Content for state-driven styling.
+- **Folder per sub-component, file keeps the full prefix** (`dialog-trigger/dialog-trigger.vue`, never `dialog-trigger/index.vue`). Reasons: (a) unambiguous error traces — stack frames show `dialog-trigger.vue`, not 27 different `index.vue` lines; (b) easier grep by file name; (c) editor breadcrumbs stay legible.
+- **One `package.json` per folder** (root + every sub-component). Mirrors how monolithic components like `button` already work — each sub-component is a self-contained entry point.
+- **Public export path stays flat.** `packages/webkit/package.json#exports` keeps `./overlay/dialog-trigger` as the consumer-facing path; only the right-hand value reflects the folder nesting (`./src/components/webkit/overlay/dialog/dialog-trigger/dialog-trigger.vue`). Consumers see no churn.
+- **Shared `InjectionKey<T>` and TypeScript types in a sibling `injection-key.ts`** at the root level (sibling of `<name>.vue`, **not** inside any sub-component folder). Root imports `./injection-key`; sub-components import `../injection-key`.
+- **`as-child`** enabled on `Trigger` and `Close` variants.
+- **`data-state`** exposed on Root + Content for state-driven styling.
+- Each public sub-component receives an entry in `package.json#exports` (`./overlay/dialog`, `./overlay/dialog-trigger`, …). The Storybook story for the root component covers the composition anatomy through the spec's `## Usage` block (which renders the full tree) — there is no separate `WithComposition` story by default.
 
 ### 3. Composition Pattern — só quando faz sentido
 
 Reference: [shadcn-vue.com/docs/components](https://www.shadcn-vue.com/docs/components).
 
-- **Composition Pattern (YES):** the consumer needs to swap order, omit, or replace parts. Examples: `Dialog` + `DialogTrigger` + `DialogPortal` + `DialogOverlay` + `DialogContent` + `DialogTitle` + `DialogDescription` + `DialogClose`; `Card` + `CardHeader` + `CardTitle` + `CardDescription` + `CardContent` + `CardFooter`; `Tabs` + `TabsList` + `TabsTrigger` + `TabsContent`; Accordion; DropdownMenu; Sheet/Drawer; Form fields. Ship the complete anatomy (see § 2.9). Sibling sub-components live in the same directory; shared state goes through `provide`/`inject` typed with `InjectionKey<T>`; each public sub-component has its own entry in `packages/webkit/package.json#exports`.
+- **Composition Pattern (YES):** the consumer needs to swap order, omit, or replace parts. Examples: `Dialog` + `DialogTrigger` + `DialogPortal` + `DialogOverlay` + `DialogContent` + `DialogTitle` + `DialogDescription` + `DialogClose`; `Card` + `CardHeader` + `CardTitle` + `CardDescription` + `CardContent` + `CardFooter`; `Tabs` + `TabsList` + `TabsTrigger` + `TabsContent`; Accordion; DropdownMenu; Sheet/Drawer; Form fields. Ship the complete anatomy (see § 2.9). **Each sub-component lives in its own folder** under the root component (`<root>/<root>-<part>/<root>-<part>.vue` + its own `package.json`); the shared `InjectionKey<T>` is a sibling of the root `.vue` (`./injection-key`, imported as `../injection-key` from each sub-component); each public sub-component has its own entry in `packages/webkit/package.json#exports`.
 - **Monolithic with props + slots (NOT Composition):** fixed layout with variations driven by configuration and limited inversion via slots. Real example: [card-pricing.vue](../src/components/webkit/content/card-pricing/card-pricing.vue) — props `slotPosition`/`cardStyle`/`showTag`/`showPricingDetails` plus a `default` and a named `actions` slot. The internal structure is fixed.
 - **Atomic** (Button, IconButton, Tag, Spinner, Badge, Currency) — always monolithic, no slots.
 - **Decision rule:** "does the consumer need to change the ORDER or OMIT parts exposed by the root?" If yes, use Composition Pattern. If no, stay monolithic. When in doubt, **start monolithic** and refactor only when a real use case appears.
@@ -1140,12 +1176,14 @@ Authoring the `.figma.ts` file works without the token; only publishing needs it
 
 ### 13. Storybook story — canonical pattern (Vue 3 + Storybook 8)
 
-Stories follow the **market-standard CSF3 pattern for Vue 3**, not whatever a local file happens to do today. The canonical template the `component-create` skill emits is reproduced below.
+Stories follow the **market-standard CSF3 pattern for Vue 3** — concretely, the existing [`apps/storybook/src/stories/webkit/actions/button/Button.stories.js`](../../apps/storybook/src/stories/webkit/actions/button/Button.stories.js). The two distinguishing traits versus a generic CSF3 file:
+
+1. **Composite stories `Types` and `Sizes`** render every variant side-by-side in a single frame — replacing one-story-per-variant (`Primary`, `Secondary`, `Outlined`, …).
+2. **`parameters.docs.description.component` is built from the spec.** The Purpose paragraph is the lead-in; the `## Usage` fenced `vue` block (import + minimal `<script setup>` + `<template>`) is appended verbatim as a shadcn-vue-style code snippet. The same block is the single source of truth for both spec docs and Storybook Docs.
 
 ```js
-// <Name>.stories.js
+// <Name>.stories.js — canonical shape (matches Button.stories.js)
 import Component from '@aziontech/webkit/<category>/<name>'
-import { expect, userEvent, within } from '@storybook/test'
 
 /** @type {import('@storybook/vue3').Meta<typeof Component>} */
 const meta = {
@@ -1154,7 +1192,7 @@ const meta = {
   // subcomponents: { ComponentTrigger, ComponentContent } // when Composition Pattern
   tags: ['autodocs'],
   parameters: {
-    layout: 'padded',
+    layout: 'centered',
     backgrounds: { default: 'dark' },
     a11y: {
       config: {
@@ -1166,27 +1204,39 @@ const meta = {
     },
     docs: {
       description: {
-        component:
-          '<one paragraph describing the component, when to use it, and any non-obvious behavior>'
+        // <Purpose paragraph from .specs/<name>.md>
+        //
+        // ## Usage
+        //
+        // ```vue
+        // <script setup>
+        // import Component from '@aziontech/webkit/<category>/<name>'
+        // </script>
+        //
+        // <template>
+        //   <Component label="Click me" />
+        // </template>
+        // ```
+        component: /* the multi-line markdown built from the spec — see .claude/skills/storybook-write/SKILL.md step 3 */
       }
     }
   },
   argTypes: {
     // --- PROPS ---
     kind: {
-      control: { type: 'select' },
+      control: 'select',
       options: ['primary', 'secondary', 'outlined', 'text'],
       description: 'Visual variant.',
       table: {
-        type: { summary: 'ButtonKind' },
-        defaultValue: { summary: 'primary' },
-        category: 'props'
+        category: 'props',
+        type: { summary: "'primary' | 'secondary' | 'outlined' | 'text'" },
+        defaultValue: { summary: "'primary'" }
       }
     },
     disabled: {
       control: 'boolean',
       description: 'Disables interaction and applies the disabled token set.',
-      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' }, category: 'props' }
+      table: { category: 'props', type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
     },
 
     // --- EVENTS ---
@@ -1195,20 +1245,8 @@ const meta = {
     // (e.g. `'action-click'`) silently fail — the Actions panel stays empty.
     onClick: {
       action: 'click',
-      description: 'Fires when the component is activated.',
-      table: { type: { summary: '(event: MouseEvent) => void' }, category: 'events' }
-    },
-    'onUpdate:open': {
-      action: 'update:open',
-      description: 'Emitted when the open state changes (works with v-model:open).',
-      table: { type: { summary: '(value: boolean) => void' }, category: 'events' }
-    },
-
-    // --- SLOTS ---
-    default: {
-      description: 'Default slot content.',
-      control: false,
-      table: { type: { summary: 'VNode | string' }, category: 'slots' }
+      description: 'Emitted when the button is activated.',
+      table: { category: 'events', type: { summary: 'MouseEvent' } }
     }
   },
   args: {
@@ -1218,71 +1256,76 @@ const meta = {
 }
 export default meta
 
+// Reusable Template — destructure event handlers off args and forward via @event.
 const Template = (args) => ({
   components: { Component },
   setup() {
-    return { args }
+    const { onClick, ...props } = args
+    return { props, onClick }
   },
-  template: '<Component v-bind="args" />'
+  template: '<Component v-bind="props" @click="onClick" />'
 })
 
 /** @type {import('@storybook/vue3').StoryObj<typeof Component>} */
 export const Default = {
   render: Template,
-  parameters: { docs: { description: { story: 'Default configuration.' } } }
+  parameters: { docs: { description: { story: 'Default primary button at large size.' } } }
+}
+
+export const Types = {
+  render: () => ({
+    components: { Component },
+    template: `
+      <div class="flex flex-wrap items-center gap-4">
+        <Component kind="primary" label="Button" />
+        <Component kind="secondary" label="Button" />
+        <Component kind="outlined" label="Button" />
+        <Component kind="text" label="Button" />
+      </div>
+    `
+  }),
+  parameters: { docs: { description: { story: 'All kind variants side by side.' } } }
+}
+
+export const Sizes = {
+  render: () => ({
+    components: { Component },
+    template: `
+      <div class="flex flex-wrap items-center gap-4">
+        <Component size="small" label="Button" />
+        <Component size="medium" label="Button" />
+        <Component size="large" label="Button" />
+      </div>
+    `
+  }),
+  parameters: { docs: { description: { story: 'All size variants side by side.' } } }
+}
+
+export const Loading = {
+  args: { loading: true, label: 'Button' },
+  render: Template,
+  parameters: { docs: { description: { story: 'Loading state with spinner replacing the icon.' } } }
 }
 
 export const Disabled = {
-  args: { disabled: true },
+  args: { disabled: true, label: 'Button' },
   render: Template,
   parameters: { docs: { description: { story: 'Disabled state.' } } }
-}
-
-export const Accessibility = {
-  render: Template,
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Keyboard: Tab focuses the control; Enter/Space activates. Screen reader announces role + name. Tested with VoiceOver.'
-      }
-    }
-  },
-  play: async ({ canvasElement, args, step }) => {
-    const canvas = within(canvasElement)
-    await step('Tab focuses the primary control', async () => {
-      await userEvent.tab()
-      expect(canvas.getByRole('button')).toHaveFocus()
-    })
-    await step('Enter triggers the click handler', async () => {
-      await userEvent.keyboard('{Enter}')
-      expect(args.onClick).toHaveBeenCalled()
-    })
-  }
-}
-
-export const Playground = {
-  render: Template,
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Drive every prop from the Controls panel; the Actions panel captures emitted events.'
-      }
-    }
-  }
 }
 ```
 
 **Hard rules:**
 
+- **`layout: 'centered'`** by default. Override to `'padded'` only when the component is full-width (header, sidebar, drawer).
+- **`parameters.docs.description.component` is built from the spec** — Purpose paragraph + the verbatim `## Usage` fenced code block. Never hand-edit the usage example in the story. Never paste it elsewhere in the file.
+- **Composite `Types` / `Sizes` stories** are the canonical replacement for one-story-per-variant. Do not split them into `Primary`, `Secondary`, `Small`, `Medium`, etc.
 - **Events as `on<EventName>` camelCase** in `argTypes`, with `action: '<emitted-name>'`. Vue 3's `v-bind` ignores kebab-case keys, so `'action-click': { action: '...' }` silently breaks the Actions panel. Use `onActionClick: { action: 'action-click' }`. For v-model events, the key keeps the colon: `'onUpdate:open': { action: 'update:open' }`.
+- **Reusable `Template` destructures event handlers off `args`** and forwards them via `@event="handler"` in the template — exactly like `Button.stories.js`. Without that, the Actions panel cannot capture them.
 - **Do NOT use** `parameters.actions.argTypesRegex` (deprecated in Storybook 8).
 - **Do NOT use** `parameters.actions.handles` (legacy Web Components addon, not Vue 3 emits).
-- **Use `table.category`** to group controls: `'props'` (default — may omit), `'events'`, `'slots'`.
+- **Use `table.category`** to group controls: `'props'`, `'events'`, `'slots'`.
 - **`control: false`** for slots and any non-controllable item.
-- **Single reusable `Template`** at module scope; do not redeclare the same render inline in every story.
-- **CSF3 object shape** (`export const Name = { args, render, parameters, play }`). Never CSF2 (`Name.args = {...}`).
+- **CSF3 object shape** (`export const Name = { args, render, parameters }`). Never CSF2 (`Name.args = {...}`).
 - **Slot demos** use a story-specific `template` with real markup inside the component — slots are not passed via `v-bind`.
 - **`tags: ['autodocs']`** on the meta.
 - **`subcomponents`** on the meta when Composition Pattern — Storybook generates Docs tabs per sub-component.
@@ -1290,11 +1333,12 @@ export const Playground = {
 **Mandatory stories — minimal by default:**
 
 - `Default`
-- One per `kind` (omit if the component has only one)
-- One per `size` (omit if the component has only one)
+- `Types` (when the component has more than one `kind`)
+- `Sizes` (when the component has more than one `size`)
+- `Loading` (only if the component has a `loading` prop)
 - `Disabled` (only if the component has a `disabled` prop)
 
-**Forbidden by default** (do **not** add unless the spec explicitly lists and justifies them): `LightDark`, `Accessibility` with `play`, `Playground`, `WithSlots`, `WithComposition`, `Controlled`, `Uncontrolled`, `Loading`. Storybook's `autodocs` + `a11y` addon + `backgrounds` already cover dark/light, axe checks, and consumer-driven exploration via Controls — adding bespoke stories duplicates work and rots over time.
+**Forbidden by default** (do **not** add unless the spec explicitly lists and justifies them): `LightDark`, `Accessibility` with `play`, `Playground`, `WithSlots`, `WithComposition`, `Controlled`, `Uncontrolled`, one-story-per-variant (`Primary`, `Secondary`, `Small`, …). Storybook's `autodocs` + `a11y` addon + `backgrounds` already cover dark/light, axe checks, and consumer-driven exploration via Controls — adding bespoke stories duplicates work and rots over time.
 
 ### 13.w Styling discipline (mandatory for new components)
 
@@ -1456,7 +1500,7 @@ The spec lists which `kind` / `size` stories exist. Do **not** add visual permut
 - [ ] **Naming conventions** applied (`kind`/`size`/booleans without prefix, events kebab-case).
 - [ ] **Controlled / uncontrolled** states implemented when applicable.
 - [ ] Composition Pattern only when justified (sibling sub-components + typed `provide`/`inject`).
-- [ ] When Composition Pattern: complete anatomy shipped (Trigger/Portal/Overlay/Content/Title/Description/Close as applicable — see § 2.9).
+- [ ] When Composition Pattern: complete anatomy shipped (Trigger/Portal/Overlay/Content/Title/Description/Close as applicable — see § 2.9), with the canonical folder-per-sub-component layout (`<root>/<root>-<part>/<root>-<part>.vue` + its own `package.json`; shared `injection-key.ts` at the root level).
 - [ ] **`asChild`** exposed on trigger-like sub-components (Trigger/Close/etc.) — § 2.5.
 - [ ] **`data-state`/`data-disabled`/`data-orientation`** exposed on the root and on stateful sub-components — § 2.6.
 - [ ] **`VariantProps`** (e.g. `ButtonKind`, `ButtonSize`) exported as named exports — § 2.8.
@@ -1500,9 +1544,9 @@ The spec lists which `kind` / `size` stories exist. Do **not** add visual permut
 - [ ] `args` with sensible defaults.
 - [ ] `parameters.actions`, `parameters.a11y`, `parameters.docs.description.*`, `parameters.backgrounds`, `parameters.layout`.
 - [ ] `decorators` when needed.
-- [ ] Stories: Default + per `kind` + per `size` + Disabled + Loading + WithSlots/WithComposition + Controlled + Uncontrolled + **LightDark** + Accessibility + **Playground**.
-- [ ] `play` function in Accessibility (or Playground) using `@storybook/test` (installed in `apps/storybook/package.json`). Import `userEvent`, `expect`, `within` from `@storybook/test`.
-- [ ] `render: (args) => ({ ..., setup() { return { args } }, template: '<Comp v-bind="args" />' })`.
+- [ ] Stories: `Default` + `Types` (composite, when more than one `kind`) + `Sizes` (composite, when more than one `size`) + `Loading` (only when the component has a `loading` prop) + `Disabled` (only when the component has a `disabled` prop). Nothing else by default — see § 13 for the forbidden list.
+- [ ] `parameters.docs.description.component` built from the spec: Purpose paragraph + the verbatim `## Usage` fenced `vue` code block (import + `<script setup>` + `<template>`). Same shadcn-vue convention used by `Button.stories.js`.
+- [ ] Reusable `Template` at module scope, destructuring event handlers off `args` and forwarding via `@event="handler"` so the Actions panel works.
 
 #### Validação
 

--- a/.claude/docs/COMPONENT_REQUIREMENTS.md
+++ b/.claude/docs/COMPONENT_REQUIREMENTS.md
@@ -862,7 +862,7 @@ npm run build:dts
 
 ## Webkit Layer Pattern (in-depth)
 
-This section describes the canonical pattern enforced for components living under `packages/webkit/src/components/webkit/<category>/<name>/`. It complements the structure rules above with the visual, behavioral, and quality requirements derived from the canonical implementations: [button.vue](../src/components/webkit/actions/button/button.vue), [icon-button.vue](../src/components/webkit/actions/icon-button/icon-button.vue), [card-pricing.vue](../src/components/webkit/content/card-pricing/card-pricing.vue). Reference for compositional decisions: [shadcn-vue.com/docs/components](https://www.shadcn-vue.com/docs/components).
+This section describes the canonical pattern enforced for components living under `packages/webkit/src/components/webkit/<category>/<name>/`. It complements the structure rules above with the visual, behavioral, and quality requirements derived from the canonical implementations: [button.vue](../src/components/webkit/actions/button/button.vue), [icon-button.vue](../src/components/webkit/actions/icon-button/icon-button.vue), [card-pricing.vue](../src/components/webkit/content/card-pricing/card-pricing.vue).
 
 > **No hallucination — only reference things that exist.** Before importing any module, calling any function, mentioning any file path, or referencing any package/export in generated code, verify it exists: `@aziontech/webkit/<subpath>` must appear in [`package.json#exports`](../package.json); relative imports must resolve on disk; npm packages must be installed; workspaces must have a `package.json`. If a needed module is missing, install it, create the file, or annotate the gap as a pending item in the report — never invent imports. The `validate-references.mjs` hook physically blocks Writes whose new imports do not resolve. Sub-sections marked `— pending` below describe patterns that depend on dependencies not yet installed; do not emulate them with phantom paths.
 
@@ -913,7 +913,7 @@ interface Props {
 - **v-model** follows Vue 3 standard via `defineModel<T>('propName')`.
 - **Refs / composables** use descriptive prefixes (`triggerRef`, `panelRef`, `useFocusTrap`).
 
-### 2.3. Estados controlados vs não-controlados (padrão shadcn)
+### 2.3. Estados controlados vs não-controlados
 
 When the component owns relevant internal state (open/value/selected/expanded), expose **both** APIs:
 
@@ -934,11 +934,11 @@ defineSlots<{
 }>()
 ```
 
-### 2.5. `as-child` / Slot pattern (shadcn-vue) — _pending_
+### 2.5. `as-child` / Slot pattern — _pending_
 
-> **Status: not yet available.** A Slot helper composable does not exist in this repository today. Do **not** import a phantom path; the `validate-references.mjs` hook will block it. When a real component needs this pattern, propose adding the helper under `packages/webkit/src/composables/` in a dedicated PR (with TypeScript Slot polyfill or via `reka-ui`), then revisit this section.
+> **Status: not yet available.** A Slot helper composable does not exist in this repository today. Do **not** import a phantom path; the `validate-references.mjs` hook will block it. When a real component needs this pattern, propose adding the helper under `packages/webkit/src/composables/` in a dedicated PR, then revisit this section.
 
-When the helper ships, the pattern looks like: a component exposes `asChild?: boolean`. When `asChild` is `true`, it clones the single default-slot child and forwards classes/attrs/refs/listeners into it (same as `DialogTrigger`/`TooltipTrigger`/`AccordionTrigger` in shadcn-vue).
+When the helper ships, the pattern looks like: a component exposes `asChild?: boolean`. When `asChild` is `true`, it clones the single default-slot child and forwards classes/attrs/refs/listeners into it (same idea used by overlay trigger components in this codebase).
 
 ```ts
 interface Props {
@@ -951,7 +951,7 @@ Use cases (when available): triggers of overlay components, link-or-button wrapp
 
 ### 2.6. `data-state` / `data-disabled` / `data-orientation` attributes
 
-Expose reactive state via `data-*` attributes on the root so consumers can style with Tailwind state variants (`data-[state=open]:bg-...`). Same approach as shadcn-vue / Reka UI.
+Expose reactive state via `data-*` attributes on the root so consumers can style with Tailwind state variants (`data-[state=open]:bg-...`).
 
 ```vue
 <template>
@@ -1014,9 +1014,9 @@ interface MyCardActionProps {
 
 Naming pattern: `<ComponentName><PropName>` — `ButtonKind`, `ButtonSize`, `DialogSize`, `TabsOrientation`. Each public type is re-exported through the component's entry in `package.json#exports` (Vue SFC default export covers the runtime; named exports cover the types).
 
-### 2.9. Anatomy completa em Composition Pattern (shadcn-vue style)
+### 2.9. Anatomy completa em Composition Pattern
 
-When the component justifies Composition Pattern, ship the **complete anatomy** following the shadcn-vue/Reka UI convention. Reference anatomies:
+When the component justifies Composition Pattern, ship the **complete anatomy** — each meaningful part is its own public sub-component. Reference anatomies:
 
 - **Dialog:** `Dialog` (root) + `DialogTrigger` (as-child) + `DialogPortal` (teleport) + `DialogOverlay` (backdrop) + `DialogContent` (panel) + `DialogTitle` + `DialogDescription` + `DialogClose` (as-child).
 - **Tabs:** `Tabs` + `TabsList` + `TabsTrigger` + `TabsContent`.
@@ -1069,8 +1069,6 @@ Conventions:
 - Each public sub-component receives an entry in `package.json#exports` (`./overlay/dialog`, `./overlay/dialog-trigger`, …). The Storybook story for the root component covers the composition anatomy through the spec's `## Usage` block (which renders the full tree) — there is no separate `WithComposition` story by default.
 
 ### 3. Composition Pattern — só quando faz sentido
-
-Reference: [shadcn-vue.com/docs/components](https://www.shadcn-vue.com/docs/components).
 
 - **Composition Pattern (YES):** the consumer needs to swap order, omit, or replace parts. Examples: `Dialog` + `DialogTrigger` + `DialogPortal` + `DialogOverlay` + `DialogContent` + `DialogTitle` + `DialogDescription` + `DialogClose`; `Card` + `CardHeader` + `CardTitle` + `CardDescription` + `CardContent` + `CardFooter`; `Tabs` + `TabsList` + `TabsTrigger` + `TabsContent`; Accordion; DropdownMenu; Sheet/Drawer; Form fields. Ship the complete anatomy (see § 2.9). **Each sub-component lives in its own folder** under the root component (`<root>/<root>-<part>/<root>-<part>.vue` + its own `package.json`); the shared `InjectionKey<T>` is a sibling of the root `.vue` (`./injection-key`, imported as `../injection-key` from each sub-component); each public sub-component has its own entry in `packages/webkit/package.json#exports`.
 - **Monolithic with props + slots (NOT Composition):** fixed layout with variations driven by configuration and limited inversion via slots. Real example: [card-pricing.vue](../src/components/webkit/content/card-pricing/card-pricing.vue) — props `slotPosition`/`cardStyle`/`showTag`/`showPricingDetails` plus a `default` and a named `actions` slot. The internal structure is fixed.
@@ -1179,7 +1177,7 @@ Authoring the `.figma.ts` file works without the token; only publishing needs it
 Stories follow the **market-standard CSF3 pattern for Vue 3** — concretely, the existing [`apps/storybook/src/stories/webkit/actions/button/Button.stories.js`](../../apps/storybook/src/stories/webkit/actions/button/Button.stories.js). The two distinguishing traits versus a generic CSF3 file:
 
 1. **Composite stories `Types` and `Sizes`** render every variant side-by-side in a single frame — replacing one-story-per-variant (`Primary`, `Secondary`, `Outlined`, …).
-2. **`parameters.docs.description.component` is built from the spec.** The Purpose paragraph is the lead-in; the `## Usage` fenced `vue` block (import + minimal `<script setup>` + `<template>`) is appended verbatim as a shadcn-vue-style code snippet. The same block is the single source of truth for both spec docs and Storybook Docs.
+2. **`parameters.docs.description.component` is built from the spec.** The Purpose paragraph is the lead-in; the `## Usage` fenced `vue` block (import + minimal `<script setup>` + `<template>`) is appended verbatim as a code snippet. The same block is the single source of truth for both spec docs and Storybook Docs.
 
 ```js
 // <Name>.stories.js — canonical shape (matches Button.stories.js)
@@ -1545,7 +1543,7 @@ The spec lists which `kind` / `size` stories exist. Do **not** add visual permut
 - [ ] `parameters.actions`, `parameters.a11y`, `parameters.docs.description.*`, `parameters.backgrounds`, `parameters.layout`.
 - [ ] `decorators` when needed.
 - [ ] Stories: `Default` + `Types` (composite, when more than one `kind`) + `Sizes` (composite, when more than one `size`) + `Loading` (only when the component has a `loading` prop) + `Disabled` (only when the component has a `disabled` prop). Nothing else by default — see § 13 for the forbidden list.
-- [ ] `parameters.docs.description.component` built from the spec: Purpose paragraph + the verbatim `## Usage` fenced `vue` code block (import + `<script setup>` + `<template>`). Same shadcn-vue convention used by `Button.stories.js`.
+- [ ] `parameters.docs.description.component` built from the spec: Purpose paragraph + the verbatim `## Usage` fenced `vue` code block (import + `<script setup>` + `<template>`). Same convention used by `Button.stories.js`.
 - [ ] Reusable `Template` at module scope, destructuring event handlers off `args` and forwarding via `@event="handler"` so the Actions panel works.
 
 #### Validação

--- a/.claude/skills/component-scaffold/SKILL.md
+++ b/.claude/skills/component-scaffold/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: component-scaffold
-description: Write the `.vue` file(s) and the local `package.json` for a component, plus the entry in `packages/webkit/package.json#exports`. Strictly spec-bound — every prop/event/slot must come from the spec.
+description: Write the `.vue` file(s) and the local `package.json` for a component, plus the entry in `packages/webkit/package.json#exports`. Strictly spec-bound — every prop/event/slot must come from the spec. For composition pattern, each sub-component lives in its own folder with its own `package.json`.
 status: active
-last_updated: 2026-05-22
+last_updated: 2026-05-27
 ---
 
 # Skill: component-scaffold
@@ -12,12 +12,52 @@ last_updated: 2026-05-22
 Convert an approved `.specs/<name>.md` into:
 
 - `packages/webkit/src/components/webkit/<category>/<name>/<name>.vue` (TypeScript, JSDoc on every public prop).
-- (Composition only) Sibling sub-component `.vue` files in the same directory.
-- (Composition only) `packages/webkit/src/components/webkit/<category>/<name>/injection-key.ts`.
-- `packages/webkit/src/components/webkit/<category>/<name>/package.json`.
-- New entry/entries in `packages/webkit/package.json#exports`.
+- `packages/webkit/src/components/webkit/<category>/<name>/package.json` for the root component.
+- (Composition only) **One folder per sub-component** under the root component directory — `<name>/<name>-<part>/<name>-<part>.vue` plus a sibling `<name>/<name>-<part>/package.json`. The full file name is preserved (`dialog-trigger.vue`, not `index.vue`) so error traces and editor breadcrumbs are unambiguous.
+- (Composition only) `packages/webkit/src/components/webkit/<category>/<name>/injection-key.ts` at the root level (shared by every sub-component).
+- New entry/entries in `packages/webkit/package.json#exports` — one per public component (root + each public sub-component). The public path keeps the short, flat form (`./overlay/dialog-trigger`) regardless of the folder nesting.
 
 Nothing else. The story, the Code Connect file, and the validation pass live in other skills.
+
+**Folder layout — composition pattern (canonical, mirrors shadcn-vue with folder-per-part):**
+
+```
+packages/webkit/src/components/webkit/overlay/dialog/
+├── dialog.vue                          # root
+├── package.json                        # root package
+├── injection-key.ts                    # shared InjectionKey<DialogContext>
+├── dialog-trigger/
+│   ├── dialog-trigger.vue
+│   └── package.json
+├── dialog-portal/
+│   ├── dialog-portal.vue
+│   └── package.json
+├── dialog-overlay/
+│   ├── dialog-overlay.vue
+│   └── package.json
+├── dialog-content/
+│   ├── dialog-content.vue
+│   └── package.json
+├── dialog-title/
+│   ├── dialog-title.vue
+│   └── package.json
+├── dialog-description/
+│   ├── dialog-description.vue
+│   └── package.json
+└── dialog-close/
+    ├── dialog-close.vue
+    └── package.json
+```
+
+**Folder layout — monolithic (unchanged):**
+
+```
+packages/webkit/src/components/webkit/actions/button/
+├── button.vue
+└── package.json
+```
+
+> Existing composition patterns (`dialog`, `drawer`, `navigation-menu`, `dropdown-menu`, `breadcrumb`) still use the legacy flat layout (`dialog-trigger.vue` directly under `dialog/`). Do **not** migrate them as part of a new-component scaffold. The new layout applies only to components scaffolded from a `status: approved` spec going forward.
 
 ## When to invoke
 
@@ -122,13 +162,21 @@ Nothing else. The story, the Code Connect file, and the validation pass live in 
 
    **Never put HTML-like tags in script JSDoc** (e.g. `` `<a>` ``, `<template>`) — Storybook runs two `@vitejs/plugin-vue` passes; the second re-parses compiled JS and fails with the same error. Use plain language ("anchor link") instead.
 
-3. **(Composition only) Write each sub-component.** Each sub-component:
+3. **(Composition only) Write each sub-component into its own folder.** For each sub-component `<name>-<part>` listed in the spec's Sub-components section, create:
+
+   - `packages/webkit/src/components/webkit/<category>/<name>/<name>-<part>/<name>-<part>.vue`
+   - `packages/webkit/src/components/webkit/<category>/<name>/<name>-<part>/package.json`
+
+   Inside the `.vue`:
    - `defineOptions({ name: '<PascalRoot><PascalPart>', inheritAttrs: false })`.
+   - Relative import for the shared injection key: `import { <PascalRoot>InjectionKey } from '../injection-key'` (one directory up — sibling of the root `.vue`).
    - `inject(<PascalRoot>InjectionKey)` to read shared state.
-   - Local `testId` derived from `ctx.testId` per [`bem-testid.md`](../../docs/COMPONENT_REQUIREMENTS.md).
-4. **(Composition only) Write `injection-key.ts`:**
+   - Local `testId` derived from `ctx.testId` per [`bem-testid.md`](../../docs/COMPONENT_REQUIREMENTS.md). The fallback follows BEM: `'<category>-<name>__<part>'` (e.g. `'overlay-dialog__trigger'`).
+
+4. **(Composition only) Write `injection-key.ts`** at the **root** level of the component (sibling of `<name>.vue`, **not** inside any sub-component folder):
 
    ```ts
+   // packages/webkit/src/components/webkit/<category>/<name>/injection-key.ts
    import type { InjectionKey, Ref } from 'vue'
 
    export interface <PascalName>Context {
@@ -140,7 +188,9 @@ Nothing else. The story, the Code Connect file, and the validation pass live in 
    export const <PascalName>InjectionKey: InjectionKey<<PascalName>Context> = Symbol('<PascalName>Context')
    ```
 
-5. **Write `package.json`:**
+   Root `.vue` imports it via `import { <PascalName>InjectionKey, ... } from './injection-key'`. Sub-components import it via `import { <PascalName>InjectionKey, ... } from '../injection-key'`.
+
+5. **Write `package.json`** for the **root** component:
 
    ```json
    {
@@ -153,11 +203,33 @@ Nothing else. The story, the Code Connect file, and the validation pass live in 
    }
    ```
 
-6. **Update `packages/webkit/package.json#exports`** — add one entry per public component (root + each public sub-component) preserving alphabetical order inside the category:
+   **(Composition only) Also write one `package.json` per sub-component folder** (sibling of the sub-component's `.vue`):
+
+   ```json
+   {
+     "name": "@aziontech/webkit-<category>-<name>-<part>",
+     "main": "./<name>-<part>.vue",
+     "module": "./<name>-<part>.vue",
+     "types": "./<name>-<part>.vue.d.ts",
+     "browser": { "./sfc": "./<name>-<part>.vue" },
+     "sideEffects": ["*.vue"]
+   }
+   ```
+
+6. **Update `packages/webkit/package.json#exports`** — add one entry per public component (root + each public sub-component) preserving alphabetical order inside the category. The **public export path stays flat** (`./<category>/<name>-<part>`) so consumers don't see the folder nesting; only the right-hand side changes:
 
    ```json
    "./<category>/<name>": "./src/components/webkit/<category>/<name>/<name>.vue",
-   "./<category>/<name>-trigger": "./src/components/webkit/<category>/<name>/<name>-trigger.vue"
+   "./<category>/<name>-trigger": "./src/components/webkit/<category>/<name>/<name>-trigger/<name>-trigger.vue",
+   "./<category>/<name>-content": "./src/components/webkit/<category>/<name>/<name>-content/<name>-content.vue"
+   ```
+
+   Concrete example for a new `popover` composition component:
+
+   ```json
+   "./overlay/popover": "./src/components/webkit/overlay/popover/popover.vue",
+   "./overlay/popover-trigger": "./src/components/webkit/overlay/popover/popover-trigger/popover-trigger.vue",
+   "./overlay/popover-content": "./src/components/webkit/overlay/popover/popover-content/popover-content.vue"
    ```
 
 7. **Stop.** Do not write the story file. Do not write the `.figma.ts`. Do not run any pnpm command.
@@ -207,10 +279,11 @@ Nothing else. The story, the Code Connect file, and the validation pass live in 
 ## Definition of Done
 
 - [ ] Root `.vue` written with every spec prop/event/slot, no extras.
-- [ ] Composition: every sub-component `.vue` written + `injection-key.ts`.
-- [ ] Local `package.json` written.
-- [ ] New entries added to `packages/webkit/package.json#exports`.
+- [ ] Root `package.json` written.
+- [ ] Composition: every sub-component is **its own folder** under the component root — `<name>/<name>-<part>/<name>-<part>.vue` + `<name>/<name>-<part>/package.json`.
+- [ ] Composition: `injection-key.ts` written at the root level (sibling of `<name>.vue`), not inside any sub-component folder. Root imports it via `./injection-key`; sub-components via `../injection-key`.
+- [ ] New entries added to `packages/webkit/package.json#exports`. Public paths stay flat (`./<category>/<name>-<part>`); right-hand paths reflect the folder nesting.
 - [ ] No HEX / Tailwind palette / raw typography / `any` / `@ts-ignore`.
 - [ ] `defineOptions.name` is PascalCase and matches the directory.
-- [ ] `data-testid` fallback equals `'<category>-<name>'` on the root.
+- [ ] `data-testid` fallback equals `'<category>-<name>'` on the root and `'<category>-<name>__<part>'` on each sub-component.
 - [ ] No story file written, no `.figma.ts` written, no pnpm command run.

--- a/.claude/skills/component-scaffold/SKILL.md
+++ b/.claude/skills/component-scaffold/SKILL.md
@@ -19,7 +19,7 @@ Convert an approved `.specs/<name>.md` into:
 
 Nothing else. The story, the Code Connect file, and the validation pass live in other skills.
 
-**Folder layout — composition pattern (canonical, mirrors shadcn-vue with folder-per-part):**
+**Folder layout — composition pattern (canonical, one folder per part):**
 
 ```
 packages/webkit/src/components/webkit/overlay/dialog/
@@ -173,22 +173,22 @@ packages/webkit/src/components/webkit/actions/button/
    - `inject(<PascalRoot>InjectionKey)` to read shared state.
    - Local `testId` derived from `ctx.testId` per [`bem-testid.md`](../../docs/COMPONENT_REQUIREMENTS.md). The fallback follows BEM: `'<category>-<name>__<part>'` (e.g. `'overlay-dialog__trigger'`).
 
-4. **(Composition only) Write `injection-key.ts`** at the **root** level of the component (sibling of `<name>.vue`, **not** inside any sub-component folder):
+4. **(Composition only) Write `injection-key.ts`** at the **root** level of the component (sibling of `<name>.vue`, **not** inside any sub-component folder). Replace `Dialog` with the PascalCase name of your component:
 
    ```ts
    // packages/webkit/src/components/webkit/<category>/<name>/injection-key.ts
    import type { InjectionKey, Ref } from 'vue'
 
-   export interface <PascalName>Context {
+   export interface DialogContext {
      testId: string
      close: () => void
      isOpen: Readonly<Ref<boolean>>
    }
 
-   export const <PascalName>InjectionKey: InjectionKey<<PascalName>Context> = Symbol('<PascalName>Context')
+   export const DialogInjectionKey: InjectionKey<DialogContext> = Symbol('DialogContext')
    ```
 
-   Root `.vue` imports it via `import { <PascalName>InjectionKey, ... } from './injection-key'`. Sub-components import it via `import { <PascalName>InjectionKey, ... } from '../injection-key'`.
+   Root `.vue` imports it via `import { DialogInjectionKey } from './injection-key'`. Sub-components import it via `import { DialogInjectionKey } from '../injection-key'`.
 
 5. **Write `package.json`** for the **root** component:
 

--- a/.claude/skills/storybook-write/SKILL.md
+++ b/.claude/skills/storybook-write/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: storybook-write
-description: Write a minimal `.stories.js` for a webkit component using the canonical CSF3 template. Only the stories listed in the spec — and the spec is intentionally minimal (Default + per kind + per size + Disabled).
+description: Write a minimal `.stories.js` for a webkit component using the canonical Button.stories.js shape. The spec lists Default + Types + Sizes + Loading + Disabled (only the state stories the component's prop set supports). Inject the spec's `## Usage` block into `parameters.docs.description.component` as a shadcn-vue-style code snippet.
 status: active
-last_updated: 2026-05-22
+last_updated: 2026-05-27
 ---
 
 # Skill: storybook-write
 
 ## Purpose
 
-Generate `apps/storybook/src/stories/webkit/<category>/<PascalName>.stories.js` covering **only** the stories listed in the spec's "Stories (Storybook)" section. The spec is intentionally minimal: Default, one per `kind`, one per `size`, Disabled. Do **not** add LightDark, Accessibility play, Playground, WithSlots, Controlled/Uncontrolled, or anything else unless the spec explicitly lists it. Storybook's autodocs + a11y addon already cover those concerns from the meta.
+Generate `apps/storybook/src/stories/webkit/<category>/<name>/<PascalName>.stories.js` (or `apps/storybook/src/stories/webkit/<category>/<PascalName>.stories.js` for short-form locations) covering **only** the stories listed in the spec's "Stories (Storybook)" section. The canonical shape is the existing `Button.stories.js` — composite `Types` and `Sizes` stories plus state-specific stories (`Loading`, `Disabled`). The spec's `## Usage` block (shadcn-vue style: import + minimal `<script setup>` + `<template>`) is injected verbatim into `parameters.docs.description.component`.
 
 ## When to invoke
 
@@ -20,25 +20,57 @@ Generate `apps/storybook/src/stories/webkit/<category>/<PascalName>.stories.js` 
 - The full text of `.specs/<name>.md`.
 - The Constraints block (verbatim).
 - [`.claude/docs/COMPONENT_REQUIREMENTS.md`](../../docs/COMPONENT_REQUIREMENTS.md), [`.claude/docs/DESIGN.md`](../../docs/DESIGN.md).
+- The reference implementation: [`apps/storybook/src/stories/webkit/actions/button/Button.stories.js`](../../../apps/storybook/src/stories/webkit/actions/button/Button.stories.js).
 
 ## Workflow
 
-1. **Read the spec.** Extract Props, Events, Slots, and the Stories list.
-2. **Write the meta** following this template (substitute spec values):
+1. **Read the spec.** Extract Props, Events, Slots, the Stories list, and the **`## Usage`** fenced code block (everything between the first ` ```vue ` and the next ` ``` ` inside the section; ignore HTML comments).
+2. **Extract the Purpose paragraph** (first paragraph under `## Purpose`). Use it as the prose lead-in for `parameters.docs.description.component`.
+3. **Build `parameters.docs.description.component`** as a single markdown string concatenating:
+   - The Purpose paragraph (one line).
+   - A blank line.
+   - The literal heading `## Usage` followed by a blank line, then the `vue` fenced code block from the spec.
+
+   Example (string literal — note the embedded newlines and the four-backtick fence to escape the inner triple-backtick block):
+
+   ````js
+   docs: {
+     description: {
+       component: [
+         'Interactive control for user actions. Supports label text, optional icon, loading state, and link rendering when `href` is set.',
+         '',
+         '## Usage',
+         '',
+         '```vue',
+         "<script setup>",
+         "import Button from '@aziontech/webkit/actions/button'",
+         '</script>',
+         '',
+         '<template>',
+         '  <Button label="Click me" />',
+         '</template>',
+         '```'
+       ].join('\n')
+     }
+   }
+   ````
+
+   Storybook's Docs page renders this markdown as a fenced code block under a `Usage` heading — the shadcn-vue convention. The same `Usage` block is the source of truth for both spec and Docs; never copy-paste it elsewhere in the story file.
+
+4. **Write the meta** following this template (substitute spec values):
 
    ```js
-   import Component from '@aziontech/webkit/<category>/<name>'
-   import { expect, userEvent, within } from '@storybook/test'
+   import <Component> from '@aziontech/webkit/<category>/<name>'
 
-   /** @type {import('@storybook/vue3').Meta<typeof Component>} */
+   /** @type {import('@storybook/vue3').Meta<typeof <Component>>} */
    const meta = {
      title: 'Webkit/<Category>/<PascalName>',
-     component: Component,
+     component: <Component>,
      // For Composition Pattern, expose subcomponents:
      // subcomponents: { <Root>Trigger, <Root>Content, ... },
      tags: ['autodocs'],
      parameters: {
-       layout: 'padded',
+       layout: 'centered',
        backgrounds: { default: 'dark' },
        a11y: {
          config: {
@@ -50,7 +82,7 @@ Generate `apps/storybook/src/stories/webkit/<category>/<PascalName>.stories.js` 
        },
        docs: {
          description: {
-           component: '<one paragraph from spec.Purpose>'
+           component: /* the multi-line string built in step 3 */
          }
        }
      },
@@ -64,47 +96,110 @@ Generate `apps/storybook/src/stories/webkit/<category>/<PascalName>.stories.js` 
    export default meta
    ```
 
-3. **Build `argTypes`.** For each row:
+   - `layout: 'centered'` is the canonical choice — same as `Button.stories.js`. Override to `'padded'` only when the component is full-width (header, sidebar, drawer).
+
+5. **Build `argTypes`.** For each row:
    - **Props row.** `<name>: { control, options?, description, table: { type, defaultValue, category: 'props' } }`. Use `select` for union-literal types, `boolean` for booleans, `text` for strings, `number` for numbers.
    - **Events row.** Key is camelCase `on<EventName>` (e.g. `onClick`, `'onUpdate:open'`). Value is `{ action: '<emitted-name>', description, table: { type, category: 'events' } }`. **The key MUST be camelCase** — kebab-case keys silently fail in Vue 3.
    - **Slots row.** Key is the slot name. Value is `{ control: false, description, table: { type, category: 'slots' } }`.
 
-4. **Write the reusable render at module scope:**
+6. **Write the reusable render at module scope** — destructure event handlers off `args` so the `Template`-driven stories forward them via `@event` listeners:
 
    ```js
    const Template = (args) => ({
-     components: { Component },
-     setup() { return { args } },
-     template: '<Component v-bind="args" />'
+     components: { <Component> },
+     setup() {
+       const { onClick, ...props } = args
+       return { props, onClick }
+     },
+     template: '<<Component> v-bind="props" @click="onClick" />'
    })
    ```
 
-5. **Write one story per item** in `spec.Stories`. **Do not** add stories that aren't in the spec. The spec is minimal on purpose; respect it. For each, emit:
+   - If the spec declares more than one event, destructure each one (`onClick`, `'onUpdate:open': onUpdateOpen`, …) and forward via the matching `@event="handler"` in the template.
+
+7. **Write one story per item** in `spec.Stories`. The spec lists only the canonical set; do **not** add extras. For each, emit one of the two shapes:
+
+   **Shape A — uses the reusable `Template` with an args delta (Default, Loading, Disabled):**
 
    ```js
-   /** @type {import('@storybook/vue3').StoryObj<typeof Component>} */
-   export const <PascalName> = {
-     args: { /* delta from meta.args */ },
+   /** @type {import('@storybook/vue3').StoryObj<typeof <Component>>} */
+   export const Default = {
      render: Template,
      parameters: {
-       docs: { description: { story: '<one sentence describing this story>' } }
+       docs: { description: { story: 'Default primary button at large size.' } }
+     }
+   }
+
+   export const Loading = {
+     args: { loading: true, label: 'Button' },
+     render: Template,
+     parameters: {
+       docs: { description: { story: 'Loading state with spinner replacing the icon.' } }
+     }
+   }
+
+   export const Disabled = {
+     args: { disabled: true, label: 'Button' },
+     render: Template,
+     parameters: {
+       docs: { description: { story: 'Disabled state.' } }
      }
    }
    ```
 
-   - Allowed: `Default`, one per `kind`, one per `size`, `Disabled`.
-   - **Forbidden unless explicitly listed in the spec**: `LightDark`, `Accessibility` (with play), `Playground`, `WithSlots`, `WithComposition`, `Controlled`, `Uncontrolled`, `Loading`. Storybook's `autodocs` + `a11y` addon + `backgrounds` already cover dark/light, axe checks, and consumer-driven exploration via Controls. Adding bespoke stories for those is duplication.
+   **Shape B — composite story with inline template (Types, Sizes):**
+
+   ```js
+   export const Types = {
+     render: () => ({
+       components: { <Component> },
+       template: `
+         <div class="flex flex-wrap items-center gap-4">
+           <<Component> kind="primary" label="Button" />
+           <<Component> kind="secondary" label="Button" />
+           <<Component> kind="outlined" label="Button" />
+           <<Component> kind="text" label="Button" />
+         </div>
+       `
+     }),
+     parameters: {
+       docs: { description: { story: 'All kind variants side by side.' } }
+     }
+   }
+
+   export const Sizes = {
+     render: () => ({
+       components: { <Component> },
+       template: `
+         <div class="flex flex-wrap items-center gap-4">
+           <<Component> size="small" label="Button" />
+           <<Component> size="medium" label="Button" />
+           <<Component> size="large" label="Button" />
+         </div>
+       `
+     }),
+     parameters: {
+       docs: { description: { story: 'All size variants side by side.' } }
+     }
+   }
+   ```
+
+   - **Allowed:** `Default`, `Types`, `Sizes`, `Loading`, `Disabled`.
+   - **Skip** any story whose backing prop is not in `spec.Props` (e.g. no `loading` prop → no `Loading` story).
+   - **Forbidden unless explicitly listed in the spec:** `LightDark`, `Accessibility` (with play), `Playground`, `WithSlots`, `WithComposition`, `Controlled`, `Uncontrolled`, one-story-per-variant (`Primary`, `Secondary`, …). Storybook's `autodocs` + `a11y` addon + `backgrounds` already cover dark/light, axe checks, and consumer-driven exploration via Controls.
 
 ## Outputs
 
-- One file: `apps/storybook/src/stories/webkit/<category>/<PascalName>.stories.js`.
+- One file: `apps/storybook/src/stories/webkit/<category>/<PascalName>.stories.js` (mirror the component's actual storybook location — some components live under `webkit/<category>/<name>/`, others directly under `webkit/<category>/`).
 - Nothing else.
 
 ## Rules
 
 - **No HEX / Tailwind palette / raw typography** in story templates (some stories embed markup for slots).
-- **No Figma references.** Do NOT add `parameters.design`, `parameters.figma`, links to Figma frames in `docs.description.component`/`docs.description.story`, or imports from `@storybook/addon-designs` / `storybook-addon-designs`. The Figma link is owned by `<name>.figma.ts` (Code Connect), not the story. Full rationale: [`.claude/docs/COMPONENT_REQUIREMENTS.md`](../../docs/COMPONENT_REQUIREMENTS.md).
-- **`docs.description.component` is one short paragraph** about the component API and when to use it. No marketing copy, no design history, no Figma URLs.
+- **No Figma references.** Do NOT add `parameters.design`, `parameters.figma`, links to Figma frames in `docs.description.component` / `docs.description.story`, or imports from `@storybook/addon-designs` / `storybook-addon-designs`. The Figma link is owned by `<name>.figma.ts` (Code Connect), not the story. Full rationale: [`.claude/docs/COMPONENT_REQUIREMENTS.md`](../../docs/COMPONENT_REQUIREMENTS.md).
+- **`docs.description.component` is built from the spec.** The leading prose comes from `## Purpose`; the trailing `## Usage` heading + fenced code block comes verbatim from `## Usage`. No marketing copy, no design history, no Figma URLs, no hand-edited usage examples.
+- **Do not duplicate the Usage snippet.** It lives in `parameters.docs.description.component` and nowhere else in the story file. Do not paste it into a story `description.story`, JSDoc, or comment.
 - **Events keys are camelCase `on<EventName>`** in `argTypes`. Kebab-case keys silently break the Actions panel.
 - **Do NOT use** `parameters.actions.argTypesRegex` (deprecated in Storybook 8). Declare each event explicitly.
 - **Do NOT use** the legacy `Name.args = {...}` form. Always object-style CSF3.
@@ -112,19 +207,25 @@ Generate `apps/storybook/src/stories/webkit/<category>/<PascalName>.stories.js` 
 - **`control: false`** for slots and any uncontrollable arg.
 - **`tags: ['autodocs']`** on meta to generate the Docs page.
 - **`subcomponents`** when Composition Pattern.
+- **`layout: 'centered'`** unless the component is full-width.
 
 ## Fallbacks
 
-- `@storybook/test` not installed → omit the `play` function in the Accessibility story; record a pending item in the report.
+- Spec has no `## Usage` block (legacy spec being migrated) → emit `BLOCKED: spec missing ## Usage block` and stop. Do not invent a usage snippet.
 - Spec.Stories lists a story name the skill does not recognize → emit it with `args: {}` and a `// TODO: define this story` comment.
+- Spec lists `Types` but the component has only one `kind` (or `Sizes` with one `size`) → omit that story silently; record the divergence in the report.
 
 ## Definition of Done
 
 - [ ] One `.stories.js` written at the canonical path.
-- [ ] Meta has `title`, `component`, `tags: ['autodocs']`, `parameters` (`layout`, `backgrounds`, `a11y`, `docs`), `argTypes`, `args`.
+- [ ] Meta has `title`, `component`, `tags: ['autodocs']`, `parameters` (`layout: 'centered'`, `backgrounds`, `a11y`, `docs`), `argTypes`, `args`.
+- [ ] `parameters.docs.description.component` contains the Purpose paragraph **and** the `## Usage` heading + the `vue` fenced code block lifted verbatim from the spec.
 - [ ] Every prop, event, and slot from the spec has an `argTypes` entry.
-- [ ] Reusable `Template` declared once at module scope.
+- [ ] Reusable `Template` declared once at module scope, destructuring event handlers off `args`.
 - [ ] Every story from spec.Stories is exported in CSF3 object form — and nothing beyond that list is exported.
+- [ ] Composite `Types` / `Sizes` stories use inline templates with side-by-side markup; state stories (`Loading`, `Disabled`) use the reusable `Template` with an args delta.
 - [ ] No bespoke `LightDark` / `Accessibility (play)` / `Playground` / `WithSlots` / `Controlled` stories unless the spec explicitly listed them.
+- [ ] No one-story-per-variant (`Primary`, `Secondary`, …) — `Types` is the canonical replacement.
 - [ ] No `argTypesRegex`, no legacy `.args =` form.
 - [ ] No `parameters.design` / `parameters.figma`, no Figma URLs anywhere in the file, no `@storybook/addon-designs` import.
+- [ ] The `## Usage` snippet appears in exactly one place in the file (inside `docs.description.component`).

--- a/.claude/skills/storybook-write/SKILL.md
+++ b/.claude/skills/storybook-write/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: storybook-write
-description: Write a minimal `.stories.js` for a webkit component using the canonical Button.stories.js shape. The spec lists Default + Types + Sizes + Loading + Disabled (only the state stories the component's prop set supports). Inject the spec's `## Usage` block into `parameters.docs.description.component` as a shadcn-vue-style code snippet.
+description: Write a minimal `.stories.js` for a webkit component using the canonical Button.stories.js shape. The spec lists Default + Types + Sizes + Loading + Disabled (only the state stories the component's prop set supports). Inject the spec's `## Usage` block into `parameters.docs.description.component` as a code snippet.
 status: active
 last_updated: 2026-05-27
 ---
@@ -9,7 +9,7 @@ last_updated: 2026-05-27
 
 ## Purpose
 
-Generate `apps/storybook/src/stories/webkit/<category>/<name>/<PascalName>.stories.js` (or `apps/storybook/src/stories/webkit/<category>/<PascalName>.stories.js` for short-form locations) covering **only** the stories listed in the spec's "Stories (Storybook)" section. The canonical shape is the existing `Button.stories.js` — composite `Types` and `Sizes` stories plus state-specific stories (`Loading`, `Disabled`). The spec's `## Usage` block (shadcn-vue style: import + minimal `<script setup>` + `<template>`) is injected verbatim into `parameters.docs.description.component`.
+Generate `apps/storybook/src/stories/webkit/<category>/<name>/<PascalName>.stories.js` (or `apps/storybook/src/stories/webkit/<category>/<PascalName>.stories.js` for short-form locations) covering **only** the stories listed in the spec's "Stories (Storybook)" section. The canonical shape is the existing `Button.stories.js` — composite `Types` and `Sizes` stories plus state-specific stories (`Loading`, `Disabled`). The spec's `## Usage` block (import + minimal `<script setup>` + `<template>`) is injected verbatim into `parameters.docs.description.component`.
 
 ## When to invoke
 
@@ -55,7 +55,7 @@ Generate `apps/storybook/src/stories/webkit/<category>/<name>/<PascalName>.stori
    }
    ````
 
-   Storybook's Docs page renders this markdown as a fenced code block under a `Usage` heading — the shadcn-vue convention. The same `Usage` block is the source of truth for both spec and Docs; never copy-paste it elsewhere in the story file.
+   Storybook's Docs page renders this markdown as a fenced code block under a `Usage` heading. The same `Usage` block is the source of truth for both spec and Docs; never copy-paste it elsewhere in the story file.
 
 4. **Write the meta** following this template (substitute spec values):
 

--- a/.claude/skills/storybook-write/SKILL.md
+++ b/.claude/skills/storybook-write/SKILL.md
@@ -60,12 +60,12 @@ Generate `apps/storybook/src/stories/webkit/<category>/<name>/<PascalName>.stori
 4. **Write the meta** following this template (substitute spec values):
 
    ```js
-   import <Component> from '@aziontech/webkit/<category>/<name>'
+   import Component from '@aziontech/webkit/<category>/<name>'
 
-   /** @type {import('@storybook/vue3').Meta<typeof <Component>>} */
+   /** @type {import('@storybook/vue3').Meta<typeof Component>} */
    const meta = {
      title: 'Webkit/<Category>/<PascalName>',
-     component: <Component>,
+     component: Component,
      // For Composition Pattern, expose subcomponents:
      // subcomponents: { <Root>Trigger, <Root>Content, ... },
      tags: ['autodocs'],
@@ -107,12 +107,12 @@ Generate `apps/storybook/src/stories/webkit/<category>/<name>/<PascalName>.stori
 
    ```js
    const Template = (args) => ({
-     components: { <Component> },
+     components: { Component },
      setup() {
        const { onClick, ...props } = args
        return { props, onClick }
      },
-     template: '<<Component> v-bind="props" @click="onClick" />'
+     template: '<Component v-bind="props" @click="onClick" />'
    })
    ```
 
@@ -123,7 +123,7 @@ Generate `apps/storybook/src/stories/webkit/<category>/<name>/<PascalName>.stori
    **Shape A — uses the reusable `Template` with an args delta (Default, Loading, Disabled):**
 
    ```js
-   /** @type {import('@storybook/vue3').StoryObj<typeof <Component>>} */
+   /** @type {import('@storybook/vue3').StoryObj<typeof Component>} */
    export const Default = {
      render: Template,
      parameters: {
@@ -153,13 +153,13 @@ Generate `apps/storybook/src/stories/webkit/<category>/<name>/<PascalName>.stori
    ```js
    export const Types = {
      render: () => ({
-       components: { <Component> },
+       components: { Component },
        template: `
          <div class="flex flex-wrap items-center gap-4">
-           <<Component> kind="primary" label="Button" />
-           <<Component> kind="secondary" label="Button" />
-           <<Component> kind="outlined" label="Button" />
-           <<Component> kind="text" label="Button" />
+           <Component kind="primary" label="Button" />
+           <Component kind="secondary" label="Button" />
+           <Component kind="outlined" label="Button" />
+           <Component kind="text" label="Button" />
          </div>
        `
      }),
@@ -170,12 +170,12 @@ Generate `apps/storybook/src/stories/webkit/<category>/<name>/<PascalName>.stori
 
    export const Sizes = {
      render: () => ({
-       components: { <Component> },
+       components: { Component },
        template: `
          <div class="flex flex-wrap items-center gap-4">
-           <<Component> size="small" label="Button" />
-           <<Component> size="medium" label="Button" />
-           <<Component> size="large" label="Button" />
+           <Component size="small" label="Button" />
+           <Component size="medium" label="Button" />
+           <Component size="large" label="Button" />
          </div>
        `
      }),

--- a/.specs/_examples/tooltip.md
+++ b/.specs/_examples/tooltip.md
@@ -19,6 +19,21 @@ last_updated: 2026-05-22
 
 Surfaces a short hint anchored to a trigger element when the user hovers, focuses, or long-presses it. Use for icon-only buttons, abbreviations, or any control whose meaning is not obvious from its label alone. **Not** for rich content or interactive children — use `overlay/popover` instead.
 
+## Usage
+
+```vue
+<script setup>
+import Tooltip from '@aziontech/webkit/feedback/tooltip'
+import IconButton from '@aziontech/webkit/actions/icon-button'
+</script>
+
+<template>
+  <Tooltip text="Delete" placement="top">
+    <IconButton icon="pi pi-trash" aria-label="Delete" />
+  </Tooltip>
+</template>
+```
+
 ## Props
 
 | Prop | Type | Default | Required | JSDoc |
@@ -90,8 +105,10 @@ Surfaces a short hint anchored to a trigger element when the user hovers, focuse
 
 ## Stories (Storybook)
 
+Canonical layout. Tooltip has no `kind` and no `size`, but it has a `placement` axis — we treat `Placements` as the composite story (one frame, all four placements side-by-side), mirroring how Button uses `Types`/`Sizes`.
+
 - Default — tooltip rendered **closed**; viewer hovers/focuses the trigger to see it open.
-- One per `placement` (top/right/bottom/left) — each renders **closed** by default; only the placement target differs.
+- Placements — composite story with all four placements (top/right/bottom/left) side-by-side; each instance defaults to **closed**.
 - Disabled — trigger present, tooltip activation no-op.
 
 ## Constraints — DO NOT
@@ -106,7 +123,8 @@ Surfaces a short hint anchored to a trigger element when the user hovers, focuse
 - Do not inherit artifacts as-is from another design system, Figma file, library, or pre-existing `CONTRACT.md` / `README.md`. Rewrite to our conventions. See `.claude/rules/migration.md`.
 - Do not add Figma references to Storybook stories. No `parameters.design`, no `parameters.figma`, no Figma URLs in `docs.description.*`, no `@storybook/addon-designs` import. The Figma link is owned by `<name>.figma.ts` (Code Connect). See `.claude/docs/COMPONENT_REQUIREMENTS.md`.
 - Do not use `parameters.actions.argTypesRegex` (deprecated in Storybook 8 and silently misroutes Vue 3 emits) or `parameters.actions.handles` (DOM-only). Declare every event explicitly in `argTypes` with a camelCase `on<Event>` key and `{ action: '<emitted-name>' }`. Do not use the legacy CSF2 `Name.args = {...}` form — always object-style CSF3.
-- Do not add bespoke Storybook stories beyond Default + per `kind` + per `size` + Disabled, unless the spec's "Stories (Storybook)" section explicitly justifies the addition.
+- Do not add bespoke Storybook stories beyond Default + Types + Sizes + state stories (`Loading`, `Disabled`) for the props the component actually declares, unless the spec's "Stories (Storybook)" section explicitly justifies the addition. Do not split Types/Sizes into one-story-per-variant — the composite stories are the canonical pattern.
+- Do not duplicate the `## Usage` block from the spec inside the Storybook story body. The block is injected once into `parameters.docs.description.component` by the storybook-write skill; copy it nowhere else.
 - Do not edit `.claude/docs/DESIGN.md`, `.claude/docs/COMPONENT_REQUIREMENTS.md`, or `.claude/docs/PRIMEVUE_ABSTRACTION.md`.
 - Do not edit the root `package.json` or `.github/workflows/*`.
 - Do not change `structure` after `status: approved`. To change structure, bump `spec_version` and re-author the spec.

--- a/.specs/_template.md
+++ b/.specs/_template.md
@@ -20,7 +20,7 @@ last_updated: <YYYY-MM-DD>
 
 ## Usage
 
-<!-- shadcn-vue-style snippet. ONE fenced ```vue block with:
+<!-- ONE fenced ```vue block with:
        • the canonical import path from packages/webkit/package.json#exports
        • a minimal <script setup> that imports the component
        • a minimal <template> showing the public API
@@ -34,11 +34,11 @@ last_updated: <YYYY-MM-DD>
 
 ```vue
 <script setup>
-import <Name> from '@aziontech/webkit/<category>/<name>'
+import MyComponent from '@aziontech/webkit/<category>/<name>'
 </script>
 
 <template>
-  <<Name> label="Click me" />
+  <MyComponent label="Click me" />
 </template>
 ```
 
@@ -70,7 +70,7 @@ import DialogClose from '@aziontech/webkit/overlay/dialog-close'
 ## Sub-components
 
 <!-- Omit this section when structure: monolithic. -->
-<!-- For structure: composition, list every public sub-component AND the folder layout the scaffolder must emit. Each sub-component lives in its own folder under the root component, mirroring the shadcn-vue convention with a folder per part. The file name keeps the full prefix (e.g. `dialog-trigger.vue`, never `index.vue`) so traces and editor breadcrumbs stay unambiguous. -->
+<!-- For structure: composition, list every public sub-component AND the folder layout the scaffolder must emit. Each sub-component lives in its own folder under the root component, one folder per part. The file name keeps the full prefix (e.g. `dialog-trigger.vue`, never `index.vue`) so traces and editor breadcrumbs stay unambiguous. -->
 
 - `<name>-trigger/<name>-trigger.vue` — purpose
 - `<name>-portal/<name>-portal.vue` — purpose

--- a/.specs/_template.md
+++ b/.specs/_template.md
@@ -18,16 +18,85 @@ last_updated: <YYYY-MM-DD>
 
 <1–3 sentences. What the component is, when to use it, what makes it different from siblings in the same category.>
 
+## Usage
+
+<!-- shadcn-vue-style snippet. ONE fenced ```vue block with:
+       • the canonical import path from packages/webkit/package.json#exports
+       • a minimal <script setup> that imports the component
+       • a minimal <template> showing the public API
+     For structure: composition, the template MUST render the full anatomy
+     (every sub-component listed in the Sub-components section, in the order
+     the consumer would compose them). For structure: monolithic, render the
+     root with the most representative props.
+     This block is injected verbatim into the Storybook
+     parameters.docs.description.component by the storybook-write skill;
+     do NOT also paste it into the Storybook story by hand. -->
+
+```vue
+<script setup>
+import <Name> from '@aziontech/webkit/<category>/<name>'
+</script>
+
+<template>
+  <<Name> label="Click me" />
+</template>
+```
+
+<!-- Composition example (structure: composition):
+
+```vue
+<script setup>
+import Dialog from '@aziontech/webkit/overlay/dialog'
+import DialogTrigger from '@aziontech/webkit/overlay/dialog-trigger'
+import DialogContent from '@aziontech/webkit/overlay/dialog-content'
+import DialogTitle from '@aziontech/webkit/overlay/dialog-title'
+import DialogDescription from '@aziontech/webkit/overlay/dialog-description'
+import DialogClose from '@aziontech/webkit/overlay/dialog-close'
+</script>
+
+<template>
+  <Dialog>
+    <DialogTrigger>Open</DialogTrigger>
+    <DialogContent>
+      <DialogTitle>Confirm action</DialogTitle>
+      <DialogDescription>This cannot be undone.</DialogDescription>
+      <DialogClose>Cancel</DialogClose>
+    </DialogContent>
+  </Dialog>
+</template>
+```
+-->
+
 ## Sub-components
 
 <!-- Omit this section when structure: monolithic. -->
-<!-- For structure: composition, list every public sub-component. -->
+<!-- For structure: composition, list every public sub-component AND the folder layout the scaffolder must emit. Each sub-component lives in its own folder under the root component, mirroring the shadcn-vue convention with a folder per part. The file name keeps the full prefix (e.g. `dialog-trigger.vue`, never `index.vue`) so traces and editor breadcrumbs stay unambiguous. -->
 
-- `<name>-trigger.vue` — purpose
-- `<name>-content.vue` — purpose
-- `<name>-title.vue` — purpose
-- `<name>-description.vue` — purpose
-- `<name>-close.vue` — purpose
+- `<name>-trigger/<name>-trigger.vue` — purpose
+- `<name>-portal/<name>-portal.vue` — purpose
+- `<name>-overlay/<name>-overlay.vue` — purpose
+- `<name>-content/<name>-content.vue` — purpose
+- `<name>-title/<name>-title.vue` — purpose
+- `<name>-description/<name>-description.vue` — purpose
+- `<name>-close/<name>-close.vue` — purpose
+
+<!-- Resulting layout (composition, canonical):
+
+  packages/webkit/src/components/webkit/<category>/<name>/
+  ├── <name>.vue
+  ├── package.json
+  ├── injection-key.ts            (shared by every sub-component; one directory up from each sub-component)
+  ├── <name>-trigger/
+  │   ├── <name>-trigger.vue
+  │   └── package.json
+  ├── <name>-content/
+  │   ├── <name>-content.vue
+  │   └── package.json
+  └── ...
+
+  Public exports in packages/webkit/package.json#exports stay flat
+  (`./<category>/<name>-trigger`) regardless of the folder nesting. -->
+
 
 ## Props
 
@@ -118,18 +187,19 @@ last_updated: <YYYY-MM-DD>
 
 ## Stories (Storybook)
 
-Keep it minimal. Default lists only the essentials. Add a story only if the variant is genuinely distinct in behavior.
+Canonical layout — matches `apps/storybook/src/stories/webkit/actions/button/Button.stories.js`. Composite stories (`Types`, `Sizes`) render every variant side-by-side in a single frame; state stories use the reusable `Template` with an args delta.
 
 - Default
-- One per `kind` (when the component has more than one)
-- One per `size` (when the component has more than one)
-- Disabled (when the component has a `disabled` prop)
+- Types — composite story rendering every `kind` value side-by-side. Omit when the component has only one `kind`.
+- Sizes — composite story rendering every `size` value side-by-side. Omit when the component has only one `size`.
+- Loading — only when the component has a `loading` prop.
+- Disabled — only when the component has a `disabled` prop.
 
 <!-- Rules:
-     - DO NOT add LightDark, Accessibility play, Playground, WithSlots, WithComposition, Controlled, Uncontrolled, Loading unless the spec explicitly justifies them in writing here.
+     - DO NOT add LightDark, Accessibility (with play), Playground, WithSlots, WithComposition, Controlled, Uncontrolled stories unless the spec explicitly justifies them in writing here.
      - Storybook addons (a11y, docs autodocs, backgrounds) cover the rest automatically without a dedicated story.
-     - If `kind` has only one value, omit the per-kind story (the Default already covers it).
-     - Same for `size`. -->
+     - For each additional state story (Loading/Disabled), the args delta is the prop being demonstrated — nothing else.
+     - Do NOT replace Types/Sizes with one-story-per-variant (Primary/Secondary/...). The composite stories are the canonical pattern. -->
 
 
 ## Constraints — DO NOT
@@ -147,7 +217,8 @@ Keep it minimal. Default lists only the essentials. Add a story only if the vari
 - Do not inherit artifacts as-is from another design system, Figma file, library, or pre-existing `CONTRACT.md` / `README.md`. Rewrite to our conventions. See `.claude/rules/migration.md`.
 - Do not add Figma references to Storybook stories. No `parameters.design`, no `parameters.figma`, no Figma URLs in `docs.description.*`, no `@storybook/addon-designs` import. The Figma link is owned by `<name>.figma.ts` (Code Connect). See `.claude/docs/COMPONENT_REQUIREMENTS.md`.
 - Do not use `parameters.actions.argTypesRegex` (deprecated in Storybook 8 and silently misroutes Vue 3 emits) or `parameters.actions.handles` (DOM-only). Declare every event explicitly in `argTypes` with a camelCase `on<Event>` key and `{ action: '<emitted-name>' }`. Do not use the legacy CSF2 `Name.args = {...}` form — always object-style CSF3.
-- Do not add bespoke Storybook stories beyond Default + per `kind` + per `size` + Disabled, unless the spec's "Stories (Storybook)" section explicitly justifies the addition.
+- Do not add bespoke Storybook stories beyond Default + Types + Sizes + state stories (`Loading`, `Disabled`) for the props the component actually declares, unless the spec's "Stories (Storybook)" section explicitly justifies the addition. Do not split Types/Sizes into one-story-per-variant — the composite stories are the canonical pattern.
+- Do not duplicate the `## Usage` block from the spec inside the Storybook story body. The block is injected once into `parameters.docs.description.component` by the storybook-write skill; copy it nowhere else.
 - Do not edit `.claude/docs/DESIGN.md`, `.claude/docs/COMPONENT_REQUIREMENTS.md`, or `.claude/docs/PRIMEVUE_ABSTRACTION.md`.
 - Do not edit the root `package.json` or `.github/workflows/*`.
 - Do not change `structure` after `status: approved`. To change structure, bump `spec_version` and re-author the spec.


### PR DESCRIPTION
## Summary

Improves the spec-driven component pipeline in two areas — neither touches existing components.

### 1. Stories pattern aligned with `Button.stories.js`

- Spec template gains a **`## Usage`** section (shadcn-vue style: import + minimal `<script setup>` + `<template>`). The `storybook-write` skill injects this block verbatim into `parameters.docs.description.component`, so the Storybook Docs page shows a code snippet under a `Usage` heading.
- Canonical stories set is now **`Default + Types + Sizes + Loading + Disabled`** — composite `Types`/`Sizes` (every variant side-by-side in one frame) instead of one-story-per-variant. Matches [`apps/storybook/src/stories/webkit/actions/button/Button.stories.js`](apps/storybook/src/stories/webkit/actions/button/Button.stories.js).
- The reusable `Template` destructures event handlers off `args` and forwards them via `@event="handler"` so the Actions panel works.
- Files: [.specs/_template.md](.specs/_template.md), [.claude/skills/storybook-write/SKILL.md](.claude/skills/storybook-write/SKILL.md), [.specs/_examples/tooltip.md](.specs/_examples/tooltip.md), [.claude/docs/COMPONENT_REQUIREMENTS.md](.claude/docs/COMPONENT_REQUIREMENTS.md) § 13 + final checklist.

### 2. Composition pattern: folder per sub-component

- New composition components scaffold one folder per sub-component — `<root>/<root>-<part>/<root>-<part>.vue` + a sibling `package.json` for each. Shared `injection-key.ts` stays at the component root (root imports `./injection-key`, sub-components import `../injection-key`).
- **Public exports stay flat** in `packages/webkit/package.json#exports` (`./overlay/dialog-trigger` → `./src/.../dialog/dialog-trigger/dialog-trigger.vue`). Consumers see no path change.
- Files: [.specs/_template.md](.specs/_template.md) Sub-components, [.claude/skills/component-scaffold/SKILL.md](.claude/skills/component-scaffold/SKILL.md), [.claude/docs/COMPONENT_REQUIREMENTS.md](.claude/docs/COMPONENT_REQUIREMENTS.md) § 2.9 + § 3 + checklist.

### Scope explicitly **not** included

- Existing composition components (`dialog`, `drawer`, `navigation-menu`, `dropdown-menu`, `breadcrumb`) keep the legacy **flat** layout. Migration would require moving files and rewriting every consumer import path in `console-kit` — out of scope here. Documented as such in § 2.9.
- `.specs/button.md` is `status: implemented` with a checksum; not touched, since `Button.stories.js` already matches the new canonical shape in practice.

## Test plan

- [ ] Run `/spec-create <new-component>` and confirm the generated draft has both `## Usage` and the new Stories layout.
- [ ] Run `/component-create <new-monolithic>` end-to-end and confirm the emitted `.stories.js` has `Default + Types + Sizes + Loading + Disabled` and `parameters.docs.description.component` contains the Purpose paragraph + the `## Usage` fenced block.
- [ ] Run `/component-create <new-composition>` and confirm: folder-per-sub-component layout on disk, `injection-key.ts` at the root, one `package.json` per sub-component folder, and flat public paths in `packages/webkit/package.json#exports`.
- [ ] `pnpm storybook:build` passes and the Docs page renders the Usage code block as a fenced code snippet under a `Usage` heading.
- [ ] `validate-spec-compliance` still passes on the existing components (no regression in flat composition components).