### PR TITLE
refactor: migrate  currency to typed model and simplify visibility logic

### DIFF
--- a/.specs/currency.md
+++ b/.specs/currency.md
@@ -4,9 +4,9 @@ category: content
 structure: monolithic
 status: implemented
 spec_version: 1
-checksum: 4ac5cb3f4b44bf426f50194452747807a15f10aa40560e29aa5d4d3a5a893180
+checksum: 0e0907d6d09e7ec2e866ef8704cf2db9bd3c87477cc2a7f07612465ee7747fb0
 created: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-05-27
 ---
 # Currency — Component Spec
 
@@ -20,9 +20,7 @@ Displays content or metadata in the UI. Migrated from the existing implementatio
 |---|---|---|---|---|
 | `value` | `string` | `''` | no | value. |
 | `prefix` | `string` | `'$'` | no | prefix. |
-| `suffix` | `string` | `'per month'` | no | suffix. |
-| `showPrefix` | `boolean` | `true` | no | show Prefix. |
-| `showSuffix` | `boolean` | `true` | no | show Suffix. |
+| `suffix` | `string` | `''` | no | suffix. |
 | `size` | `'small' | 'large'` | `'small'` | no | Size token; affects height, padding, and typography. |
 
 ## Events

--- a/apps/storybook/src/stories/webkit/content/currency/Currency.stories.js
+++ b/apps/storybook/src/stories/webkit/content/currency/Currency.stories.js
@@ -25,14 +25,6 @@ export default {
       control: 'text',
       description: 'Secondary label after the value (e.g. billing period)'
     },
-    showPrefix: {
-      control: 'boolean',
-      description: 'Whether the prefix symbol is visible'
-    },
-    showSuffix: {
-      control: 'boolean',
-      description: 'Whether the suffix label is visible'
-    },
     size: {
       control: 'select',
       options: sizes,
@@ -46,9 +38,7 @@ export const Default = {
     value: '20',
     prefix: '$',
     suffix: 'per month',
-    size: 'small',
-    showPrefix: true,
-    showSuffix: true
+    size: 'small'
   },
   render: (args) => ({
     components: { Currency },

--- a/packages/webkit/src/components/content/currency/currency.vue
+++ b/packages/webkit/src/components/content/currency/currency.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
   import { computed, useAttrs } from 'vue'
 
   defineOptions({
@@ -6,32 +6,24 @@
     inheritAttrs: false
   })
 
-  const props = defineProps({
-    value: {
-      type: String,
-      default: ''
-    },
-    prefix: {
-      type: String,
-      default: '$'
-    },
-    suffix: {
-      type: String,
-      default: 'per month'
-    },
-    showPrefix: {
-      type: Boolean,
-      default: true
-    },
-    showSuffix: {
-      type: Boolean,
-      default: true
-    },
-    size: {
-      type: String,
-      default: 'small',
-      validator: (value) => ['small', 'large'].includes(value)
-    }
+  type CurrencySize = 'small' | 'large'
+
+  interface CurrencyProps {
+    /** Monetary value content. */
+    value?: string
+    /** Text displayed before the value. */
+    prefix?: string
+    /** Text displayed after the value. */
+    suffix?: string
+    /** Visual size token for text and spacing. */
+    size?: CurrencySize
+  }
+
+  const props = withDefaults(defineProps<CurrencyProps>(), {
+    value: '',
+    prefix: '$',
+    suffix: '',
+    size: 'small'
   })
 
   const attrs = useAttrs()
@@ -39,62 +31,47 @@
   const testId = computed(() => attrs['data-testid'] ?? 'content-currency')
 
   const isLarge = computed(() => props.size === 'large')
-
-  const rootClass = computed(() => {
-    const classes = [
-      'inline-flex items-center',
-      isLarge.value ? 'gap-[var(--spacing-xs)]' : 'gap-[var(--spacing-xxs)]'
-    ]
-
-    if (attrs.class) {
-      classes.push(attrs.class)
-    }
-
-    return classes
-  })
-
-  const groupClass = 'inline-flex items-center gap-[var(--spacing-xxs)]'
-
-  const primaryTextClass = computed(() => {
-    if (isLarge.value) {
-      return ['text-heading-md text-[var(--text-default)]']
-    }
-
-    return ['text-label-lg text-[var(--text-default)]']
-  })
-
-  const suffixClass = computed(() => {
-    if (isLarge.value) {
-      return ['text-label-md text-[var(--text-muted)]']
-    }
-
-    return ['text-label-sm text-[var(--text-muted)]']
-  })
 </script>
 
 <template>
   <span
-    :class="rootClass"
+    :class="[
+      'inline-flex items-center',
+      isLarge ? 'gap-[var(--spacing-xs)]' : 'gap-[var(--spacing-xxs)]',
+      attrs.class
+    ]"
     :data-testid="testId"
   >
-    <span :class="groupClass">
+    <span class="inline-flex items-center gap-[var(--spacing-xxs)]">
       <span
-        v-if="showPrefix"
-        :class="primaryTextClass"
+        v-if="prefix"
+        :class="[
+          isLarge
+            ? 'text-heading-md text-[var(--text-default)]'
+            : 'text-label-lg text-[var(--text-default)]'
+        ]"
         :data-testid="`${testId}__prefix`"
       >
         {{ prefix }}
       </span>
       <span
-        :class="primaryTextClass"
+        :class="[
+          isLarge
+            ? 'text-heading-md text-[var(--text-default)]'
+            : 'text-label-lg text-[var(--text-default)]'
+        ]"
         :data-testid="`${testId}__value`"
       >
         {{ value }}
       </span>
     </span>
     <span
-      v-if="showSuffix"
-      :class="suffixClass"
+      v-if="suffix"
+      :class="[
+        isLarge
+          ? 'text-label-md text-[var(--text-muted)]'
+          : 'text-label-sm text-[var(--text-muted)]'
+      ]"
       :data-testid="`${testId}__suffix`"
     >
       {{ suffix }}


### PR DESCRIPTION
## Summary
- migrate `Currency` to `<script setup lang=\"ts\">` with typed props and `withDefaults`
- simplify visibility logic by removing `showPrefix`/`showSuffix` and rendering prefix/suffix based on value presence
- align Storybook and `.specs/currency.md` with the updated prop contract and checksum

## Test plan
- [x] Run pre-commit hooks (eslint/prettier) on staged files
- [x] Verify no linter diagnostics in edited files via IDE lints
- [x] Validate visual behavior in Storybook (`Currency` default and sizes)
