### PR TITLE
[ENG-46310] feat(webkit): add Chip (inputs)

### DIFF
--- a/.specs/chips.md
+++ b/.specs/chips.md
@@ -1,0 +1,129 @@
+---
+name: chips
+category: inputs
+structure: monolithic
+status: approved
+spec_version: 1
+figma:
+  url: https://www.figma.com/design/t97pXRs7xME3SJDs5iZ5RF/Webkit?node-id=476-948
+  node_id: 476:948
+checksum: 9c0f5a4b7631f7b17370bc31aceb48f51a41a8aec1c401b5b544e3fcd25eacbb
+created: 2026-06-23
+last_updated: 2026-06-24
+---
+
+# Chips — Component Spec
+
+## Purpose
+
+A Chip is a compact, self-contained token that labels a discrete value the user has applied — most often a removable filter on a data view. Unlike `tag` (a read-only status/category badge with severity color coding), a Chip carries no severity and exposes an optional trailing remove control: when `removable` is set, it renders a real `<button>` that emits `remove`, so the consumer can drop the value from a collection. This is the token consumed by the data table's `#filters` slot (`<Chip :label="f.label" removable @remove="dropFilter(f)" />`): each active filter becomes one removable Chip, and dismissing it removes that filter. Reach for a Chip when a value is user-applied and dismissible; reach for `tag` when it is a static status or category indicator.
+
+## Usage
+
+```vue
+<script setup>
+import Chip from '@aziontech/webkit/inputs/chips'
+</script>
+
+<template>
+  <Chip label="Active" size="medium" removable @remove="onRemove" />
+</template>
+```
+
+## Props
+
+| Prop | Type | Default | Required | JSDoc |
+|---|---|---|---|---|
+| `label` | `string` | `'undefined'` | no | Fallback text when the default slot is empty. |
+| `size` | `'small' \| 'medium'` | `'medium'` | no | Size token; `medium` is 24px tall, `small` is 20px. |
+| `removable` | `boolean` | `false` | no | When true, renders a trailing remove button that emits `remove`. |
+
+## Events
+
+| Event | Payload | Notes |
+|---|---|---|
+| `remove` | `MouseEvent` | Fires when `removable` is true and the remove button is activated (click / Enter / Space). |
+
+## Slots
+
+| Slot | Scope | Notes |
+|---|---|---|
+| `default` | — | Chip content; falls back to `label` when empty. |
+
+## States
+
+- Visual states: `default`, `hover`, `focus-visible` (on the remove button), `active`
+- `data-size` mirrors the `size` prop (`small` | `medium`)
+- `data-removable` is present when the `removable` prop is true
+- The root is a non-interactive container; only the remove button is focusable, and it shows a visible focus ring on `focus-visible`.
+
+## Motion & Animations
+
+| Trigger | Animation / Transition | Token (see `.claude/docs/DESIGN.md` § Animations) | Reduced-motion fallback |
+|---|---|---|---|
+| remove button hover/focus state change | `transition-colors duration-150 ease-out` | inline (matches catalog) | `motion-reduce:transition-none` |
+
+## Tokens
+
+| Region | Token (DESIGN.md) |
+|---|---|
+| surface | `var(--bg-surface)` (Figma uses the raised surface variant — see Theme gaps) |
+| border (color) | `var(--border-default)` |
+| shape | `var(--shape-elements)` |
+| elevation | `var(--shadow-sm)` |
+| typography (medium) | `.text-label-md` + `leading-none` (Figma Typography/Label/md, 14px) |
+| typography (small) | `.text-label-sm` + `leading-none` (Figma Typography/Label/sm, 12px) |
+| text | `var(--text-default)` |
+| spacing (medium padding) | `var(--spacing-sm)` / `var(--spacing-xs)` |
+| spacing (small padding) | `var(--spacing-xs)` / `var(--spacing-xxs)` |
+| spacing (label↔icon gap) | `var(--spacing-xxs)` |
+| ring | `var(--ring-color)` |
+
+## Theme gaps
+
+| Figma variable | Temporary primitive | Follow-up |
+|---|---|---|
+| raised surface `var(--bg-surface-raised)` | `var(--bg-surface-raised)` (exists in the theme; not yet catalogued in DESIGN.md) | `TODO: catalogar --bg-surface-raised em DESIGN.md` |
+| border width `var(--border-width-default)` | `var(--border-width-default)` (exists in the theme; not yet catalogued in DESIGN.md; already used by `tag.vue`) | `TODO: catalogar --border-width-default em DESIGN.md` |
+| label↔icon gap `6px` | `var(--spacing-xxs)` (4px) | `TODO: tokenizar gap de 6px se virar recorrente` |
+
+## Accessibility (WCAG 2.1 AA)
+
+- Visible focus: the remove button uses `focus-visible:ring-2 focus-visible:ring-[var(--ring-color)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-canvas)]`.
+- Keyboard map: the root is not focusable; `Tab` focuses the remove button (when `removable`), `Enter`/`Space` activates it and emits `remove`.
+- ARIA: the root is a non-interactive `<span>` container; the remove control is a real `<button type="button">` with `aria-label="Remove"`; the `pi pi-times` glyph is `aria-hidden="true"`.
+- Contrast ≥4.5:1 (text) / ≥3:1 (large + icons), including the remove icon.
+- `motion-reduce:transition-none` on the remove button's color transition.
+- Touch target: justified deviation — the chip height is 20–24px, so the remove button's touch target is below 40×40 px. This matches the design (the Chip is a compact inline token, not a primary action), and the larger surrounding chip remains the visible affordance.
+
+## Stories (Storybook)
+
+- Default — the baseline Chip with `label`.
+- Sizes — composite story rendering `small` and `medium` side by side, justified because `size` is a real axis with two values.
+- Removable — args delta `removable: true`, wiring the `remove` event to the Actions panel; justified because `removable` is a real boolean state that changes the rendered anatomy (adds the trailing remove button) and the emitted event.
+
+Types/Sizes canonical note: there is no `kind`/`severity` axis on Chip, so the `Types` story is omitted.
+
+## Constraints — DO NOT
+
+<!-- This block is injected VERBATIM into every sub-agent prompt.
+     spec-validator rejects the spec if this block is missing or shorter than the template. -->
+
+- Do not add props beyond the Props table above. If you need a prop that is not listed, emit `BLOCKED: missing prop <name>` and stop — do not invent.
+- Do not add events beyond the Events table above. Same rule for slots and sub-components.
+- Do not invent imports. Every `@aziontech/webkit/*` path must exist in `packages/webkit/package.json#exports`. Every relative import must resolve to a real file. Every npm package must be installed.
+- Do not use HEX/RGB/HSL colors, Tailwind palette names (e.g. `bg-blue-500`), raw typography classes (e.g. `text-sm`), `any`, `@ts-ignore`, or `class` inside `defineProps`.
+- Do not install or import positioning/animation libraries (`@floating-ui/*`, `popper.js`, `tippy.js`, `gsap`, `framer-motion`, `motion`, `@vueuse/motion`, `@formkit/auto-animate`, drag-drop runtimes, scroll virtualization libs). Use CSS + Vue primitives (`<Teleport>`, `<Transition>`). See `.claude/rules/dependencies.md`.
+- Do not improvise animations. Every `animate-*` / `transition-*` class must come from `packages/theme/src/tokens/semantic/animations.js`; every motion-bearing class pairs with `motion-reduce:*` on the same class string; no component-local `@keyframes`.
+- Do not create class presets in JavaScript (`const kindClasses = {...}`, `const sharedClasses = [...]`, `const sizeClasses = {...}`, `const rootClasses = computed(...)`). Variants live on `data-*` attributes consumed by Tailwind `data-[attr=value]:`. All utilities live inline on the root element's `class` attribute. No `<style>` block, no component-local `.css`/`.scss`. See `.claude/rules/styling.md`.
+- Do not inherit artifacts as-is from another design system, Figma file, library, or pre-existing `CONTRACT.md` / `README.md`. Rewrite to our conventions. See `.claude/rules/migration.md`.
+- Do not add Figma references to Storybook stories. No `parameters.design`, no `parameters.figma`, no Figma URLs in `docs.description.*`, no `@storybook/addon-designs` import. The Figma link is owned by `<name>.figma.ts` (Code Connect). See `.claude/docs/COMPONENT_REQUIREMENTS.md`.
+- Do not use `parameters.actions.argTypesRegex` (deprecated in Storybook 8 and silently misroutes Vue 3 emits) or `parameters.actions.handles` (DOM-only). Declare every event explicitly in `argTypes` with a camelCase `on<Event>` key and `{ action: '<emitted-name>' }`. Do not use the legacy CSF2 `Name.args = {...}` form — always object-style CSF3.
+- Do not add bespoke Storybook stories beyond Default + Types + Sizes + state stories (`Loading`, `Disabled`) for the props the component actually declares, unless the spec's "Stories (Storybook)" section explicitly justifies the addition. Do not split Types/Sizes into one-story-per-variant — the composite stories are the canonical pattern.
+- Do not duplicate the `## Usage` block from the spec inside the Storybook story body. The block is injected once into `parameters.docs.description.component` by the storybook-write skill; copy it nowhere else.
+- Do not edit `.claude/docs/DESIGN.md`, `.claude/docs/COMPONENT_REQUIREMENTS.md`, or `.claude/docs/PRIMEVUE_ABSTRACTION.md`.
+- Do not edit the root `package.json` or `.github/workflows/*`.
+- Do not change `structure` after `status: approved`. To change structure, bump `spec_version` and re-author the spec.
+- Do not create files outside the paths declared by your task (the orchestrator tells you exactly which files to write).
+- Do not run `git` commands, `pnpm install`, or any command that changes the lockfile.
+- If anything in the spec is ambiguous or contradicts the rules, emit `BLOCKED: <one-sentence reason>` and write nothing.

--- a/apps/storybook/src/stories/webkit/inputs/chips/Chip.stories.js
+++ b/apps/storybook/src/stories/webkit/inputs/chips/Chip.stories.js
@@ -1,0 +1,112 @@
+import Chip from '@aziontech/webkit/inputs/chips'
+
+const IMPORT = "import Chip from '@aziontech/webkit/inputs/chips'"
+
+/** Indent a `<template>` body and wrap it in a runnable `<script setup>` SFC. */
+const indent = (code) =>
+  code
+    .trim()
+    .split('\n')
+    .map((line) => (line ? `  ${line}` : line))
+    .join('\n')
+
+const sfc = (body) => ['<script setup>', IMPORT, '</script>', '', '<template>', indent(body), '</template>'].join('\n')
+
+const meta = {
+  title: 'Webkit/Inputs/Chip',
+  component: Chip,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A compact, dismissible token that labels a user-applied value, such as a removable filter on a data view. When `removable` is set, it renders a trailing button that emits the `remove` event.'
+      },
+      source: {
+        type: 'dynamic',
+        excludeDecorators: true,
+        // Composite stories supply their own full-SFC `source.code` (Storybook's
+        // dynamic source can't introspect a multi-element render template); pass
+        // those through untouched. Arg-driven stories get bare markup (sometimes
+        // already wrapped in <template>) — unwrap once, then wrap in a runnable SFC.
+        transform: (code) => {
+          let src = String(code).trim()
+          if (/<script[\s>]/.test(src)) return src
+          const wrapped = src.match(/^<template>\s*([\s\S]*?)\s*<\/template>$/)
+          if (wrapped) src = wrapped[1].trim()
+          return sfc(src)
+        }
+      },
+      canvas: { sourceState: 'shown' }
+    }
+  },
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Fallback text when the default slot is empty.',
+      table: { category: 'props', type: { summary: 'string' }, defaultValue: { summary: 'undefined' } }
+    },
+    size: {
+      control: 'inline-radio',
+      options: ['small', 'medium'],
+      description: 'Size token; medium is 24px tall, small is 20px.',
+      table: {
+        category: 'props',
+        type: { summary: "'small' | 'medium'" },
+        defaultValue: { summary: 'medium' }
+      }
+    },
+    removable: {
+      control: 'boolean',
+      description: 'When true, renders a trailing remove button that emits remove.',
+      table: { category: 'props', type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    }
+  },
+  args: { label: 'Label', size: 'medium', removable: false }
+}
+
+export default meta
+
+const Template = (args) => ({
+  components: { Chip },
+  setup() {
+    return { props: args }
+  },
+  template: '<Chip v-bind="props" />'
+})
+
+export const Default = {
+  render: Template,
+  parameters: {
+    docs: { description: { story: 'The baseline Chip rendering its `label`.' } }
+  }
+}
+
+const SIZES_TEMPLATE = `<div class="flex flex-wrap items-center gap-4">
+  <Chip label="Small" size="small" />
+  <Chip label="Medium" size="medium" />
+</div>`
+
+export const Sizes = {
+  render: () => ({
+    components: { Chip },
+    template: SIZES_TEMPLATE
+  }),
+  parameters: {
+    docs: {
+      controls: { disable: true },
+      description: { story: 'Both sizes side by side.' },
+      source: { code: sfc(SIZES_TEMPLATE) }
+    }
+  }
+}
+
+export const Removable = {
+  args: { removable: true },
+  render: Template,
+  argTypes: { onRemove: { action: 'remove' } },
+  parameters: {
+    docs: { description: { story: 'Removable chip; the × button emits `remove`.' } }
+  }
+}

--- a/packages/webkit/package.json
+++ b/packages/webkit/package.json
@@ -166,6 +166,7 @@
     "./message": "./src/components/feedback/message/message.vue",
     "./feedback/status-indicator": "./src/components/feedback/status-indicator/status-indicator.vue",
     "./inputs/input-text": "./src/components/inputs/input-text/input-text.vue",
+    "./inputs/chips": "./src/components/inputs/chips/chips.vue",
     "./inputs/label": "./src/components/inputs/label/label.vue",
     "./inputs/box-grid-selection": "./src/components/inputs/box-grid-selection/box-grid-selection.vue",
     "./inputs/checkbox": "./src/components/inputs/checkbox/checkbox.vue",

--- a/packages/webkit/src/components/inputs/chips/chips.vue
+++ b/packages/webkit/src/components/inputs/chips/chips.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+  import { computed, useAttrs } from 'vue'
+
+  export type ChipSize = 'small' | 'medium'
+
+  defineOptions({
+    name: 'Chips',
+    inheritAttrs: false
+  })
+
+  interface Props {
+    /** Fallback text when the default slot is empty. */
+    label?: string
+    /** Size token; `medium` is 24px tall, `small` is 20px. */
+    size?: ChipSize
+    /** When true, renders a trailing remove button that emits remove. */
+    removable?: boolean
+  }
+
+  withDefaults(defineProps<Props>(), {
+    label: undefined,
+    size: 'medium',
+    removable: false
+  })
+
+  const emit = defineEmits<{
+    remove: [event: MouseEvent]
+  }>()
+
+  defineSlots<{
+    default(): unknown
+  }>()
+
+  const attrs = useAttrs()
+
+  const testId = computed(() => (attrs['data-testid'] as string | undefined) ?? 'input-chips')
+
+  function onRemove(event: MouseEvent) {
+    emit('remove', event)
+  }
+</script>
+
+<template>
+  <span
+    v-bind="$attrs"
+    :data-testid="testId"
+    :data-size="size"
+    :data-removable="removable || null"
+    :class="attrs.class"
+    class="inline-flex items-center justify-center overflow-hidden border border-[var(--border-default)] border-[length:var(--border-width-default)] bg-[var(--bg-surface-raised)] text-[var(--text-default)] shadow-[var(--shadow-sm)] leading-none rounded-[var(--shape-elements)] gap-[var(--spacing-xxs)] data-[size=medium]:text-label-md data-[size=small]:text-label-sm data-[size=medium]:h-6 data-[size=small]:h-5 data-[size=medium]:py-[var(--spacing-xs)] data-[size=medium]:px-[var(--spacing-sm)] data-[size=small]:p-[var(--spacing-xs)] data-[size=medium]:data-[removable]:pr-[var(--spacing-xs)] data-[size=small]:data-[removable]:pr-[var(--spacing-xxs)]"
+  >
+    <slot v-if="$slots['default']" />
+    <span
+      v-else-if="label"
+      :data-testid="`${testId}__label`"
+    >
+      {{ label }}
+    </span>
+    <button
+      v-if="removable"
+      type="button"
+      aria-label="Remove"
+      :data-testid="`${testId}__remove`"
+      class="inline-flex shrink-0 items-center justify-center rounded-[var(--shape-elements)] text-[var(--text-default)] transition-colors duration-150 ease-out motion-reduce:transition-none hover:bg-[var(--bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-color)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-canvas)]"
+      @click="onRemove"
+    >
+      <i
+        class="pi pi-times flex shrink-0 items-center size-[14px]"
+        aria-hidden="true"
+        :data-testid="`${testId}__remove-icon`"
+      />
+    </button>
+  </span>
+</template>

--- a/packages/webkit/src/components/inputs/chips/package.json
+++ b/packages/webkit/src/components/inputs/chips/package.json
@@ -1,0 +1,11 @@
+{
+  "main": "./chips.vue",
+  "module": "./chips.vue",
+  "types": "./chips.vue.d.ts",
+  "browser": {
+    "./sfc": "./chips.vue"
+  },
+  "sideEffects": [
+    "*.vue"
+  ]
+}


### PR DESCRIPTION
## ENG-46310

Adds the **Chip** component (`inputs/chips`), following the Figma Chip set (node `476:948`) and our spec-driven pipeline. Aligns with how `.specs/table.md` already consumes it (`<Chip :label removable @remove />`, e.g. the data table's `#filters` slot).

## API

- **Props:** `label` (fallback text for the default slot), `size` (`small | medium`), `removable` (renders a trailing × button).
- **Event:** `remove` — emitted when `removable` and the × is activated.
- **Slot:** `default` (falls back to `label`).
- Monolithic; inline Tailwind + `data-*` variants (no JS class presets, no `<style>`); tokens mapped to `DESIGN.md` (`--bg-surface-raised`, `--border-default`, `--shape-elements`, label typography). The × is a real `<button aria-label="Remove">` with a visible focus ring; the chip root is a non-interactive container.

## Stories

`Default`, `Sizes` (small/medium), `Removable` (wires `remove` to the Actions panel) — with the **"Show code" copy-paste-ready** panel (runnable SFC, shown by default).

## Checks

`pnpm --filter webkit lint` ✓ · `type-coverage` 100% ✓. Write-time hooks (tokens / references / spec-compliance) passed. (`type-check` / `build:dts` surface only the unrelated pre-existing `navigation-menu-popup.vue` error already present on `main`; the Chip itself is dts-valid.)
