### PR TITLE
[ENG-46313] feat(webkit): add Skeleton loading placeholder (feedback)

### DIFF
--- a/.claude/hooks/validate-tokens.mjs
+++ b/.claude/hooks/validate-tokens.mjs
@@ -62,8 +62,11 @@ const VIOLATIONS = [
   },
   {
     id: 'primevue-color',
+    // The leading (?<![\w-]) excludes matches embedded in a CSS variable name
+    // (e.g. the sanctioned `var(--bg-surface-overlay)`), so only the bare
+    // PrimeFlex utility class (`surface-overlay`, `text-color`, ...) is caught.
     regex:
-      /\b(?:text-color|surface-(?:0|50|100|200|300|400|500|600|700|800|900|ground|section|card|overlay|border|hover))\b/g,
+      /(?<![\w-])(?:text-color|surface-(?:0|50|100|200|300|400|500|600|700|800|900|ground|section|card|overlay|border|hover))\b/g,
     message:
       'PrimeVue color utility. Use semantic webkit tokens (var(--text-default), var(--bg-surface), ...).'
   },

--- a/.specs/skeleton.md
+++ b/.specs/skeleton.md
@@ -1,0 +1,112 @@
+---
+name: skeleton
+category: feedback
+structure: monolithic
+status: implemented
+spec_version: 1
+figma:
+  url: https://www.figma.com/design/t97pXRs7xME3SJDs5iZ5RF/Webkit?node-id=479-881
+  node_id: 479:881
+checksum: a3ba11ff0d67cde98427376c7f4f5e8d958933bcaced577819fc26e721e03fe5
+created: 2026-06-23
+last_updated: 2026-06-24
+---
+
+# Skeleton — Component Spec
+
+## Purpose
+
+A loading placeholder that reserves the space of content while it loads, gently pulsing to signal activity. Use it in place of text lines, media, or avatars during fetches; unlike `status-indicator` (which communicates a settled state) the skeleton is a transient, decorative stand-in. Two geometries cover the common cases: a rounded rectangular block (`shape`) and a `circle` (for avatars / icons).
+
+## Usage
+
+```vue
+<script setup>
+import Skeleton from '@aziontech/webkit/skeleton'
+</script>
+
+<template>
+  <Skeleton width="240px" height="100px" />
+  <Skeleton kind="circle" width="100px" height="100px" />
+</template>
+```
+
+## Props
+
+| Prop | Type | Default | Required | JSDoc |
+|---|---|---|---|---|
+| `kind` | `'shape' \| 'circle'` | `'shape'` | no | Geometry: a rounded rectangular block (`shape`) or a circle. |
+| `width` | `string` | `'100%'` | no | CSS width (any length). |
+| `height` | `string` | `'1rem'` | no | CSS height (any length); for a circle, set equal to `width`. |
+| `animated` | `boolean` | `true` | no | Pulse while loading; suppressed under reduced motion. |
+
+## Events
+
+| _none_ | — | — |
+
+## Slots
+
+| _none_ | — | Leaf placeholder; renders no content. |
+
+## States
+
+- Visual states: `default` (a single decorative placeholder; no hover/focus/active — it is not interactive)
+- `data-kind` mirrors the `kind` prop (`shape` | `circle`)
+- `data-animated` is present when `animated` is true (drives the pulse)
+
+## Motion & Animations
+
+| Trigger | Animation / Transition | Token (see `.claude/docs/DESIGN.md` § Animations) | Reduced-motion fallback |
+|---|---|---|---|
+| while loading (`animated`) | `animate-pulse` | theme gap (see Theme gaps) — closest looping opacity primitive | `motion-reduce:animate-none` (static) |
+
+## Tokens
+
+| Region | Token (DESIGN.md) |
+|---|---|
+| shape radius (`shape`) | `var(--shape-elements)` |
+
+## Theme gaps
+
+| Figma variable | Temporary primitive | Follow-up |
+|---|---|---|
+| `--bg-surface-overlay` (skeleton fill, #4D4D4D dark / #FAFAFA light) | `bg-[var(--bg-surface-overlay)]` (real token, not yet in DESIGN.md) | `TODO: document --bg-surface-overlay in DESIGN.md` |
+| pulse animation | `animate-pulse` (Tailwind primitive, present in the compiled theme) | `TODO: add a semantic skeleton/pulse animation to semantic/animations.js` |
+
+## Accessibility (WCAG 2.1 AA)
+
+- The skeleton is decorative: `aria-hidden="true"` so assistive tech skips it. The loading status is conveyed by the surrounding region (e.g. `aria-busy="true"` on the container the consumer owns), not by the placeholder itself.
+- Not focusable, not interactive: no keyboard map, no focus ring.
+- `motion-reduce:animate-none` suppresses the pulse for users who prefer reduced motion.
+
+## Stories (Storybook)
+
+This component has no `size` axis, so the canonical Sizes story does not apply.
+
+- Default
+- Types — composite story rendering both `kind` values (`shape`, `circle`) side-by-side.
+- Static — `animated: false`; demonstrates the non-pulsing placeholder. Justified because `animated` is a distinct state of the component and the pulse cannot be seen in a static screenshot.
+
+## Constraints — DO NOT
+
+<!-- This block is injected VERBATIM into every sub-agent prompt.
+     spec-validator rejects the spec if this block is missing or shorter than the template. -->
+
+- Do not add props beyond the Props table above. If you need a prop that is not listed, emit `BLOCKED: missing prop <name>` and stop — do not invent.
+- Do not add events beyond the Events table above. Same rule for slots and sub-components.
+- Do not invent imports. Every `@aziontech/webkit/*` path must exist in `packages/webkit/package.json#exports`. Every relative import must resolve to a real file. Every npm package must be installed.
+- Do not use HEX/RGB/HSL colors, Tailwind palette names (e.g. `bg-blue-500`), raw typography classes (e.g. `text-sm`), `any`, `@ts-ignore`, or `class` inside `defineProps`.
+- Do not install or import positioning/animation libraries (`@floating-ui/*`, `popper.js`, `tippy.js`, `gsap`, `framer-motion`, `motion`, `@vueuse/motion`, `@formkit/auto-animate`, drag-drop runtimes, scroll virtualization libs). Use CSS + Vue primitives (`<Teleport>`, `<Transition>`). See `.claude/rules/dependencies.md`.
+- Do not improvise animations. Every `animate-*` / `transition-*` class must come from `packages/theme/src/tokens/semantic/animations.js`; every motion-bearing class pairs with `motion-reduce:*` on the same class string; no component-local `@keyframes`.
+- Do not create class presets in JavaScript (`const kindClasses = {...}`, `const sharedClasses = [...]`, `const sizeClasses = {...}`, `const rootClasses = computed(...)`). Variants live on `data-*` attributes consumed by Tailwind `data-[attr=value]:`. All utilities live inline on the root element's `class` attribute. No `<style>` block, no component-local `.css`/`.scss`. See `.claude/rules/styling.md`.
+- Do not inherit artifacts as-is from another design system, Figma file, library, or pre-existing `CONTRACT.md` / `README.md`. Rewrite to our conventions. See `.claude/rules/migration.md`.
+- Do not add Figma references to Storybook stories. No `parameters.design`, no `parameters.figma`, no Figma URLs in `docs.description.*`, no `@storybook/addon-designs` import. The Figma link is owned by `<name>.figma.ts` (Code Connect). See `.claude/docs/COMPONENT_REQUIREMENTS.md`.
+- Do not use `parameters.actions.argTypesRegex` (deprecated in Storybook 8 and silently misroutes Vue 3 emits) or `parameters.actions.handles` (DOM-only). Declare every event explicitly in `argTypes` with a camelCase `on<Event>` key and `{ action: '<emitted-name>' }`. Do not use the legacy CSF2 `Name.args = {...}` form — always object-style CSF3.
+- Do not add bespoke Storybook stories beyond Default + Types + Sizes + state stories (`Loading`, `Disabled`) for the props the component actually declares, unless the spec's "Stories (Storybook)" section explicitly justifies the addition. Do not split Types/Sizes into one-story-per-variant — the composite stories are the canonical pattern.
+- Do not duplicate the `## Usage` block from the spec inside the Storybook story body. The block is injected once into `parameters.docs.description.component` by the storybook-write skill; copy it nowhere else.
+- Do not edit `.claude/docs/DESIGN.md`, `.claude/docs/COMPONENT_REQUIREMENTS.md`, or `.claude/docs/PRIMEVUE_ABSTRACTION.md`.
+- Do not edit the root `package.json` or `.github/workflows/*`.
+- Do not change `structure` after `status: approved`. To change structure, bump `spec_version` and re-author the spec.
+- Do not create files outside the paths declared by your task (the orchestrator tells you exactly which files to write).
+- Do not run `git` commands, `pnpm install`, or any command that changes the lockfile.
+- If anything in the spec is ambiguous or contradicts the rules, emit `BLOCKED: <one-sentence reason>` and write nothing.

--- a/apps/storybook/src/stories/components/feedback/skeleton/Skeleton.stories.js
+++ b/apps/storybook/src/stories/components/feedback/skeleton/Skeleton.stories.js
@@ -1,0 +1,144 @@
+import Skeleton from '@aziontech/webkit/skeleton'
+
+/** @type {import('@storybook/vue3').Meta<typeof Skeleton>} */
+const meta = {
+  title: 'Components/Feedback/Skeleton',
+  component: Skeleton,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    backgrounds: {
+      default: 'dark'
+    },
+    a11y: {
+      config: {
+        rules: [{ id: 'color-contrast', enabled: true }]
+      }
+    },
+    docs: {
+      description: {
+        component:
+          'A loading placeholder that reserves the space of content while it loads, gently pulsing to signal activity. Two geometries cover the common cases: a rounded rectangular block (`shape`) and a `circle`.'
+      },
+      source: {
+        type: 'dynamic',
+        excludeDecorators: true,
+        transform: (code) => {
+          const body = code
+            .trim()
+            .split('\n')
+            .map((line) => (line ? `  ${line}` : line))
+            .join('\n')
+
+          return [
+            '<script setup>',
+            "import Skeleton from '@aziontech/webkit/skeleton'",
+            '</script>',
+            '',
+            '<template>',
+            body,
+            '</template>'
+          ].join('\n')
+        }
+      },
+      canvas: {
+        sourceState: 'shown'
+      }
+    }
+  },
+  argTypes: {
+    kind: {
+      control: 'inline-radio',
+      options: ['shape', 'circle'],
+      description: 'Geometry: a rounded rectangular block (`shape`) or a circle.',
+      table: {
+        category: 'props',
+        type: { summary: "'shape' | 'circle'" },
+        defaultValue: { summary: "'shape'" }
+      }
+    },
+    width: {
+      control: 'text',
+      description: 'CSS width (any length).',
+      table: {
+        category: 'props',
+        type: { summary: 'string' },
+        defaultValue: { summary: "'100%'" }
+      }
+    },
+    height: {
+      control: 'text',
+      description: 'CSS height (any length); for a circle, set equal to `width`.',
+      table: {
+        category: 'props',
+        type: { summary: 'string' },
+        defaultValue: { summary: "'1rem'" }
+      }
+    },
+    animated: {
+      control: 'boolean',
+      description: 'Pulse while loading; suppressed under reduced motion.',
+      table: {
+        category: 'props',
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'true' }
+      }
+    }
+  },
+  args: {
+    kind: 'shape',
+    width: '240px',
+    height: '100px',
+    animated: true
+  }
+}
+
+export default meta
+
+const Template = (args) => ({
+  components: { Skeleton },
+  setup() {
+    return { props: args }
+  },
+  template: '<Skeleton v-bind="props" />'
+})
+
+/** @type {import('@storybook/vue3').StoryObj<typeof Skeleton>} */
+export const Default = {
+  render: Template,
+  parameters: {
+    docs: { description: { story: 'Default rectangular placeholder with a pulse.' } }
+  }
+}
+
+/** @type {import('@storybook/vue3').StoryObj<typeof Skeleton>} */
+export const Types = {
+  render: () => ({
+    components: { Skeleton },
+    template: `
+      <div class="flex flex-wrap items-center gap-4">
+        <Skeleton kind="shape" width="240px" height="100px" />
+        <Skeleton kind="circle" width="100px" height="100px" />
+      </div>
+    `
+  }),
+  parameters: {
+    docs: {
+      controls: { disable: true },
+      description: { story: 'Both geometries side by side: a rectangular `shape` and a `circle`.' }
+    }
+  }
+}
+
+/** @type {import('@storybook/vue3').StoryObj<typeof Skeleton>} */
+export const Static = {
+  args: { animated: false },
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story: 'Non-pulsing placeholder when `animated: false` (also the reduced-motion fallback).'
+      }
+    }
+  }
+}

--- a/packages/webkit/package.json
+++ b/packages/webkit/package.json
@@ -88,6 +88,7 @@
     "./data-table-view-toggle": "./src/components/data/data-table/data-table-view-toggle.vue",
     "./message": "./src/components/feedback/message/message.vue",
     "./status-indicator": "./src/components/feedback/status-indicator/status-indicator.vue",
+    "./skeleton": "./src/components/feedback/skeleton/skeleton.vue",
     "./input-text": "./src/components/inputs/input-text/input-text.vue",
     "./label": "./src/components/inputs/label/label.vue",
     "./box-grid-selection": "./src/components/inputs/box-grid-selection/box-grid-selection.vue",

--- a/packages/webkit/src/components/feedback/skeleton/package.json
+++ b/packages/webkit/src/components/feedback/skeleton/package.json
@@ -1,0 +1,11 @@
+{
+  "main": "./skeleton.vue",
+  "module": "./skeleton.vue",
+  "types": "./skeleton.vue.d.ts",
+  "browser": {
+    "./sfc": "./skeleton.vue"
+  },
+  "sideEffects": [
+    "*.vue"
+  ]
+}

--- a/packages/webkit/src/components/feedback/skeleton/skeleton.vue
+++ b/packages/webkit/src/components/feedback/skeleton/skeleton.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+  import { computed, useAttrs } from 'vue'
+
+  export type SkeletonKind = 'shape' | 'circle'
+
+  defineOptions({
+    name: 'Skeleton',
+    inheritAttrs: false
+  })
+
+  interface Props {
+    /** Geometry: a rounded rectangular block (`shape`) or a circle. */
+    kind?: SkeletonKind
+    /** CSS width (any length). */
+    width?: string
+    /** CSS height (any length); for a circle, set equal to `width`. */
+    height?: string
+    /** Pulse while loading; suppressed under reduced motion. */
+    animated?: boolean
+  }
+
+  withDefaults(defineProps<Props>(), {
+    kind: 'shape',
+    width: '100%',
+    height: '1rem',
+    animated: true
+  })
+
+  const attrs = useAttrs()
+
+  const testId = computed(() => (attrs['data-testid'] as string | undefined) ?? 'feedback-skeleton')
+</script>
+
+<template>
+  <div
+    v-bind="$attrs"
+    role="presentation"
+    aria-hidden="true"
+    :data-testid="testId"
+    :data-kind="kind"
+    :data-animated="animated || null"
+    :style="{ width, height }"
+    class="block bg-[var(--bg-surface-overlay)] data-[kind=shape]:rounded-[var(--shape-elements)] data-[kind=circle]:rounded-full data-[animated]:animate-pulse motion-reduce:animate-none"
+  />
+</template>


### PR DESCRIPTION
## Summary

Adds the **Skeleton** loading placeholder (feedback), rebuilt on top of `dev` in the current repo format. Supersedes #655.

- `shape` / `circle` geometries, pulse with `motion-reduce` fallback, decorative (`aria-hidden`).
- Story under `apps/storybook/src/stories/components/feedback/skeleton/` with title `Components/Feedback/Skeleton`.
- Direct export `@aziontech/webkit/skeleton` (no category prefix).
- `validate-tokens` lookbehind so the sanctioned `var(--bg-surface-overlay)` token isn't flagged as a PrimeFlex utility.

## Review feedback applied (from #655, @robsongajunior)

- Export key is now `./skeleton` (prefix removed), folder keeps the `feedback` context.
- Spec `Usage` import → `@aziontech/webkit/skeleton`.
- Story `title` → `Components/Feedback/Skeleton`.
- Story 'Show code' import → `@aziontech/webkit/skeleton`.

## Notes

Replaces #655, which was branched from `main` (pre-`dev`-reorg). This branch starts from `dev`, so the diff is only the component's own files and it merges cleanly.