### PR TITLE
fix(storybook): restore IconButton controls reactivity

### DIFF
--- a/apps/storybook/src/stories/webkit/actions/icon-button/IconButton.stories.js
+++ b/apps/storybook/src/stories/webkit/actions/icon-button/IconButton.stories.js
@@ -104,11 +104,9 @@ export default meta
 const Template = (args) => ({
   components: { IconButton },
   setup() {
-    const { onClick, ...props } = args
-
-    return { props, onClick }
+    return { args }
   },
-  template: '<IconButton v-bind="props" @click="onClick" />'
+  template: '<IconButton v-bind="args" @click="args.onClick" />'
 })
 
 /** @type {import('@storybook/vue3').StoryObj<typeof IconButton>} */


### PR DESCRIPTION
## Summary
- fix the IconButton Storybook template to bind `args` directly instead of destructuring, restoring Controls reactivity
- ensure the Props panel updates the rendered component live for interactive testing and docs usage

## Test plan
- [x] Open `Webkit/Actions/Icon Button` story in Storybook
- [x] Change values in Controls (for example `kind`, `size`, `loading`, `disabled`) and verify UI updates immediately
- [x] Confirm click action still logs in the Actions panel

Made with [Cursor](https://cursor.com)