### PR TITLE
fix: use semantic primary token in overline and card-content

### DIFF
--- a/packages/webkit/src/components/wip/overline/overline.vue
+++ b/packages/webkit/src/components/wip/overline/overline.vue
@@ -36,7 +36,7 @@
       {{ prefix }}
     </span>
     <span
-      class="font-proto-mono text-pretty text-brand-primary-500 font-medium leading-1 tracking-tightest uppercase text-overline-md"
+      class="font-proto-mono text-pretty text-primary font-medium leading-1 tracking-tightest uppercase text-overline-md"
       :class="{ 'whitespace-nowrap': singleLine }"
     >
       <slot />

--- a/packages/webkit/src/core/card/card-content/card-content.vue
+++ b/packages/webkit/src/core/card/card-content/card-content.vue
@@ -151,7 +151,7 @@
       :class="contentInnerClass"
     >
       <p
-        class="font-proto-mono text-overline-sm text-brand-primary-500"
+        class="font-proto-mono text-overline-sm text-primary-500"
         v-if="overline"
       >
         {{ overline }}
@@ -160,7 +160,7 @@
       <span
         v-if="icon"
         :class="icon"
-        class="text-brand-primary-500 text-heading-sm"
+        class="text-primary text-heading-sm"
       ></span>
 
       <h3


### PR DESCRIPTION
## Summary
- Replace palette class `text-brand-primary-500` with the semantic `text-primary` token in `overline.vue` and `card-content.vue`.
- `card-content` overline paragraph uses `text-primary-500` to preserve the existing shade.

## Test plan
- [ ] Visual check of Overline (wip) story in Storybook
- [ ] Visual check of CardContent story (overline + icon) in Storybook