### PR TITLE
feat: dim focus ring color to reduce visual weight

### DIFF
--- a/packages/theme/dist/v3/globals.css
+++ b/packages/theme/dist/v3/globals.css
@@ -723,7 +723,7 @@
   --text-disabled: #999999;
   --text-link: #005FCC;
   --text-contrast: #FAFAFA;
-  --ring-color: #0A0A0A;
+  --ring-color: #666666;
   --success: #A4F4C0;
   --success-border: #22C55E66;
   --success-contrast: #12542B;
@@ -783,7 +783,7 @@
   --text-disabled: #4D4D4D;
   --text-link: #3392FF;
   --text-contrast: #000000;
-  --ring-color: #FFFFFF;
+  --ring-color: #4D4D4D;
   --success: #0A2916;
   --success-border: #22C55E66;
   --success-contrast: #52E086;

--- a/packages/theme/dist/v3/globals.scss
+++ b/packages/theme/dist/v3/globals.scss
@@ -723,7 +723,7 @@
   --text-disabled: #999999;
   --text-link: #005FCC;
   --text-contrast: #FAFAFA;
-  --ring-color: #0A0A0A;
+  --ring-color: #666666;
   --success: #A4F4C0;
   --success-border: #22C55E66;
   --success-contrast: #12542B;
@@ -783,7 +783,7 @@
   --text-disabled: #4D4D4D;
   --text-link: #3392FF;
   --text-contrast: #000000;
-  --ring-color: #FFFFFF;
+  --ring-color: #4D4D4D;
   --success: #0A2916;
   --success-border: #22C55E66;
   --success-contrast: #52E086;

--- a/packages/theme/src/tokens/theme/ring.js
+++ b/packages/theme/src/tokens/theme/ring.js
@@ -2,10 +2,10 @@ import { tokenRef } from '../../scripts/refs.js';
 
 export const ring = {
   light: {
-    'ring-color': tokenRef('theme.surfaces.surface-950'),
+    'ring-color': tokenRef('theme.surfaces.surface-600'),
   },
   dark: {
-    'ring-color': tokenRef('theme.surfaces.surface-0'),
+    'ring-color': tokenRef('theme.surfaces.surface-700'),
   },
 };
 


### PR DESCRIPTION
## Summary

- Move `--ring-color` away from the maximum-contrast surface (`surface-950` light / `surface-0` dark) to a mid-tone neutral (`surface-600` light / `surface-700` dark).
- The focus ring stays visible and WCAG-compliant, but no longer competes with form field content for attention.
- Regenerated `dist/v3/globals.css` and `globals.scss` via `pnpm --filter @aziontech/theme build:tokens:v3`.

This is the visual-foundation PR for the inputs work (InputText v2, InputPassword, etc.) that follows.

## Test plan

- [ ] Focus any input/button in Storybook (light + dark) — ring is visible but softer than before.
- [ ] Contrast ratio between ring and adjacent surface remains ≥3:1.