### PR TITLE
fix: use fixed rem sizes for heading-xs and heading-xxs

### DIFF
--- a/packages/theme/dist/v3/globals.css
+++ b/packages/theme/dist/v3/globals.css
@@ -475,15 +475,19 @@
     --text-big-number-lg-line-height: 1.20;
     --text-big-number-lg-font-family: Proto Mono;
     --text-heading-2xl-font-size: 1.875rem;
-    --text-heading-2xl-line-height: 1.2;
+    --text-heading-2xl-line-height: 1.1;
     --text-heading-xl-font-size: 1.25rem;
-    --text-heading-xl-line-height: 1.2;
+    --text-heading-xl-line-height: 1.1;
     --text-heading-lg-font-size: 1.125rem;
     --text-heading-lg-line-height: 1.2;
     --text-heading-md-font-size: 1rem;
-    --text-heading-md-line-height: 1.2;
+    --text-heading-md-line-height: 1.3;
     --text-heading-sm-font-size: 0.875rem;
-    --text-heading-sm-line-height: 1.2;
+    --text-heading-sm-line-height: 1.4;
+    --text-heading-xs-font-size: 1rem;
+    --text-heading-xs-line-height: 1.4;
+    --text-heading-xxs-font-size: 0.875rem;
+    --text-heading-xxs-line-height: 1.4;
     --text-label-lg-font-size: 1rem;
     --text-label-lg-line-height: 1.5;
     --text-label-lg-font-weight: 500;
@@ -825,6 +829,8 @@
   .text-heading-lg { font-size: var(--text-heading-lg-font-size); line-height: var(--text-heading-lg-line-height); }
   .text-heading-md { font-size: var(--text-heading-md-font-size); line-height: var(--text-heading-md-line-height); }
   .text-heading-sm { font-size: var(--text-heading-sm-font-size); line-height: var(--text-heading-sm-line-height); }
+  .text-heading-xs { font-size: var(--text-heading-xs-font-size); line-height: var(--text-heading-xs-line-height); }
+  .text-heading-xxs { font-size: var(--text-heading-xxs-font-size); line-height: var(--text-heading-xxs-line-height); }
   .text-label-lg { font-size: var(--text-label-lg-font-size); line-height: var(--text-label-lg-line-height); font-weight: var(--text-label-lg-font-weight); }
   .text-label-md { font-size: var(--text-label-md-font-size); line-height: var(--text-label-md-line-height); font-weight: var(--text-label-md-font-weight); }
   .text-label-sm { font-size: var(--text-label-sm-font-size); line-height: var(--text-label-sm-line-height); font-weight: var(--text-label-sm-font-weight); }

--- a/packages/theme/dist/v3/globals.scss
+++ b/packages/theme/dist/v3/globals.scss
@@ -475,15 +475,19 @@
     --text-big-number-lg-line-height: 1.20;
     --text-big-number-lg-font-family: Proto Mono;
     --text-heading-2xl-font-size: 1.875rem;
-    --text-heading-2xl-line-height: 1.2;
+    --text-heading-2xl-line-height: 1.1;
     --text-heading-xl-font-size: 1.25rem;
-    --text-heading-xl-line-height: 1.2;
+    --text-heading-xl-line-height: 1.1;
     --text-heading-lg-font-size: 1.125rem;
     --text-heading-lg-line-height: 1.2;
     --text-heading-md-font-size: 1rem;
-    --text-heading-md-line-height: 1.2;
+    --text-heading-md-line-height: 1.3;
     --text-heading-sm-font-size: 0.875rem;
-    --text-heading-sm-line-height: 1.2;
+    --text-heading-sm-line-height: 1.4;
+    --text-heading-xs-font-size: 1rem;
+    --text-heading-xs-line-height: 1.4;
+    --text-heading-xxs-font-size: 0.875rem;
+    --text-heading-xxs-line-height: 1.4;
     --text-label-lg-font-size: 1rem;
     --text-label-lg-line-height: 1.5;
     --text-label-lg-font-weight: 500;
@@ -825,6 +829,8 @@
   .text-heading-lg { font-size: var(--text-heading-lg-font-size); line-height: var(--text-heading-lg-line-height); }
   .text-heading-md { font-size: var(--text-heading-md-font-size); line-height: var(--text-heading-md-line-height); }
   .text-heading-sm { font-size: var(--text-heading-sm-font-size); line-height: var(--text-heading-sm-line-height); }
+  .text-heading-xs { font-size: var(--text-heading-xs-font-size); line-height: var(--text-heading-xs-line-height); }
+  .text-heading-xxs { font-size: var(--text-heading-xxs-font-size); line-height: var(--text-heading-xxs-line-height); }
   .text-label-lg { font-size: var(--text-label-lg-font-size); line-height: var(--text-label-lg-line-height); font-weight: var(--text-label-lg-font-weight); }
   .text-label-md { font-size: var(--text-label-md-font-size); line-height: var(--text-label-md-line-height); font-weight: var(--text-label-md-font-weight); }
   .text-label-sm { font-size: var(--text-label-sm-font-size); line-height: var(--text-label-sm-line-height); font-weight: var(--text-label-sm-font-weight); }

--- a/packages/theme/dist/v3/tailwind-preset.js
+++ b/packages/theme/dist/v3/tailwind-preset.js
@@ -307,6 +307,18 @@ const preset = {
             "lineHeight": "var(--text-heading-sm-line-height)"
           }
         ],
+        "heading-xs": [
+          "var(--text-heading-xs-font-size)",
+          {
+            "lineHeight": "var(--text-heading-xs-line-height)"
+          }
+        ],
+        "heading-xxs": [
+          "var(--text-heading-xxs-font-size)",
+          {
+            "lineHeight": "var(--text-heading-xxs-line-height)"
+          }
+        ],
         "label-lg": [
           "var(--text-label-lg-font-size)",
           {

--- a/packages/theme/dist/v3/tailwind.config.js
+++ b/packages/theme/dist/v3/tailwind.config.js
@@ -315,6 +315,18 @@ module.exports = {
             "lineHeight": "var(--text-heading-sm-line-height)"
           }
         ],
+        "heading-xs": [
+          "var(--text-heading-xs-font-size)",
+          {
+            "lineHeight": "var(--text-heading-xs-line-height)"
+          }
+        ],
+        "heading-xxs": [
+          "var(--text-heading-xxs-font-size)",
+          {
+            "lineHeight": "var(--text-heading-xxs-line-height)"
+          }
+        ],
         "label-lg": [
           "var(--text-label-lg-font-size)",
           {

--- a/packages/theme/dist/v4/globals.css
+++ b/packages/theme/dist/v4/globals.css
@@ -470,15 +470,19 @@
   --text-big-number-lg-line-height: 1.20;
   --text-big-number-lg-font-family: Proto Mono;
   --text-heading-2xl-font-size: 1.875rem;
-  --text-heading-2xl-line-height: 1.2;
+  --text-heading-2xl-line-height: 1.1;
   --text-heading-xl-font-size: 1.25rem;
-  --text-heading-xl-line-height: 1.2;
+  --text-heading-xl-line-height: 1.1;
   --text-heading-lg-font-size: 1.125rem;
   --text-heading-lg-line-height: 1.2;
   --text-heading-md-font-size: 1rem;
-  --text-heading-md-line-height: 1.2;
+  --text-heading-md-line-height: 1.3;
   --text-heading-sm-font-size: 0.875rem;
-  --text-heading-sm-line-height: 1.2;
+  --text-heading-sm-line-height: 1.4;
+  --text-heading-xs-font-size: 1rem;
+  --text-heading-xs-line-height: 1.4;
+  --text-heading-xxs-font-size: 0.875rem;
+  --text-heading-xxs-line-height: 1.4;
   --text-label-lg-font-size: 1rem;
   --text-label-lg-line-height: 1.5;
   --text-label-lg-font-weight: 500;
@@ -603,6 +607,8 @@
   .text-heading-lg { font-size: var(--text-heading-lg-font-size); line-height: var(--text-heading-lg-line-height); }
   .text-heading-md { font-size: var(--text-heading-md-font-size); line-height: var(--text-heading-md-line-height); }
   .text-heading-sm { font-size: var(--text-heading-sm-font-size); line-height: var(--text-heading-sm-line-height); }
+  .text-heading-xs { font-size: var(--text-heading-xs-font-size); line-height: var(--text-heading-xs-line-height); }
+  .text-heading-xxs { font-size: var(--text-heading-xxs-font-size); line-height: var(--text-heading-xxs-line-height); }
   .text-label-lg { font-size: var(--text-label-lg-font-size); line-height: var(--text-label-lg-line-height); font-weight: var(--text-label-lg-font-weight); }
   .text-label-md { font-size: var(--text-label-md-font-size); line-height: var(--text-label-md-line-height); font-weight: var(--text-label-md-font-weight); }
   .text-label-sm { font-size: var(--text-label-sm-font-size); line-height: var(--text-label-sm-line-height); font-weight: var(--text-label-sm-font-weight); }

--- a/packages/theme/dist/v4/globals.scss
+++ b/packages/theme/dist/v4/globals.scss
@@ -470,15 +470,19 @@
   --text-big-number-lg-line-height: 1.20;
   --text-big-number-lg-font-family: Proto Mono;
   --text-heading-2xl-font-size: 1.875rem;
-  --text-heading-2xl-line-height: 1.2;
+  --text-heading-2xl-line-height: 1.1;
   --text-heading-xl-font-size: 1.25rem;
-  --text-heading-xl-line-height: 1.2;
+  --text-heading-xl-line-height: 1.1;
   --text-heading-lg-font-size: 1.125rem;
   --text-heading-lg-line-height: 1.2;
   --text-heading-md-font-size: 1rem;
-  --text-heading-md-line-height: 1.2;
+  --text-heading-md-line-height: 1.3;
   --text-heading-sm-font-size: 0.875rem;
-  --text-heading-sm-line-height: 1.2;
+  --text-heading-sm-line-height: 1.4;
+  --text-heading-xs-font-size: 1rem;
+  --text-heading-xs-line-height: 1.4;
+  --text-heading-xxs-font-size: 0.875rem;
+  --text-heading-xxs-line-height: 1.4;
   --text-label-lg-font-size: 1rem;
   --text-label-lg-line-height: 1.5;
   --text-label-lg-font-weight: 500;
@@ -603,6 +607,8 @@
   .text-heading-lg { font-size: var(--text-heading-lg-font-size); line-height: var(--text-heading-lg-line-height); }
   .text-heading-md { font-size: var(--text-heading-md-font-size); line-height: var(--text-heading-md-line-height); }
   .text-heading-sm { font-size: var(--text-heading-sm-font-size); line-height: var(--text-heading-sm-line-height); }
+  .text-heading-xs { font-size: var(--text-heading-xs-font-size); line-height: var(--text-heading-xs-line-height); }
+  .text-heading-xxs { font-size: var(--text-heading-xxs-font-size); line-height: var(--text-heading-xxs-line-height); }
   .text-label-lg { font-size: var(--text-label-lg-font-size); line-height: var(--text-label-lg-line-height); font-weight: var(--text-label-lg-font-weight); }
   .text-label-md { font-size: var(--text-label-md-font-size); line-height: var(--text-label-md-line-height); font-weight: var(--text-label-md-font-weight); }
   .text-label-sm { font-size: var(--text-label-sm-font-size); line-height: var(--text-label-sm-line-height); font-weight: var(--text-label-sm-font-weight); }

--- a/packages/theme/src/tokens/semantic/texts.data.js
+++ b/packages/theme/src/tokens/semantic/texts.data.js
@@ -35,11 +35,11 @@ export const textsData = {
   },
   'text-heading-2xl': {
     fontSize: { _: '1.875rem', sm: '3rem', md: '3.75rem' },
-    lineHeight: '1.2'
+    lineHeight: '1.1'
   },
   'text-heading-xl': {
     fontSize: { _: '1.25rem', sm: '1.875rem', md: '2.25rem' },
-    lineHeight: '1.2'
+    lineHeight: '1.1'
   },
   'text-heading-lg': {
     fontSize: { _: '1.125rem', md: '1.875rem' },
@@ -47,11 +47,19 @@ export const textsData = {
   },
   'text-heading-md': {
     fontSize: { _: '1rem', sm: '1.25rem', md: '1.5rem' },
-    lineHeight: '1.2'
+    lineHeight: '1.3'
   },
   'text-heading-sm': {
     fontSize: { _: '0.875rem', sm: '1rem', md: '1.125rem' },
-    lineHeight: '1.2'
+    lineHeight: '1.4'
+  },
+  'text-heading-xs': {
+    fontSize: '1rem',
+    lineHeight: '1.4'
+  },
+  'text-heading-xxs': {
+    fontSize: '0.875rem',
+    lineHeight: '1.4'
   },
   'text-label-lg': {
     fontSize: '1rem',


### PR DESCRIPTION
## Summary

Convert the heading text styles from responsive `fontSize` objects to fixed `rem` values:

- `text-heading-xs` → `1rem` (16px)
- `text-heading-xxs` → `0.875rem` (14px)

Also fixed the stray indentation on those two entries. Rebuilt the theme tokens (`dist/v3`, `dist/v4`).