### PR TITLE
fix: remove passthrough forwarding

### DIFF
--- a/packages/webkit/src/components/actions/icon-button/icon-button.vue
+++ b/packages/webkit/src/components/actions/icon-button/icon-button.vue
@@ -46,15 +46,6 @@
 
   const attrs = useAttrs()
 
-  const passthroughAttrs = computed(() => {
-    const rest = { ...attrs }
-
-    delete rest.class
-    delete rest['data-testid']
-
-    return rest
-  })
-
   const testId = computed(
     () => (attrs['data-testid'] as string | undefined) ?? 'action-icon-button'
   )
@@ -131,7 +122,6 @@
 <template>
   <a
     v-if="isAnchor"
-    v-bind="passthroughAttrs"
     :href="href"
     :target="target"
     :rel="target === '_blank' ? 'noopener noreferrer' : undefined"
@@ -161,7 +151,6 @@
 
   <button
     v-else
-    v-bind="passthroughAttrs"
     type="button"
     :disabled="disabled"
     :aria-label="ariaLabel"


### PR DESCRIPTION
## Summary
- remove generic passthrough attribute forwarding from `icon-button` root elements
- keep explicit API behavior intact while preserving `class` merge and `data-testid` override support
- reduce unintended attribute surface on both anchor and button render paths

## Test plan
- [ ] pnpm webkit:lint
- [ ] pnpm webkit:type-check
- [ ] pnpm webkit:type-coverage
- [ ] pnpm webkit:build:dts
- [ ] pnpm storybook:build

Made with [Cursor](https://cursor.com)