### PR TITLE
fix: remove duplicated/conflicting size height classes in button

### DIFF
--- a/packages/webkit/src/components/actions/button/button.vue
+++ b/packages/webkit/src/components/actions/button/button.vue
@@ -87,8 +87,8 @@
     'pointer-events-none cursor-not-allowed border-transparent bg-[var(--bg-disabled)] text-[var(--text-disabled)] before:hidden after:hidden'
 
   const sizeClasses: Record<ButtonSize, string> = {
-    large: 'min-w-20 h-10 h-10 px-[var(--spacing-md)] text-button-lg',
-    medium: 'min-w-16 h-8 h-10 px-[var(--spacing-sm)] text-button-md',
+    large: 'min-w-20 h-10 px-[var(--spacing-md)] text-button-lg',
+    medium: 'min-w-16 h-8 px-[var(--spacing-sm)] text-button-md',
     small: 'min-w-14 h-7 px-[var(--spacing-xs)] text-button-md'
   }
 


### PR DESCRIPTION
## Summary

The `large` and `medium` size class strings in `actions/button.vue` contained duplicated/conflicting `h-*` Tailwind classes:

\`\`\`diff
- large: 'min-w-20 h-10 h-10 px-[var(--spacing-md)] text-button-lg',
- medium: 'min-w-16 h-8 h-10 px-[var(--spacing-sm)] text-button-md',
+ large: 'min-w-20 h-10 px-[var(--spacing-md)] text-button-lg',
+ medium: 'min-w-16 h-8 px-[var(--spacing-sm)] text-button-md',
\`\`\`

- \`large\` had \`h-10 h-10\` duplicated — harmless but noisy
- \`medium\` had \`h-8 h-10\` conflicting — Tailwind kept the last (`h-10`), so medium buttons rendered with the same height as large

## Root cause

Likely copy-paste during a refactor; the conflict wasn't caught because both classes resolve to valid Tailwind utilities and only the last wins in the build output.

## Bonus

This fix is a \`fix:\` per the project's conventional commits rules, which should trigger semantic-release to publish a new \`@aziontech/webkit\` version. Pending unreleased commits since \`3.0.4\` will ship together:

- \`b2a062b\` feat(webkit): enhance segmented-button with sliding indicator and disabled affordance
- \`22d3632\` refactor(webkit): move SegmentedButton from wip to actions layer
- \`a0fb709\` refactor(currency): migrate to typed model and simplify visibility logic
- \`5f91828\` refactor(card-pricing): align component with typed spec contract

## Test plan

- [ ] Confirm \`size="medium"\` button renders at 32px height (not 40px)
- [ ] Confirm \`size="large"\` button still renders at 40px height
- [ ] Storybook visual diff stays clean except for the medium height correction