### PR TITLE
[NO-ISSUE] docs: translate .claude/rules files to English

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,24 +1,24 @@
-# Rule: git workflow — branches e PRs sempre via `/create-branch` e `/open-pr`
+# Rule: git workflow — branches and PRs always via `/create-branch` and `/open-pr`
 
-Quando o usuário pedir para **criar uma branch** ou **abrir/fazer um PR** — em qualquer frase, slash command ou linguagem natural ("abre um PR", "manda pro PR", "cria uma branch pra isso") — siga os fluxos canônicos. **Não improvise** os passos de git/PR.
+When the user asks to **create a branch** or **open/make a PR** — in any phrasing, slash command, or natural language ("open a PR", "send it to a PR", "create a branch for this") — follow the canonical flows. **Do not improvise** the git/PR steps.
 
-| Intenção do usuário | Fluxo a seguir |
+| User intent | Flow to follow |
 |---|---|
-| Criar branch nova | [`/create-branch`](../commands/create-branch.md) |
-| Commitar + push + abrir PR | [`/open-pr`](../commands/open-pr.md) |
+| Create a new branch | [`/create-branch`](../commands/create-branch.md) |
+| Commit + push + open PR | [`/open-pr`](../commands/open-pr.md) |
 
-Esses commands são a **fonte da verdade** do processo. Esta regra existe só para garantir que eles sejam acionados mesmo quando o usuário não digita a slash explicitamente.
+These commands are the **source of truth** for the process. This rule exists only to ensure they are triggered even when the user does not type the slash explicitly.
 
-## Convenções (já embutidas nos fluxos — repetidas aqui porque são inegociáveis)
+## Conventions (already embedded in the flows — repeated here because they are non-negotiable)
 
-- **Base sempre `dev`.** Branch sai de `origin/dev`, PR aponta para `dev`. **Nunca** `main`, nunca branch a partir de `main`.
-- **Nome da branch:** kebab-case `<type>/<ISSUE>-<slug>` (ou `<type>/<slug>` sem issue). `type` vem do mesmo enum do Conventional Commits ([`CONTRIBUTING.md`](../../CONTRIBUTING.md) § Commit convention / [`commitlint.config.js`](../../commitlint.config.js)). Esse enum precisa bater com todo `packages/*/.releaserc` — ver [`release-types.md`](./release-types.md).
-- **Commit:** Conventional Commits, header commitlint-válido. **Nunca** adicionar `Co-Authored-By` nem rodapé de atribuição ("Generated with Claude"). **Nunca** `--no-verify` para pular o commitlint.
-- **Commitar/push só como parte do `/open-pr`** — rodar o command é a autorização. Não commitar mudanças não relacionadas.
-- **Docs/rules compartilhados em PR separado de código.** Se o diff misturar código com `.claude/rules/*`, `.claude/skills/*`, `.specs/_template.md` etc., separar em outro PR. O `.specs/<name>.md` do próprio componente fica junto do componente.
+- **Always base on `dev`.** The branch comes off `origin/dev`, the PR targets `dev`. **Never** `main`, never branch from `main`.
+- **Branch name:** kebab-case `<type>/<ISSUE>-<slug>` (or `<type>/<slug>` without an issue). `type` comes from the same Conventional Commits enum ([`CONTRIBUTING.md`](../../CONTRIBUTING.md) § Commit convention / [`commitlint.config.js`](../../commitlint.config.js)). That enum must match every `packages/*/.releaserc` — see [`release-types.md`](./release-types.md).
+- **Commit:** Conventional Commits, commitlint-valid header. **Never** add `Co-Authored-By` or an attribution footer ("Generated with Claude"). **Never** `--no-verify` to skip commitlint.
+- **Commit/push only as part of `/open-pr`** — running the command is the authorization. Do not commit unrelated changes.
+- **Shared docs/rules in a separate PR from code.** If the diff mixes code with `.claude/rules/*`, `.claude/skills/*`, `.specs/_template.md`, etc., split them into another PR. A component's own `.specs/<name>.md` stays with the component.
 
-## O que não fazer
+## What not to do
 
-- Não rodar `git checkout -b`, `git commit`, `git push` ou `gh pr create` "na mão" fora desses fluxos quando o pedido for criar branch / abrir PR.
-- Não abrir PR direto de `main` ou `dev`.
-- Não marcar uma mudança como breaking sem confirmar com o usuário antes.
+- Don't run `git checkout -b`, `git commit`, `git push`, or `gh pr create` "by hand" outside these flows when the request is to create a branch / open a PR.
+- Don't open a PR directly from `main` or `dev`.
+- Don't mark a change as breaking without confirming with the user first.

--- a/.claude/rules/migration.md
+++ b/.claude/rules/migration.md
@@ -4,7 +4,7 @@ When importing a component, pattern, or any artifact from **outside** this codeb
 
 ## The rule
 
-> **NUNCA criar nada fora do padrão.** Every artifact you produce — spec, `.vue`, `package.json`, `.figma.ts`, `.stories.js`, rule update — must conform to our patterns. No exceptions, no "temporary" deviations, no "to make migration easier."
+> **NEVER create anything outside the standard.** Every artifact you produce — spec, `.vue`, `package.json`, `.figma.ts`, `.stories.js`, rule update — must conform to our patterns. No exceptions, no "temporary" deviations, no "to make migration easier."
 
 ## What this means in practice
 

--- a/.claude/rules/no-invention.md
+++ b/.claude/rules/no-invention.md
@@ -16,7 +16,7 @@ You are a transcriber, not an author. The spec at `.specs/<name>.md` is the cont
 10. **Do not improvise animations.** Every `animate-*` / `transition-*` class comes from the catalog. Every motion-bearing class pairs with `motion-reduce:*`. No component-local `@keyframes`. See [`tokens.md`](./tokens.md#animations--semanticanimationsjs).
 11. **Do not add Figma references to Storybook stories.** No `parameters.design`, no `parameters.figma`, no Figma URLs in `docs.description.component`, no addon-designs links. The story documents the **component API and behavior**; the Figma file documents the design. They stay separate. See [`.claude/docs/COMPONENT_REQUIREMENTS.md`](../docs/COMPONENT_REQUIREMENTS.md) § 13.x.
 12. **Do not create CSS class presets in JavaScript** (`const kindClasses = {...}`, `const sharedClasses = [...]`, `const sizeClasses = {...}`, `const rootClasses = computed(...)` that only composes classes). Variants live on `data-*` attributes; styles live as Tailwind utilities on the root element's `class` attribute. No `<style>` block, no component-local `.css`/`.scss`. See [`styling.md`](./styling.md).
-13. **NUNCA criar nada fora do padrão.** If the only way to satisfy a request is to deviate from our patterns, that's a spec problem — emit `BLOCKED:` and stop.
+13. **NEVER create anything outside the standard.** If the only way to satisfy a request is to deviate from our patterns, that's a spec problem — emit `BLOCKED:` and stop.
 
 ## What to do when the spec is incomplete
 

--- a/.claude/rules/release-types.md
+++ b/.claude/rules/release-types.md
@@ -1,52 +1,52 @@
-# Rule: release types — um único conjunto de tipos em commitlint, `.releaserc`, CONTRIBUTING e commands
+# Rule: release types — one single set of types across commitlint, `.releaserc`, CONTRIBUTING and commands
 
-O conjunto de `type`s de Conventional Commit e o **bump de versão** de cada um são versionados em quatro lugares. Eles **têm que ser idênticos**. Quando divergem, o commitlint aceita um commit que o `semantic-release` silenciosamente ignora (ou vice-versa), e os fluxos `/open-pr` / `/create-branch` passam a oferecer um type que não gera o release esperado. Esta regra é o que o reviewer cobra em PR: _"should match release and commit lint"_.
+The set of Conventional Commit `type`s and the **version bump** of each one are versioned in four places. They **must be identical**. When they diverge, commitlint accepts a commit that `semantic-release` silently ignores (or vice versa), and the `/open-pr` / `/create-branch` flows start offering a type that does not produce the expected release. This rule is what the reviewer enforces in a PR: _"should match release and commit lint"_.
 
-## A regra (invariante)
+## The rule (invariant)
 
-A lista de types aceitos e o type→bump devem ser **iguais** nestes quatro pontos:
+The list of accepted types and the type→bump must be **identical** at these four points:
 
-| Arquivo | O que define |
+| File | What it defines |
 |---|---|
-| [`commitlint.config.js`](../../commitlint.config.js) (`type-enum`) | quais types passam no `commit-msg` |
-| `packages/*/.releaserc` (`releaseRules`) | o bump de cada type — em **todos** os pacotes: [`webkit`](../../packages/webkit/.releaserc), [`theme`](../../packages/theme/.releaserc), [`icons`](../../packages/icons/.releaserc) |
-| [`CONTRIBUTING.md`](../../CONTRIBUTING.md) § Commit convention | a tabela type → bump, documentada para humanos |
-| [`open-pr.md`](../commands/open-pr.md) + [`create-branch.md`](../commands/create-branch.md) | a lista de types que os fluxos inferem/oferecem |
+| [`commitlint.config.js`](../../commitlint.config.js) (`type-enum`) | which types pass `commit-msg` |
+| `packages/*/.releaserc` (`releaseRules`) | the bump of each type — in **all** packages: [`webkit`](../../packages/webkit/.releaserc), [`theme`](../../packages/theme/.releaserc), [`icons`](../../packages/icons/.releaserc) |
+| [`CONTRIBUTING.md`](../../CONTRIBUTING.md) § Commit convention | the type → bump table, documented for humans |
+| [`open-pr.md`](../commands/open-pr.md) + [`create-branch.md`](../commands/create-branch.md) | the list of types the flows infer/offer |
 
-## Conjunto canônico (hoje)
+## Canonical set (today)
 
 - `feat` → **minor**
 - `fix` / `hotfix` / `chore` / `docs` / `style` / `refactor` / `perf` → **patch**
-- `test` / `ci` / `revert` → `release: false` (sem bump; permitidos para higiene)
-- `!` após o type ou rodapé `BREAKING CHANGE:` → **major**
+- `test` / `ci` / `revert` → `release: false` (no bump; allowed for hygiene)
+- `!` after the type or a `BREAKING CHANGE:` footer → **major**
 
-Cada type é listado **explicitamente** no `releaseRules` de cada `.releaserc` — não dependa do default implícito do preset `conventionalcommits`. Um type sem regra explícita é uma divergência esperando para acontecer.
+Each type is listed **explicitly** in the `releaseRules` of every `.releaserc` — do not rely on the implicit default of the `conventionalcommits` preset. A type without an explicit rule is a divergence waiting to happen.
 
-## Ao adicionar, remover ou re-mapear um type
+## When adding, removing, or re-mapping a type
 
-Faça as quatro edições **no mesmo PR**:
+Make the four edits **in the same PR**:
 
 1. `commitlint.config.js` → `type-enum`.
-2. **Todos** os `packages/*/.releaserc` → `releaseRules` (webkit, theme, icons). Não esqueça nenhum pacote.
-3. `CONTRIBUTING.md` → a tabela type → bump e a nota de enforcement.
-4. `open-pr.md` + `create-branch.md` → a lista de types e o mapeamento de bump.
+2. **Every** `packages/*/.releaserc` → `releaseRules` (webkit, theme, icons). Don't forget any package.
+3. `CONTRIBUTING.md` → the type → bump table and the enforcement note.
+4. `open-pr.md` + `create-branch.md` → the list of types and the bump mapping.
 
-Sem release? Use `{ "type": "<x>", "release": false }` no `releaseRules` (não omita o type).
+No release? Use `{ "type": "<x>", "release": false }` in `releaseRules` (do not omit the type).
 
-## Detalhes do `@semantic-release/commit-analyzer` que importam
+## `@semantic-release/commit-analyzer` details that matter
 
-- O `releaseRules` custom é avaliado **antes** do `DEFAULT_RELEASE_RULES`; o default só entra quando **nenhuma** regra custom casa (`isUndefined`).
-- Uma regra custom com `release: false` retorna `false` (não `undefined`), então **suprime** o default. É assim que `revert` fica sem release, em vez de cair no default `{ revert: true } → patch`.
-- A regra `{ "breaking": true, "release": "major" }` fica **sempre por último** no array. Por causa do `compareReleaseTypes`, uma regra `release: false` anterior não rebaixa um commit breaking — `major` ainda vence.
-- O analyzer também filtra por path: um commit só conta para o release de um pacote se tocar arquivos sob `packages/<scope>/`.
+- The custom `releaseRules` is evaluated **before** `DEFAULT_RELEASE_RULES`; the default only kicks in when **no** custom rule matches (`isUndefined`).
+- A custom rule with `release: false` returns `false` (not `undefined`), so it **suppresses** the default. This is how `revert` ends up with no release, instead of falling into the default `{ revert: true } → patch`.
+- The rule `{ "breaking": true, "release": "major" }` is **always last** in the array. Because of `compareReleaseTypes`, an earlier `release: false` rule does not downgrade a breaking commit — `major` still wins.
+- The analyzer also filters by path: a commit only counts toward a package's release if it touches files under `packages/<scope>/`.
 
-## O que não fazer
+## What not to do
 
-- Não adicionar um type ao comando ou ao commitlint sem adicioná-lo aos três `.releaserc`.
-- Não mexer só no `.releaserc` do `webkit` e esquecer `theme` / `icons`.
-- Não confiar no default do preset para um type — liste-o explicitamente.
-- Não deixar `CONTRIBUTING.md` descrevendo um bump diferente do que o `releaseRules` produz.
+- Don't add a type to the command or to commitlint without adding it to the three `.releaserc` files.
+- Don't touch only `webkit`'s `.releaserc` and forget `theme` / `icons`.
+- Don't rely on the preset default for a type — list it explicitly.
+- Don't let `CONTRIBUTING.md` describe a different bump than the one `releaseRules` produces.
 
-## Por que essa regra existe
+## Why this rule exists
 
-O `/open-pr` e o `/create-branch` listavam `perf` / `test` / `ci` / `revert`, e o `commitlint` os aceitava, mas os `.releaserc` só enumeravam sete types + breaking. `perf` só dava patch pelo default do preset e `test`/`ci`/`revert` não apareciam — uma divergência que rendeu `CHANGES_REQUESTED`. Tornar os quatro pontos idênticos e explícitos elimina a classe inteira de bug.
+`/open-pr` and `/create-branch` listed `perf` / `test` / `ci` / `revert`, and `commitlint` accepted them, but the `.releaserc` files only enumerated seven types + breaking. `perf` only got a patch from the preset default and `test`/`ci`/`revert` did not appear — a divergence that earned a `CHANGES_REQUESTED`. Making the four points identical and explicit eliminates the entire class of bug.

--- a/.claude/rules/styling.md
+++ b/.claude/rules/styling.md
@@ -4,7 +4,7 @@ Styles live on the **template root element's `class` attribute**, not in JavaScr
 
 ## The rule
 
-> **Não crie presets de classe CSS** (objetos `kindClasses` / `sizeClasses` / `sharedClasses` no script). **Não crie classes dentro do componente** (sem `<style>` block, sem CSS local, sem utility custom). Tudo vai inline no `class` do root, usando `data-*` para alternar variantes.
+> **Do not create CSS class presets** (`kindClasses` / `sizeClasses` / `sharedClasses` objects in the script). **Do not create classes inside the component** (no `<style>` block, no local CSS, no custom utility). Everything goes inline on the root's `class`, using `data-*` to switch variants.
 
 ## What this means in practice
 


### PR DESCRIPTION
## Summary

Docs-only PR. Translates the remaining Portuguese-mixed `.claude/rules/*` files to English so the convention docs are consistent in one language, following the reviewer feedback on #665 ("pt-br mixed en").

- **`release-types.md`** — full translation (prose, tables, section headings).
- **`git-workflow.md`** — full translation (prose, tables, section headings).
- **`styling.md`** — the one PT-BR "The rule" blockquote translated.
- **`no-invention.md`** — item 13 ("NUNCA criar nada fora do padrão") translated.
- **`migration.md`** — the "The rule" blockquote ("NUNCA criar nada fora do padrão") translated.

No semantics changed: code blocks, links, file paths, type→bump mappings, and table structure are preserved verbatim — only natural-language prose was translated.

## Notes

- Docs/tooling only — no component code, no new dependency, no release bump (files live under `.claude/rules/`, outside any `packages/<scope>/`).
- `dependencies.md` was already English (untouched).
- Companion to #665, which fixed the `imports.md` blockquote.
