### PR TITLE
[ENG-46314] feat(webkit): add Badge (content)

### DIFF
--- a/.specs/badge.md
+++ b/.specs/badge.md
@@ -1,0 +1,120 @@
+---
+name: badge
+category: content
+structure: monolithic
+status: approved
+spec_version: 1
+figma:
+  url: https://www.figma.com/design/t97pXRs7xME3SJDs5iZ5RF/Webkit?node-id=476-909
+  node_id: 476:909
+checksum: b6ac23ed182931b114be1c72d42e415c01f8ad7437547fe3fe27fff63f126e29
+created: 2026-06-23
+last_updated: 2026-06-23
+---
+# Badge — Component Spec
+
+## Purpose
+
+Badge is a compact, non-interactive indicator that surfaces a numeric count or a very short status value with severity-based color coding. Use it to draw attention to a small piece of state — an unread count, a quantity, a short status word — and it is commonly overlaid on icons, avatars, or buttons. It differs from its sibling `tag`: `tag` is a labelled status/category chip (optional leading icon, optional pill shape, masked surfaces), whereas `badge` is a denser count/short-value indicator with fully filled severity surfaces and no icon affordance.
+
+## Usage
+
+```vue
+<script setup>
+import Badge from '@aziontech/webkit/content/badge'
+</script>
+
+<template>
+  <Badge value="99" severity="primary" size="medium" />
+</template>
+```
+
+## Props
+
+| Prop | Type | Default | Required | JSDoc |
+|---|---|---|---|---|
+| `value` | `string` | `'undefined'` | no | Fallback text when the default slot is empty. |
+| `severity` | `'primary' \| 'secondary' \| 'success' \| 'warning' \| 'danger' \| 'default'` | `'primary'` | no | Color style for the badge surface and label; `default` uses the neutral `var(--bg-surface)` / `var(--text-default)` surface. |
+| `size` | `'small' \| 'medium' \| 'large'` | `'medium'` | no | Size token; `small` is 20px tall, `medium` is 24px, `large` is 30px. |
+
+## Events
+
+| _none_ | — | — |
+
+## Slots
+
+| Slot | Scope | Notes |
+|---|---|---|
+| `default` | — | Main content; falls back to `value` when empty. |
+
+## States
+
+Badge is non-interactive: it has no hover, focus, active, or disabled states and emits no events. Variants are exposed verbatim as `data-*` attributes on the root for Tailwind variant styling and for test/Code-Connect hooks:
+
+- `data-severity` mirrors the `severity` prop (`primary` | `secondary` | `success` | `warning` | `danger` | `default`).
+- `data-size` mirrors the `size` prop (`small` | `medium` | `large`).
+
+## Motion & Animations
+
+_none_
+
+## Tokens
+
+| Region | Token (DESIGN.md) |
+|---|---|
+| typography (medium, large) | `.text-label-md` + `leading-none` (Figma Typography/Label/md, 14px) |
+| typography (small) | `.text-label-sm` + `leading-none` (Figma Typography/Label/sm, 12px) |
+| spacing (medium, large) | `var(--spacing-xs)` horizontal padding |
+| spacing (small) | `var(--spacing-xxs)` horizontal padding |
+| shape (all severities) | `var(--shape-elements)` |
+| surface (primary) | `var(--primary)` / `var(--primary-contrast)` |
+| surface (secondary) | `var(--secondary)` / `var(--secondary-contrast)` |
+| surface (success) | `var(--success)` / `var(--success-contrast)` |
+| surface (warning) | `var(--warning)` / `var(--warning-contrast)` |
+| surface (danger) | `var(--danger)` / `var(--danger-contrast)` |
+| surface (default) | `var(--bg-surface)` / `var(--text-default)` |
+
+## Theme gaps
+
+_none_
+
+## Accessibility (WCAG 2.1 AA)
+
+- Visible focus: not applicable — Badge is non-interactive (no focus, no keyboard, no tab stop).
+- Keyboard map: none — Badge is not focusable and exposes no interactive affordance.
+- ARIA: the root is a presentational `<span>`; consumers that use the badge as a live count should label the host control (e.g. `aria-label="3 unread"`) since the visual value alone is not announced as status.
+- Contrast ≥4.5:1 (text) / ≥3:1 (large + icons): every severity pairs a surface token with its matching `-contrast` (or `--text-default` for `default`), which the theme guarantees in both light and dark.
+- `motion-reduce:*`: not applicable — Badge is static (no motion).
+- Touch target: not applicable — Badge is non-interactive.
+
+## Stories (Storybook)
+
+- Default
+- Types — composite story rendering every `severity` value side-by-side.
+- Sizes — composite story rendering every `size` value side-by-side.
+
+<!-- Loading/Disabled stories are omitted: Badge declares neither prop and is non-interactive, so there are no such states to demonstrate (consistent with the canonical layout, which gates those stories on the props existing). -->
+
+## Constraints — DO NOT
+
+<!-- This block is injected VERBATIM into every sub-agent prompt.
+     spec-validator rejects the spec if this block is missing or shorter than the template. -->
+
+- Do not add props beyond the Props table above. If you need a prop that is not listed, emit `BLOCKED: missing prop <name>` and stop — do not invent.
+- Do not add events beyond the Events table above. Same rule for slots and sub-components.
+- Do not invent imports. Every `@aziontech/webkit/*` path must exist in `packages/webkit/package.json#exports`. Every relative import must resolve to a real file. Every npm package must be installed.
+- Do not use HEX/RGB/HSL colors, Tailwind palette names (e.g. `bg-blue-500`), raw typography classes (e.g. `text-sm`), `any`, `@ts-ignore`, or `class` inside `defineProps`.
+- Do not install or import positioning/animation libraries (`@floating-ui/*`, `popper.js`, `tippy.js`, `gsap`, `framer-motion`, `motion`, `@vueuse/motion`, `@formkit/auto-animate`, drag-drop runtimes, scroll virtualization libs). Use CSS + Vue primitives (`<Teleport>`, `<Transition>`). See `.claude/rules/dependencies.md`.
+- Do not improvise animations. Every `animate-*` / `transition-*` class must come from `packages/theme/src/tokens/semantic/animations.js`; every motion-bearing class pairs with `motion-reduce:*` on the same class string; no component-local `@keyframes`.
+- Do not create class presets in JavaScript (`const kindClasses = {...}`, `const sharedClasses = [...]`, `const sizeClasses = {...}`, `const rootClasses = computed(...)`). Variants live on `data-*` attributes consumed by Tailwind `data-[attr=value]:`. All utilities live inline on the root element's `class` attribute. No `<style>` block, no component-local `.css`/`.scss`. See `.claude/rules/styling.md`.
+- Do not inherit artifacts as-is from another design system, Figma file, library, or pre-existing `CONTRACT.md` / `README.md`. Rewrite to our conventions. See `.claude/rules/migration.md`.
+- Do not add Figma references to Storybook stories. No `parameters.design`, no `parameters.figma`, no Figma URLs in `docs.description.*`, no `@storybook/addon-designs` import. The Figma link is owned by `<name>.figma.ts` (Code Connect). See `.claude/docs/COMPONENT_REQUIREMENTS.md`.
+- Do not use `parameters.actions.argTypesRegex` (deprecated in Storybook 8 and silently misroutes Vue 3 emits) or `parameters.actions.handles` (DOM-only). Declare every event explicitly in `argTypes` with a camelCase `on<Event>` key and `{ action: '<emitted-name>' }`. Do not use the legacy CSF2 `Name.args = {...}` form — always object-style CSF3.
+- Do not add bespoke Storybook stories beyond Default + Types + Sizes + state stories (`Loading`, `Disabled`) for the props the component actually declares, unless the spec's "Stories (Storybook)" section explicitly justifies the addition. Do not split Types/Sizes into one-story-per-variant — the composite stories are the canonical pattern.
+- Do not duplicate the `## Usage` block from the spec inside the Storybook story body. The block is injected once into `parameters.docs.description.component` by the storybook-write skill; copy it nowhere else.
+- Do not edit `.claude/docs/DESIGN.md`, `.claude/docs/COMPONENT_REQUIREMENTS.md`, or `.claude/docs/PRIMEVUE_ABSTRACTION.md`.
+- Do not edit the root `package.json` or `.github/workflows/*`.
+- Do not change `structure` after `status: approved`. To change structure, bump `spec_version` and re-author the spec.
+- Do not create files outside the paths declared by your task (the orchestrator tells you exactly which files to write).
+- Do not run `git` commands, `pnpm install`, or any command that changes the lockfile.
+- If anything in the spec is ambiguous or contradicts the rules, emit `BLOCKED: <one-sentence reason>` and write nothing.

--- a/apps/storybook/src/stories/webkit/content/badge/Badge.stories.js
+++ b/apps/storybook/src/stories/webkit/content/badge/Badge.stories.js
@@ -1,0 +1,137 @@
+import Badge from '@aziontech/webkit/content/badge'
+
+const IMPORT = "import Badge from '@aziontech/webkit/content/badge'"
+
+/** Indent a `<template>` body and wrap it in a runnable `<script setup>` SFC. */
+const indent = (code) =>
+  code
+    .trim()
+    .split('\n')
+    .map((line) => (line ? `  ${line}` : line))
+    .join('\n')
+
+const sfc = (body) => ['<script setup>', IMPORT, '</script>', '', '<template>', indent(body), '</template>'].join('\n')
+
+const meta = {
+  title: 'Webkit/Content/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Compact, non-interactive indicator that surfaces a numeric count or short status value with severity-based color coding. Commonly overlaid on icons, avatars, or buttons.'
+      },
+      source: {
+        type: 'dynamic',
+        excludeDecorators: true,
+        // Composite stories supply their own full-SFC `source.code` (Storybook's
+        // dynamic source can't introspect a multi-element render template); pass
+        // those through untouched. For arg-driven stories Storybook emits bare
+        // markup (sometimes already wrapped in <template>) — unwrap once, then
+        // wrap in a runnable SFC so "Show code" matches the canvas exactly.
+        transform: (code) => {
+          let src = String(code).trim()
+          if (/<script[\s>]/.test(src)) return src
+          const wrapped = src.match(/^<template>\s*([\s\S]*?)\s*<\/template>$/)
+          if (wrapped) src = wrapped[1].trim()
+          return sfc(src)
+        }
+      },
+      canvas: { sourceState: 'shown' }
+    }
+  },
+  argTypes: {
+    value: {
+      control: 'text',
+      description: 'Fallback text when the default slot is empty.',
+      table: { category: 'props', type: { summary: 'string' }, defaultValue: { summary: 'undefined' } }
+    },
+    severity: {
+      control: 'select',
+      options: ['primary', 'secondary', 'success', 'warning', 'danger', 'default'],
+      description: 'Color style for the badge surface and label.',
+      table: {
+        category: 'props',
+        type: { summary: "'primary' | 'secondary' | 'success' | 'warning' | 'danger' | 'default'" },
+        defaultValue: { summary: 'primary' }
+      }
+    },
+    size: {
+      control: 'inline-radio',
+      options: ['small', 'medium', 'large'],
+      description: 'Size token; small is 20px tall, medium is 24px, large is 30px.',
+      table: {
+        category: 'props',
+        type: { summary: "'small' | 'medium' | 'large'" },
+        defaultValue: { summary: 'medium' }
+      }
+    }
+  },
+  args: {
+    value: '99',
+    severity: 'primary',
+    size: 'medium'
+  }
+}
+
+export default meta
+
+const Template = (args) => ({
+  components: { Badge },
+  setup() {
+    return { props: args }
+  },
+  template: '<Badge v-bind="props" />'
+})
+
+export const Default = {
+  render: Template,
+  parameters: {
+    docs: { description: { story: 'A single badge driven by the controls.' } }
+  }
+}
+
+const TYPES_TEMPLATE = `<div class="flex flex-wrap items-center gap-4">
+  <Badge value="99" severity="primary" />
+  <Badge value="99" severity="secondary" />
+  <Badge value="99" severity="success" />
+  <Badge value="99" severity="warning" />
+  <Badge value="99" severity="danger" />
+  <Badge value="99" severity="default" />
+</div>`
+
+export const Types = {
+  render: () => ({
+    components: { Badge },
+    template: TYPES_TEMPLATE
+  }),
+  parameters: {
+    docs: {
+      controls: { disable: true },
+      description: { story: 'All severities side by side.' },
+      source: { code: sfc(TYPES_TEMPLATE) }
+    }
+  }
+}
+
+const SIZES_TEMPLATE = `<div class="flex flex-wrap items-center gap-4">
+  <Badge value="99" size="small" />
+  <Badge value="99" size="medium" />
+  <Badge value="99" size="large" />
+</div>`
+
+export const Sizes = {
+  render: () => ({
+    components: { Badge },
+    template: SIZES_TEMPLATE
+  }),
+  parameters: {
+    docs: {
+      controls: { disable: true },
+      description: { story: 'All sizes side by side.' },
+      source: { code: sfc(SIZES_TEMPLATE) }
+    }
+  }
+}

--- a/packages/webkit/package.json
+++ b/packages/webkit/package.json
@@ -140,6 +140,7 @@
     "./calendar": "./src/core/primevue/calendar/calendar.vue",
     "./picklist": "./src/core/primevue/picklist/picklist.vue",
     "./avatar": "./src/components/avatar/avatar.vue",
+    "./content/badge": "./src/components/content/badge/badge.vue",
     "./content/card-box": "./src/components/content/card-box/card-box.vue",
     "./content/card-pricing": "./src/components/content/card-pricing/card-pricing.vue",
     "./content/item": "./src/components/content/item/index.js",

--- a/packages/webkit/src/components/content/badge/badge.vue
+++ b/packages/webkit/src/components/content/badge/badge.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+  import { computed, useAttrs } from 'vue'
+
+  export type BadgeSeverity = 'primary' | 'secondary' | 'success' | 'warning' | 'danger' | 'default'
+
+  export type BadgeSize = 'small' | 'medium' | 'large'
+
+  defineOptions({
+    name: 'Badge',
+    inheritAttrs: false
+  })
+
+  interface Props {
+    /** Fallback text when the default slot is empty. */
+    value?: string
+    /** Color style for the badge surface and label. */
+    severity?: BadgeSeverity
+    /** Size token; `small` is 20px tall, `medium` is 24px, `large` is 30px. */
+    size?: BadgeSize
+  }
+
+  const props = withDefaults(defineProps<Props>(), {
+    value: undefined,
+    severity: 'primary',
+    size: 'medium'
+  })
+
+  defineSlots<{
+    default(): unknown
+  }>()
+
+  const attrs = useAttrs()
+
+  const testId = computed(() => (attrs['data-testid'] as string | undefined) ?? 'content-badge')
+
+  const resolvedSeverity = computed((): BadgeSeverity => {
+    const severity = props.severity ?? 'primary'
+
+    if (
+      severity === 'primary' ||
+      severity === 'secondary' ||
+      severity === 'success' ||
+      severity === 'warning' ||
+      severity === 'danger' ||
+      severity === 'default'
+    ) {
+      return severity
+    }
+
+    return 'primary'
+  })
+</script>
+
+<template>
+  <span
+    v-bind="$attrs"
+    :data-testid="testId"
+    :data-severity="resolvedSeverity"
+    :data-size="size"
+    :class="attrs.class"
+    class="inline-flex items-center justify-center overflow-hidden leading-none text-label-md data-[size=small]:text-label-sm data-[size=small]:h-5 data-[size=small]:px-[var(--spacing-xxs)] data-[size=medium]:h-6 data-[size=medium]:px-[var(--spacing-xs)] data-[size=large]:h-[30px] data-[size=large]:px-[var(--spacing-xs)] rounded-[var(--shape-elements)] data-[severity=primary]:bg-[var(--primary)] data-[severity=primary]:text-[var(--primary-contrast)] data-[severity=secondary]:bg-[var(--secondary)] data-[severity=secondary]:text-[var(--secondary-contrast)] data-[severity=success]:bg-[var(--success)] data-[severity=success]:text-[var(--success-contrast)] data-[severity=warning]:bg-[var(--warning)] data-[severity=warning]:text-[var(--warning-contrast)] data-[severity=danger]:bg-[var(--danger)] data-[severity=danger]:text-[var(--danger-contrast)] data-[severity=default]:bg-[var(--bg-surface)] data-[severity=default]:text-[var(--text-default)]"
+  >
+    <slot v-if="$slots['default']" />
+    <span
+      v-else-if="value"
+      :data-testid="`${testId}__value`"
+    >
+      {{ value }}
+    </span>
+  </span>
+</template>

--- a/packages/webkit/src/components/content/badge/package.json
+++ b/packages/webkit/src/components/content/badge/package.json
@@ -1,0 +1,11 @@
+{
+  "main": "./badge.vue",
+  "module": "./badge.vue",
+  "types": "./badge.vue.d.ts",
+  "browser": {
+    "./sfc": "./badge.vue"
+  },
+  "sideEffects": [
+    "*.vue"
+  ]
+}


### PR DESCRIPTION
## ENG-46314

Adds the **Badge** component (`content/badge`), following the Figma Badge set (node `476:909`). Mirrors the existing `tag` pattern.

## API

- **Props:** `value` (numeric count / short status text; fallback for the default slot), `severity` (`primary | secondary | success | warning | danger | default`), `size` (`small | medium | large`, mapped from Figma `md/lg/xl`).
- **Slot:** `default` (falls back to `value`).
- Non-interactive; inline Tailwind + `data-*` variants (no JS class presets, no `<style>`); all colors/typography mapped to `DESIGN.md` tokens (`var(--<severity>)` / `var(--<severity>-contrast)`, `--shape-elements`, label typography).

## Stories

`Default`, `Types` (6 severities), `Sizes` (small/medium/large) — with the **"Show code" copy-paste-ready** panel. Composite stories carry an explicit `docs.source.code` so the shown SFC matches the canvas exactly (all variants, not a single one).

## Checks

`pnpm --filter webkit lint` ✓ · `type-coverage` 100% ✓. Write-time hooks (tokens / references / spec-compliance) passed. (`type-check` / `build:dts` surface only the unrelated pre-existing `navigation-menu-popup.vue` error already on `main`.)
