### PR TITLE
[NO-ISSUE] style(theme): alias typography tokens and set 6xl to 56px

### DIFF
--- a/packages/theme/dist/v3/globals.css
+++ b/packages/theme/dist/v3/globals.css
@@ -370,7 +370,7 @@
     --text-4xl--line-height: calc(2.5 / 2.25);
     --text-5xl: 3rem;
     --text-5xl--line-height: 1;
-    --text-6xl: 3.75rem;
+    --text-6xl: 3.5rem;
     --text-6xl--line-height: 1;
     --text-7xl: 4.5rem;
     --text-7xl--line-height: 1;
@@ -469,28 +469,38 @@
 
     /* ── Texts ── */
     --text-big-number-md-font-size: 1.25rem;
-    --text-big-number-md-line-height: 1.20;
+    --text-big-number-md-line-height: 1.25;
+    --text-big-number-md-font-weight: 400;
     --text-big-number-md-font-family: Proto Mono;
     --text-big-number-sm-font-size: 1rem;
-    --text-big-number-sm-line-height: 1.20;
+    --text-big-number-sm-line-height: 1.25;
+    --text-big-number-sm-font-weight: 400;
     --text-big-number-sm-font-family: Proto Mono;
     --text-big-number-lg-font-size: 1.5rem;
-    --text-big-number-lg-line-height: 1.20;
+    --text-big-number-lg-line-height: 1.25;
+    --text-big-number-lg-font-weight: 400;
     --text-big-number-lg-font-family: Proto Mono;
     --text-heading-2xl-font-size: 1.875rem;
-    --text-heading-2xl-line-height: 1.1;
+    --text-heading-2xl-line-height: 1.25;
+    --text-heading-2xl-font-weight: 400;
     --text-heading-xl-font-size: 1.25rem;
-    --text-heading-xl-line-height: 1.1;
+    --text-heading-xl-line-height: 1.25;
+    --text-heading-xl-font-weight: 400;
     --text-heading-lg-font-size: 1.125rem;
-    --text-heading-lg-line-height: 1.2;
+    --text-heading-lg-line-height: 1.25;
+    --text-heading-lg-font-weight: 400;
     --text-heading-md-font-size: 1rem;
-    --text-heading-md-line-height: 1.3;
+    --text-heading-md-line-height: 1.25;
+    --text-heading-md-font-weight: 400;
     --text-heading-sm-font-size: 0.875rem;
-    --text-heading-sm-line-height: 1.4;
+    --text-heading-sm-line-height: 1.375;
+    --text-heading-sm-font-weight: 400;
     --text-heading-xs-font-size: 1rem;
-    --text-heading-xs-line-height: 1.4;
+    --text-heading-xs-line-height: 1.375;
+    --text-heading-xs-font-weight: 400;
     --text-heading-xxs-font-size: 0.875rem;
-    --text-heading-xxs-line-height: 1.4;
+    --text-heading-xxs-line-height: 1.375;
+    --text-heading-xxs-font-weight: 400;
     --text-label-lg-font-size: 1rem;
     --text-label-lg-line-height: 1.5;
     --text-label-lg-font-weight: 500;
@@ -508,38 +518,38 @@
     --text-body-sm-line-height: 1.5;
     --text-body-xs-font-size: 0.75rem;
     --text-body-xs-line-height: 1.5;
-    --text-tag-sm-font-size: 0.6875rem;
-    --text-tag-sm-line-height: 1;
+    --text-tag-sm-font-size: 0.75rem;
+    --text-tag-sm-line-height: 1.25;
     --text-tag-sm-font-weight: 600;
     --text-tag-md-font-size: 0.75rem;
-    --text-tag-md-line-height: 1;
+    --text-tag-md-line-height: 1.25;
     --text-tag-md-font-weight: 600;
-    --text-body-xxs-font-size: 0.625rem;
+    --text-body-xxs-font-size: 0.75rem;
     --text-body-xxs-line-height: 1.5;
     --text-overline-md-font-family: Proto Mono;
     --text-overline-md-font-size: 0.75rem;
-    --text-overline-md-line-height: 1.4;
+    --text-overline-md-line-height: 1.375;
     --text-overline-md-letter-spacing: 0.08em;
     --text-overline-md-text-transform: uppercase;
     --text-overline-sm-font-family: Proto Mono;
     --text-overline-sm-font-size: 0.75rem;
-    --text-overline-sm-line-height: 1.4;
+    --text-overline-sm-line-height: 1.375;
     --text-overline-sm-letter-spacing: 0.08em;
     --text-overline-sm-text-transform: uppercase;
     --text-overline-xs-font-family: Proto Mono;
-    --text-overline-xs-font-size: 0.625rem;
-    --text-overline-xs-line-height: 1.4;
+    --text-overline-xs-font-size: 0.75rem;
+    --text-overline-xs-line-height: 1.375;
     --text-overline-xs-letter-spacing: 0.08em;
     --text-overline-xs-text-transform: uppercase;
     --text-button-lg-font-family: Sora;
     --text-button-lg-font-size: 0.875rem;
-    --text-button-lg-font-weight: 600;
-    --text-button-lg-line-height: 1;
+    --text-button-lg-font-weight: 400;
+    --text-button-lg-line-height: 1.25;
     --text-button-lg-letter-spacing: 0;
     --text-button-md-font-family: Sora;
     --text-button-md-font-size: 0.75rem;
-    --text-button-md-font-weight: 600;
-    --text-button-md-line-height: 1;
+    --text-button-md-font-weight: 400;
+    --text-button-md-line-height: 1.25;
     --text-button-md-letter-spacing: 0;
     --text-link-font-size: inherit;
     --text-link-line-height: inherit;
@@ -614,8 +624,8 @@
   @media (min-width: 768px) {
     :root, [data-theme=light], .azion.azion-light {
       --text-big-number-md-font-size: 2.25rem;
-      --text-big-number-lg-font-size: 3.75rem;
-      --text-heading-2xl-font-size: 3.75rem;
+      --text-big-number-lg-font-size: 3.5rem;
+      --text-heading-2xl-font-size: 3.5rem;
       --text-heading-xl-font-size: 2.25rem;
       --text-heading-lg-font-size: 1.875rem;
       --text-heading-md-font-size: 1.5rem;
@@ -824,16 +834,16 @@
   .p-spacing-xxs { padding: var(--spacing-xxs); }
 
   /* ── Texts ── */
-  .text-big-number-md { font-size: var(--text-big-number-md-font-size); line-height: var(--text-big-number-md-line-height); font-family: var(--text-big-number-md-font-family); }
-  .text-big-number-sm { font-size: var(--text-big-number-sm-font-size); line-height: var(--text-big-number-sm-line-height); font-family: var(--text-big-number-sm-font-family); }
-  .text-big-number-lg { font-size: var(--text-big-number-lg-font-size); line-height: var(--text-big-number-lg-line-height); font-family: var(--text-big-number-lg-font-family); }
-  .text-heading-2xl { font-size: var(--text-heading-2xl-font-size); line-height: var(--text-heading-2xl-line-height); }
-  .text-heading-xl { font-size: var(--text-heading-xl-font-size); line-height: var(--text-heading-xl-line-height); }
-  .text-heading-lg { font-size: var(--text-heading-lg-font-size); line-height: var(--text-heading-lg-line-height); }
-  .text-heading-md { font-size: var(--text-heading-md-font-size); line-height: var(--text-heading-md-line-height); }
-  .text-heading-sm { font-size: var(--text-heading-sm-font-size); line-height: var(--text-heading-sm-line-height); }
-  .text-heading-xs { font-size: var(--text-heading-xs-font-size); line-height: var(--text-heading-xs-line-height); }
-  .text-heading-xxs { font-size: var(--text-heading-xxs-font-size); line-height: var(--text-heading-xxs-line-height); }
+  .text-big-number-md { font-size: var(--text-big-number-md-font-size); line-height: var(--text-big-number-md-line-height); font-weight: var(--text-big-number-md-font-weight); font-family: var(--text-big-number-md-font-family); }
+  .text-big-number-sm { font-size: var(--text-big-number-sm-font-size); line-height: var(--text-big-number-sm-line-height); font-weight: var(--text-big-number-sm-font-weight); font-family: var(--text-big-number-sm-font-family); }
+  .text-big-number-lg { font-size: var(--text-big-number-lg-font-size); line-height: var(--text-big-number-lg-line-height); font-weight: var(--text-big-number-lg-font-weight); font-family: var(--text-big-number-lg-font-family); }
+  .text-heading-2xl { font-size: var(--text-heading-2xl-font-size); line-height: var(--text-heading-2xl-line-height); font-weight: var(--text-heading-2xl-font-weight); }
+  .text-heading-xl { font-size: var(--text-heading-xl-font-size); line-height: var(--text-heading-xl-line-height); font-weight: var(--text-heading-xl-font-weight); }
+  .text-heading-lg { font-size: var(--text-heading-lg-font-size); line-height: var(--text-heading-lg-line-height); font-weight: var(--text-heading-lg-font-weight); }
+  .text-heading-md { font-size: var(--text-heading-md-font-size); line-height: var(--text-heading-md-line-height); font-weight: var(--text-heading-md-font-weight); }
+  .text-heading-sm { font-size: var(--text-heading-sm-font-size); line-height: var(--text-heading-sm-line-height); font-weight: var(--text-heading-sm-font-weight); }
+  .text-heading-xs { font-size: var(--text-heading-xs-font-size); line-height: var(--text-heading-xs-line-height); font-weight: var(--text-heading-xs-font-weight); }
+  .text-heading-xxs { font-size: var(--text-heading-xxs-font-size); line-height: var(--text-heading-xxs-line-height); font-weight: var(--text-heading-xxs-font-weight); }
   .text-label-lg { font-size: var(--text-label-lg-font-size); line-height: var(--text-label-lg-line-height); font-weight: var(--text-label-lg-font-weight); }
   .text-label-md { font-size: var(--text-label-md-font-size); line-height: var(--text-label-md-line-height); font-weight: var(--text-label-md-font-weight); }
   .text-label-sm { font-size: var(--text-label-sm-font-size); line-height: var(--text-label-sm-line-height); font-weight: var(--text-label-sm-font-weight); }

--- a/packages/theme/dist/v3/globals.css
+++ b/packages/theme/dist/v3/globals.css
@@ -520,10 +520,10 @@
     --text-body-xs-line-height: 1.5;
     --text-tag-sm-font-size: 0.75rem;
     --text-tag-sm-line-height: 1.25;
-    --text-tag-sm-font-weight: 400;
+    --text-tag-sm-font-weight: 600;
     --text-tag-md-font-size: 0.75rem;
     --text-tag-md-line-height: 1.25;
-    --text-tag-md-font-weight: 400;
+    --text-tag-md-font-weight: 600;
     --text-body-xxs-font-size: 0.75rem;
     --text-body-xxs-line-height: 1.5;
     --text-overline-md-font-family: Proto Mono;

--- a/packages/theme/dist/v3/globals.css
+++ b/packages/theme/dist/v3/globals.css
@@ -520,10 +520,10 @@
     --text-body-xs-line-height: 1.5;
     --text-tag-sm-font-size: 0.75rem;
     --text-tag-sm-line-height: 1.25;
-    --text-tag-sm-font-weight: 600;
+    --text-tag-sm-font-weight: 400;
     --text-tag-md-font-size: 0.75rem;
     --text-tag-md-line-height: 1.25;
-    --text-tag-md-font-weight: 600;
+    --text-tag-md-font-weight: 400;
     --text-body-xxs-font-size: 0.75rem;
     --text-body-xxs-line-height: 1.5;
     --text-overline-md-font-family: Proto Mono;

--- a/packages/theme/dist/v3/globals.scss
+++ b/packages/theme/dist/v3/globals.scss
@@ -370,7 +370,7 @@
     --text-4xl--line-height: calc(2.5 / 2.25);
     --text-5xl: 3rem;
     --text-5xl--line-height: 1;
-    --text-6xl: 3.75rem;
+    --text-6xl: 3.5rem;
     --text-6xl--line-height: 1;
     --text-7xl: 4.5rem;
     --text-7xl--line-height: 1;
@@ -469,28 +469,38 @@
 
     /* ── Texts ── */
     --text-big-number-md-font-size: 1.25rem;
-    --text-big-number-md-line-height: 1.20;
+    --text-big-number-md-line-height: 1.25;
+    --text-big-number-md-font-weight: 400;
     --text-big-number-md-font-family: Proto Mono;
     --text-big-number-sm-font-size: 1rem;
-    --text-big-number-sm-line-height: 1.20;
+    --text-big-number-sm-line-height: 1.25;
+    --text-big-number-sm-font-weight: 400;
     --text-big-number-sm-font-family: Proto Mono;
     --text-big-number-lg-font-size: 1.5rem;
-    --text-big-number-lg-line-height: 1.20;
+    --text-big-number-lg-line-height: 1.25;
+    --text-big-number-lg-font-weight: 400;
     --text-big-number-lg-font-family: Proto Mono;
     --text-heading-2xl-font-size: 1.875rem;
-    --text-heading-2xl-line-height: 1.1;
+    --text-heading-2xl-line-height: 1.25;
+    --text-heading-2xl-font-weight: 400;
     --text-heading-xl-font-size: 1.25rem;
-    --text-heading-xl-line-height: 1.1;
+    --text-heading-xl-line-height: 1.25;
+    --text-heading-xl-font-weight: 400;
     --text-heading-lg-font-size: 1.125rem;
-    --text-heading-lg-line-height: 1.2;
+    --text-heading-lg-line-height: 1.25;
+    --text-heading-lg-font-weight: 400;
     --text-heading-md-font-size: 1rem;
-    --text-heading-md-line-height: 1.3;
+    --text-heading-md-line-height: 1.25;
+    --text-heading-md-font-weight: 400;
     --text-heading-sm-font-size: 0.875rem;
-    --text-heading-sm-line-height: 1.4;
+    --text-heading-sm-line-height: 1.375;
+    --text-heading-sm-font-weight: 400;
     --text-heading-xs-font-size: 1rem;
-    --text-heading-xs-line-height: 1.4;
+    --text-heading-xs-line-height: 1.375;
+    --text-heading-xs-font-weight: 400;
     --text-heading-xxs-font-size: 0.875rem;
-    --text-heading-xxs-line-height: 1.4;
+    --text-heading-xxs-line-height: 1.375;
+    --text-heading-xxs-font-weight: 400;
     --text-label-lg-font-size: 1rem;
     --text-label-lg-line-height: 1.5;
     --text-label-lg-font-weight: 500;
@@ -508,38 +518,38 @@
     --text-body-sm-line-height: 1.5;
     --text-body-xs-font-size: 0.75rem;
     --text-body-xs-line-height: 1.5;
-    --text-tag-sm-font-size: 0.6875rem;
-    --text-tag-sm-line-height: 1;
+    --text-tag-sm-font-size: 0.75rem;
+    --text-tag-sm-line-height: 1.25;
     --text-tag-sm-font-weight: 600;
     --text-tag-md-font-size: 0.75rem;
-    --text-tag-md-line-height: 1;
+    --text-tag-md-line-height: 1.25;
     --text-tag-md-font-weight: 600;
-    --text-body-xxs-font-size: 0.625rem;
+    --text-body-xxs-font-size: 0.75rem;
     --text-body-xxs-line-height: 1.5;
     --text-overline-md-font-family: Proto Mono;
     --text-overline-md-font-size: 0.75rem;
-    --text-overline-md-line-height: 1.4;
+    --text-overline-md-line-height: 1.375;
     --text-overline-md-letter-spacing: 0.08em;
     --text-overline-md-text-transform: uppercase;
     --text-overline-sm-font-family: Proto Mono;
     --text-overline-sm-font-size: 0.75rem;
-    --text-overline-sm-line-height: 1.4;
+    --text-overline-sm-line-height: 1.375;
     --text-overline-sm-letter-spacing: 0.08em;
     --text-overline-sm-text-transform: uppercase;
     --text-overline-xs-font-family: Proto Mono;
-    --text-overline-xs-font-size: 0.625rem;
-    --text-overline-xs-line-height: 1.4;
+    --text-overline-xs-font-size: 0.75rem;
+    --text-overline-xs-line-height: 1.375;
     --text-overline-xs-letter-spacing: 0.08em;
     --text-overline-xs-text-transform: uppercase;
     --text-button-lg-font-family: Sora;
     --text-button-lg-font-size: 0.875rem;
-    --text-button-lg-font-weight: 600;
-    --text-button-lg-line-height: 1;
+    --text-button-lg-font-weight: 400;
+    --text-button-lg-line-height: 1.25;
     --text-button-lg-letter-spacing: 0;
     --text-button-md-font-family: Sora;
     --text-button-md-font-size: 0.75rem;
-    --text-button-md-font-weight: 600;
-    --text-button-md-line-height: 1;
+    --text-button-md-font-weight: 400;
+    --text-button-md-line-height: 1.25;
     --text-button-md-letter-spacing: 0;
     --text-link-font-size: inherit;
     --text-link-line-height: inherit;
@@ -614,8 +624,8 @@
   @media (min-width: 768px) {
     :root, [data-theme=light], .azion.azion-light {
       --text-big-number-md-font-size: 2.25rem;
-      --text-big-number-lg-font-size: 3.75rem;
-      --text-heading-2xl-font-size: 3.75rem;
+      --text-big-number-lg-font-size: 3.5rem;
+      --text-heading-2xl-font-size: 3.5rem;
       --text-heading-xl-font-size: 2.25rem;
       --text-heading-lg-font-size: 1.875rem;
       --text-heading-md-font-size: 1.5rem;
@@ -824,16 +834,16 @@
   .p-spacing-xxs { padding: var(--spacing-xxs); }
 
   /* ── Texts ── */
-  .text-big-number-md { font-size: var(--text-big-number-md-font-size); line-height: var(--text-big-number-md-line-height); font-family: var(--text-big-number-md-font-family); }
-  .text-big-number-sm { font-size: var(--text-big-number-sm-font-size); line-height: var(--text-big-number-sm-line-height); font-family: var(--text-big-number-sm-font-family); }
-  .text-big-number-lg { font-size: var(--text-big-number-lg-font-size); line-height: var(--text-big-number-lg-line-height); font-family: var(--text-big-number-lg-font-family); }
-  .text-heading-2xl { font-size: var(--text-heading-2xl-font-size); line-height: var(--text-heading-2xl-line-height); }
-  .text-heading-xl { font-size: var(--text-heading-xl-font-size); line-height: var(--text-heading-xl-line-height); }
-  .text-heading-lg { font-size: var(--text-heading-lg-font-size); line-height: var(--text-heading-lg-line-height); }
-  .text-heading-md { font-size: var(--text-heading-md-font-size); line-height: var(--text-heading-md-line-height); }
-  .text-heading-sm { font-size: var(--text-heading-sm-font-size); line-height: var(--text-heading-sm-line-height); }
-  .text-heading-xs { font-size: var(--text-heading-xs-font-size); line-height: var(--text-heading-xs-line-height); }
-  .text-heading-xxs { font-size: var(--text-heading-xxs-font-size); line-height: var(--text-heading-xxs-line-height); }
+  .text-big-number-md { font-size: var(--text-big-number-md-font-size); line-height: var(--text-big-number-md-line-height); font-weight: var(--text-big-number-md-font-weight); font-family: var(--text-big-number-md-font-family); }
+  .text-big-number-sm { font-size: var(--text-big-number-sm-font-size); line-height: var(--text-big-number-sm-line-height); font-weight: var(--text-big-number-sm-font-weight); font-family: var(--text-big-number-sm-font-family); }
+  .text-big-number-lg { font-size: var(--text-big-number-lg-font-size); line-height: var(--text-big-number-lg-line-height); font-weight: var(--text-big-number-lg-font-weight); font-family: var(--text-big-number-lg-font-family); }
+  .text-heading-2xl { font-size: var(--text-heading-2xl-font-size); line-height: var(--text-heading-2xl-line-height); font-weight: var(--text-heading-2xl-font-weight); }
+  .text-heading-xl { font-size: var(--text-heading-xl-font-size); line-height: var(--text-heading-xl-line-height); font-weight: var(--text-heading-xl-font-weight); }
+  .text-heading-lg { font-size: var(--text-heading-lg-font-size); line-height: var(--text-heading-lg-line-height); font-weight: var(--text-heading-lg-font-weight); }
+  .text-heading-md { font-size: var(--text-heading-md-font-size); line-height: var(--text-heading-md-line-height); font-weight: var(--text-heading-md-font-weight); }
+  .text-heading-sm { font-size: var(--text-heading-sm-font-size); line-height: var(--text-heading-sm-line-height); font-weight: var(--text-heading-sm-font-weight); }
+  .text-heading-xs { font-size: var(--text-heading-xs-font-size); line-height: var(--text-heading-xs-line-height); font-weight: var(--text-heading-xs-font-weight); }
+  .text-heading-xxs { font-size: var(--text-heading-xxs-font-size); line-height: var(--text-heading-xxs-line-height); font-weight: var(--text-heading-xxs-font-weight); }
   .text-label-lg { font-size: var(--text-label-lg-font-size); line-height: var(--text-label-lg-line-height); font-weight: var(--text-label-lg-font-weight); }
   .text-label-md { font-size: var(--text-label-md-font-size); line-height: var(--text-label-md-line-height); font-weight: var(--text-label-md-font-weight); }
   .text-label-sm { font-size: var(--text-label-sm-font-size); line-height: var(--text-label-sm-line-height); font-weight: var(--text-label-sm-font-weight); }

--- a/packages/theme/dist/v3/globals.scss
+++ b/packages/theme/dist/v3/globals.scss
@@ -520,10 +520,10 @@
     --text-body-xs-line-height: 1.5;
     --text-tag-sm-font-size: 0.75rem;
     --text-tag-sm-line-height: 1.25;
-    --text-tag-sm-font-weight: 400;
+    --text-tag-sm-font-weight: 600;
     --text-tag-md-font-size: 0.75rem;
     --text-tag-md-line-height: 1.25;
-    --text-tag-md-font-weight: 400;
+    --text-tag-md-font-weight: 600;
     --text-body-xxs-font-size: 0.75rem;
     --text-body-xxs-line-height: 1.5;
     --text-overline-md-font-family: Proto Mono;

--- a/packages/theme/dist/v3/globals.scss
+++ b/packages/theme/dist/v3/globals.scss
@@ -520,10 +520,10 @@
     --text-body-xs-line-height: 1.5;
     --text-tag-sm-font-size: 0.75rem;
     --text-tag-sm-line-height: 1.25;
-    --text-tag-sm-font-weight: 600;
+    --text-tag-sm-font-weight: 400;
     --text-tag-md-font-size: 0.75rem;
     --text-tag-md-line-height: 1.25;
-    --text-tag-md-font-weight: 600;
+    --text-tag-md-font-weight: 400;
     --text-body-xxs-font-size: 0.75rem;
     --text-body-xxs-line-height: 1.5;
     --text-overline-md-font-family: Proto Mono;

--- a/packages/theme/dist/v3/tailwind-preset.js
+++ b/packages/theme/dist/v3/tailwind-preset.js
@@ -262,61 +262,71 @@ const preset = {
         "big-number-md": [
           "var(--text-big-number-md-font-size)",
           {
-            "lineHeight": "var(--text-big-number-md-line-height)"
+            "lineHeight": "var(--text-big-number-md-line-height)",
+            "fontWeight": "var(--text-big-number-md-font-weight)"
           }
         ],
         "big-number-sm": [
           "var(--text-big-number-sm-font-size)",
           {
-            "lineHeight": "var(--text-big-number-sm-line-height)"
+            "lineHeight": "var(--text-big-number-sm-line-height)",
+            "fontWeight": "var(--text-big-number-sm-font-weight)"
           }
         ],
         "big-number-lg": [
           "var(--text-big-number-lg-font-size)",
           {
-            "lineHeight": "var(--text-big-number-lg-line-height)"
+            "lineHeight": "var(--text-big-number-lg-line-height)",
+            "fontWeight": "var(--text-big-number-lg-font-weight)"
           }
         ],
         "heading-2xl": [
           "var(--text-heading-2xl-font-size)",
           {
-            "lineHeight": "var(--text-heading-2xl-line-height)"
+            "lineHeight": "var(--text-heading-2xl-line-height)",
+            "fontWeight": "var(--text-heading-2xl-font-weight)"
           }
         ],
         "heading-xl": [
           "var(--text-heading-xl-font-size)",
           {
-            "lineHeight": "var(--text-heading-xl-line-height)"
+            "lineHeight": "var(--text-heading-xl-line-height)",
+            "fontWeight": "var(--text-heading-xl-font-weight)"
           }
         ],
         "heading-lg": [
           "var(--text-heading-lg-font-size)",
           {
-            "lineHeight": "var(--text-heading-lg-line-height)"
+            "lineHeight": "var(--text-heading-lg-line-height)",
+            "fontWeight": "var(--text-heading-lg-font-weight)"
           }
         ],
         "heading-md": [
           "var(--text-heading-md-font-size)",
           {
-            "lineHeight": "var(--text-heading-md-line-height)"
+            "lineHeight": "var(--text-heading-md-line-height)",
+            "fontWeight": "var(--text-heading-md-font-weight)"
           }
         ],
         "heading-sm": [
           "var(--text-heading-sm-font-size)",
           {
-            "lineHeight": "var(--text-heading-sm-line-height)"
+            "lineHeight": "var(--text-heading-sm-line-height)",
+            "fontWeight": "var(--text-heading-sm-font-weight)"
           }
         ],
         "heading-xs": [
           "var(--text-heading-xs-font-size)",
           {
-            "lineHeight": "var(--text-heading-xs-line-height)"
+            "lineHeight": "var(--text-heading-xs-line-height)",
+            "fontWeight": "var(--text-heading-xs-font-weight)"
           }
         ],
         "heading-xxs": [
           "var(--text-heading-xxs-font-size)",
           {
-            "lineHeight": "var(--text-heading-xxs-line-height)"
+            "lineHeight": "var(--text-heading-xxs-line-height)",
+            "fontWeight": "var(--text-heading-xxs-font-weight)"
           }
         ],
         "label-lg": [

--- a/packages/theme/dist/v3/tailwind.config.js
+++ b/packages/theme/dist/v3/tailwind.config.js
@@ -270,61 +270,71 @@ module.exports = {
         "big-number-md": [
           "var(--text-big-number-md-font-size)",
           {
-            "lineHeight": "var(--text-big-number-md-line-height)"
+            "lineHeight": "var(--text-big-number-md-line-height)",
+            "fontWeight": "var(--text-big-number-md-font-weight)"
           }
         ],
         "big-number-sm": [
           "var(--text-big-number-sm-font-size)",
           {
-            "lineHeight": "var(--text-big-number-sm-line-height)"
+            "lineHeight": "var(--text-big-number-sm-line-height)",
+            "fontWeight": "var(--text-big-number-sm-font-weight)"
           }
         ],
         "big-number-lg": [
           "var(--text-big-number-lg-font-size)",
           {
-            "lineHeight": "var(--text-big-number-lg-line-height)"
+            "lineHeight": "var(--text-big-number-lg-line-height)",
+            "fontWeight": "var(--text-big-number-lg-font-weight)"
           }
         ],
         "heading-2xl": [
           "var(--text-heading-2xl-font-size)",
           {
-            "lineHeight": "var(--text-heading-2xl-line-height)"
+            "lineHeight": "var(--text-heading-2xl-line-height)",
+            "fontWeight": "var(--text-heading-2xl-font-weight)"
           }
         ],
         "heading-xl": [
           "var(--text-heading-xl-font-size)",
           {
-            "lineHeight": "var(--text-heading-xl-line-height)"
+            "lineHeight": "var(--text-heading-xl-line-height)",
+            "fontWeight": "var(--text-heading-xl-font-weight)"
           }
         ],
         "heading-lg": [
           "var(--text-heading-lg-font-size)",
           {
-            "lineHeight": "var(--text-heading-lg-line-height)"
+            "lineHeight": "var(--text-heading-lg-line-height)",
+            "fontWeight": "var(--text-heading-lg-font-weight)"
           }
         ],
         "heading-md": [
           "var(--text-heading-md-font-size)",
           {
-            "lineHeight": "var(--text-heading-md-line-height)"
+            "lineHeight": "var(--text-heading-md-line-height)",
+            "fontWeight": "var(--text-heading-md-font-weight)"
           }
         ],
         "heading-sm": [
           "var(--text-heading-sm-font-size)",
           {
-            "lineHeight": "var(--text-heading-sm-line-height)"
+            "lineHeight": "var(--text-heading-sm-line-height)",
+            "fontWeight": "var(--text-heading-sm-font-weight)"
           }
         ],
         "heading-xs": [
           "var(--text-heading-xs-font-size)",
           {
-            "lineHeight": "var(--text-heading-xs-line-height)"
+            "lineHeight": "var(--text-heading-xs-line-height)",
+            "fontWeight": "var(--text-heading-xs-font-weight)"
           }
         ],
         "heading-xxs": [
           "var(--text-heading-xxs-font-size)",
           {
-            "lineHeight": "var(--text-heading-xxs-line-height)"
+            "lineHeight": "var(--text-heading-xxs-line-height)",
+            "fontWeight": "var(--text-heading-xxs-font-weight)"
           }
         ],
         "label-lg": [

--- a/packages/theme/dist/v4/globals.css
+++ b/packages/theme/dist/v4/globals.css
@@ -515,10 +515,10 @@
   --text-body-xs-line-height: 1.5;
   --text-tag-sm-font-size: 0.75rem;
   --text-tag-sm-line-height: 1.25;
-  --text-tag-sm-font-weight: 600;
+  --text-tag-sm-font-weight: 400;
   --text-tag-md-font-size: 0.75rem;
   --text-tag-md-line-height: 1.25;
-  --text-tag-md-font-weight: 600;
+  --text-tag-md-font-weight: 400;
   --text-body-xxs-font-size: 0.75rem;
   --text-body-xxs-line-height: 1.5;
   --text-overline-md-font-family: Proto Mono;

--- a/packages/theme/dist/v4/globals.css
+++ b/packages/theme/dist/v4/globals.css
@@ -515,10 +515,10 @@
   --text-body-xs-line-height: 1.5;
   --text-tag-sm-font-size: 0.75rem;
   --text-tag-sm-line-height: 1.25;
-  --text-tag-sm-font-weight: 400;
+  --text-tag-sm-font-weight: 600;
   --text-tag-md-font-size: 0.75rem;
   --text-tag-md-line-height: 1.25;
-  --text-tag-md-font-weight: 400;
+  --text-tag-md-font-weight: 600;
   --text-body-xxs-font-size: 0.75rem;
   --text-body-xxs-line-height: 1.5;
   --text-overline-md-font-family: Proto Mono;

--- a/packages/theme/dist/v4/globals.css
+++ b/packages/theme/dist/v4/globals.css
@@ -371,7 +371,7 @@
   --text-4xl--line-height: calc(2.5 / 2.25);
   --text-5xl: 3rem;
   --text-5xl--line-height: 1;
-  --text-6xl: 3.75rem;
+  --text-6xl: 3.5rem;
   --text-6xl--line-height: 1;
   --text-7xl: 4.5rem;
   --text-7xl--line-height: 1;
@@ -447,6 +447,7 @@
   --animate-ping: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
   --animate-pulse: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
   --animate-bounce: bounce 1s infinite;
+  --animate-shimmer: shimmer 1.6s linear infinite;
   --animate-popup-scale-in: popupScaleIn 150ms cubic-bezier(0.39, 0.57, 0.56, 1);
   --animate-popup-scale-out: popupScaleOut 110ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
   --animate-progress-indeterminate: progressIndeterminate 2100ms cubic-bezier(0.39, 0.57, 0.56, 1) infinite;
@@ -463,28 +464,38 @@
   --spacing-xs: 0.5rem;
   --spacing-xxs: 0.25rem;
   --text-big-number-md-font-size: 1.25rem;
-  --text-big-number-md-line-height: 1.20;
+  --text-big-number-md-line-height: 1.25;
+  --text-big-number-md-font-weight: 400;
   --text-big-number-md-font-family: Proto Mono;
   --text-big-number-sm-font-size: 1rem;
-  --text-big-number-sm-line-height: 1.20;
+  --text-big-number-sm-line-height: 1.25;
+  --text-big-number-sm-font-weight: 400;
   --text-big-number-sm-font-family: Proto Mono;
   --text-big-number-lg-font-size: 1.5rem;
-  --text-big-number-lg-line-height: 1.20;
+  --text-big-number-lg-line-height: 1.25;
+  --text-big-number-lg-font-weight: 400;
   --text-big-number-lg-font-family: Proto Mono;
   --text-heading-2xl-font-size: 1.875rem;
-  --text-heading-2xl-line-height: 1.1;
+  --text-heading-2xl-line-height: 1.25;
+  --text-heading-2xl-font-weight: 400;
   --text-heading-xl-font-size: 1.25rem;
-  --text-heading-xl-line-height: 1.1;
+  --text-heading-xl-line-height: 1.25;
+  --text-heading-xl-font-weight: 400;
   --text-heading-lg-font-size: 1.125rem;
-  --text-heading-lg-line-height: 1.2;
+  --text-heading-lg-line-height: 1.25;
+  --text-heading-lg-font-weight: 400;
   --text-heading-md-font-size: 1rem;
-  --text-heading-md-line-height: 1.3;
+  --text-heading-md-line-height: 1.25;
+  --text-heading-md-font-weight: 400;
   --text-heading-sm-font-size: 0.875rem;
-  --text-heading-sm-line-height: 1.4;
+  --text-heading-sm-line-height: 1.375;
+  --text-heading-sm-font-weight: 400;
   --text-heading-xs-font-size: 1rem;
-  --text-heading-xs-line-height: 1.4;
+  --text-heading-xs-line-height: 1.375;
+  --text-heading-xs-font-weight: 400;
   --text-heading-xxs-font-size: 0.875rem;
-  --text-heading-xxs-line-height: 1.4;
+  --text-heading-xxs-line-height: 1.375;
+  --text-heading-xxs-font-weight: 400;
   --text-label-lg-font-size: 1rem;
   --text-label-lg-line-height: 1.5;
   --text-label-lg-font-weight: 500;
@@ -502,38 +513,38 @@
   --text-body-sm-line-height: 1.5;
   --text-body-xs-font-size: 0.75rem;
   --text-body-xs-line-height: 1.5;
-  --text-tag-sm-font-size: 0.6875rem;
-  --text-tag-sm-line-height: 1;
+  --text-tag-sm-font-size: 0.75rem;
+  --text-tag-sm-line-height: 1.25;
   --text-tag-sm-font-weight: 600;
   --text-tag-md-font-size: 0.75rem;
-  --text-tag-md-line-height: 1;
+  --text-tag-md-line-height: 1.25;
   --text-tag-md-font-weight: 600;
-  --text-body-xxs-font-size: 0.625rem;
+  --text-body-xxs-font-size: 0.75rem;
   --text-body-xxs-line-height: 1.5;
   --text-overline-md-font-family: Proto Mono;
   --text-overline-md-font-size: 0.75rem;
-  --text-overline-md-line-height: 1.4;
+  --text-overline-md-line-height: 1.375;
   --text-overline-md-letter-spacing: 0.08em;
   --text-overline-md-text-transform: uppercase;
   --text-overline-sm-font-family: Proto Mono;
   --text-overline-sm-font-size: 0.75rem;
-  --text-overline-sm-line-height: 1.4;
+  --text-overline-sm-line-height: 1.375;
   --text-overline-sm-letter-spacing: 0.08em;
   --text-overline-sm-text-transform: uppercase;
   --text-overline-xs-font-family: Proto Mono;
-  --text-overline-xs-font-size: 0.625rem;
-  --text-overline-xs-line-height: 1.4;
+  --text-overline-xs-font-size: 0.75rem;
+  --text-overline-xs-line-height: 1.375;
   --text-overline-xs-letter-spacing: 0.08em;
   --text-overline-xs-text-transform: uppercase;
   --text-button-lg-font-family: Sora;
   --text-button-lg-font-size: 0.875rem;
-  --text-button-lg-font-weight: 600;
-  --text-button-lg-line-height: 1;
+  --text-button-lg-font-weight: 400;
+  --text-button-lg-line-height: 1.25;
   --text-button-lg-letter-spacing: 0;
   --text-button-md-font-family: Sora;
   --text-button-md-font-size: 0.75rem;
-  --text-button-md-font-weight: 600;
-  --text-button-md-line-height: 1;
+  --text-button-md-font-weight: 400;
+  --text-button-md-line-height: 1.25;
   --text-button-md-letter-spacing: 0;
   --text-link-font-size: inherit;
   --text-link-line-height: inherit;
@@ -560,8 +571,8 @@
 
   @media (min-width: 768px) {
     --text-big-number-md-font-size: 2.25rem;
-    --text-big-number-lg-font-size: 3.75rem;
-    --text-heading-2xl-font-size: 3.75rem;
+    --text-big-number-lg-font-size: 3.5rem;
+    --text-heading-2xl-font-size: 3.5rem;
     --text-heading-xl-font-size: 2.25rem;
     --text-heading-lg-font-size: 1.875rem;
     --text-heading-md-font-size: 1.5rem;
@@ -601,16 +612,16 @@
   .p-spacing-xxs { padding: var(--spacing-xxs); }
 
   /* ── Texts ── */
-  .text-big-number-md { font-size: var(--text-big-number-md-font-size); line-height: var(--text-big-number-md-line-height); font-family: var(--text-big-number-md-font-family); }
-  .text-big-number-sm { font-size: var(--text-big-number-sm-font-size); line-height: var(--text-big-number-sm-line-height); font-family: var(--text-big-number-sm-font-family); }
-  .text-big-number-lg { font-size: var(--text-big-number-lg-font-size); line-height: var(--text-big-number-lg-line-height); font-family: var(--text-big-number-lg-font-family); }
-  .text-heading-2xl { font-size: var(--text-heading-2xl-font-size); line-height: var(--text-heading-2xl-line-height); }
-  .text-heading-xl { font-size: var(--text-heading-xl-font-size); line-height: var(--text-heading-xl-line-height); }
-  .text-heading-lg { font-size: var(--text-heading-lg-font-size); line-height: var(--text-heading-lg-line-height); }
-  .text-heading-md { font-size: var(--text-heading-md-font-size); line-height: var(--text-heading-md-line-height); }
-  .text-heading-sm { font-size: var(--text-heading-sm-font-size); line-height: var(--text-heading-sm-line-height); }
-  .text-heading-xs { font-size: var(--text-heading-xs-font-size); line-height: var(--text-heading-xs-line-height); }
-  .text-heading-xxs { font-size: var(--text-heading-xxs-font-size); line-height: var(--text-heading-xxs-line-height); }
+  .text-big-number-md { font-size: var(--text-big-number-md-font-size); line-height: var(--text-big-number-md-line-height); font-weight: var(--text-big-number-md-font-weight); font-family: var(--text-big-number-md-font-family); }
+  .text-big-number-sm { font-size: var(--text-big-number-sm-font-size); line-height: var(--text-big-number-sm-line-height); font-weight: var(--text-big-number-sm-font-weight); font-family: var(--text-big-number-sm-font-family); }
+  .text-big-number-lg { font-size: var(--text-big-number-lg-font-size); line-height: var(--text-big-number-lg-line-height); font-weight: var(--text-big-number-lg-font-weight); font-family: var(--text-big-number-lg-font-family); }
+  .text-heading-2xl { font-size: var(--text-heading-2xl-font-size); line-height: var(--text-heading-2xl-line-height); font-weight: var(--text-heading-2xl-font-weight); }
+  .text-heading-xl { font-size: var(--text-heading-xl-font-size); line-height: var(--text-heading-xl-line-height); font-weight: var(--text-heading-xl-font-weight); }
+  .text-heading-lg { font-size: var(--text-heading-lg-font-size); line-height: var(--text-heading-lg-line-height); font-weight: var(--text-heading-lg-font-weight); }
+  .text-heading-md { font-size: var(--text-heading-md-font-size); line-height: var(--text-heading-md-line-height); font-weight: var(--text-heading-md-font-weight); }
+  .text-heading-sm { font-size: var(--text-heading-sm-font-size); line-height: var(--text-heading-sm-line-height); font-weight: var(--text-heading-sm-font-weight); }
+  .text-heading-xs { font-size: var(--text-heading-xs-font-size); line-height: var(--text-heading-xs-line-height); font-weight: var(--text-heading-xs-font-weight); }
+  .text-heading-xxs { font-size: var(--text-heading-xxs-font-size); line-height: var(--text-heading-xxs-line-height); font-weight: var(--text-heading-xxs-font-weight); }
   .text-label-lg { font-size: var(--text-label-lg-font-size); line-height: var(--text-label-lg-line-height); font-weight: var(--text-label-lg-font-weight); }
   .text-label-md { font-size: var(--text-label-md-font-size); line-height: var(--text-label-md-line-height); font-weight: var(--text-label-md-font-weight); }
   .text-label-sm { font-size: var(--text-label-sm-font-size); line-height: var(--text-label-sm-line-height); font-weight: var(--text-label-sm-font-weight); }

--- a/packages/theme/dist/v4/globals.scss
+++ b/packages/theme/dist/v4/globals.scss
@@ -515,10 +515,10 @@
   --text-body-xs-line-height: 1.5;
   --text-tag-sm-font-size: 0.75rem;
   --text-tag-sm-line-height: 1.25;
-  --text-tag-sm-font-weight: 600;
+  --text-tag-sm-font-weight: 400;
   --text-tag-md-font-size: 0.75rem;
   --text-tag-md-line-height: 1.25;
-  --text-tag-md-font-weight: 600;
+  --text-tag-md-font-weight: 400;
   --text-body-xxs-font-size: 0.75rem;
   --text-body-xxs-line-height: 1.5;
   --text-overline-md-font-family: Proto Mono;

--- a/packages/theme/dist/v4/globals.scss
+++ b/packages/theme/dist/v4/globals.scss
@@ -515,10 +515,10 @@
   --text-body-xs-line-height: 1.5;
   --text-tag-sm-font-size: 0.75rem;
   --text-tag-sm-line-height: 1.25;
-  --text-tag-sm-font-weight: 400;
+  --text-tag-sm-font-weight: 600;
   --text-tag-md-font-size: 0.75rem;
   --text-tag-md-line-height: 1.25;
-  --text-tag-md-font-weight: 400;
+  --text-tag-md-font-weight: 600;
   --text-body-xxs-font-size: 0.75rem;
   --text-body-xxs-line-height: 1.5;
   --text-overline-md-font-family: Proto Mono;

--- a/packages/theme/dist/v4/globals.scss
+++ b/packages/theme/dist/v4/globals.scss
@@ -371,7 +371,7 @@
   --text-4xl--line-height: calc(2.5 / 2.25);
   --text-5xl: 3rem;
   --text-5xl--line-height: 1;
-  --text-6xl: 3.75rem;
+  --text-6xl: 3.5rem;
   --text-6xl--line-height: 1;
   --text-7xl: 4.5rem;
   --text-7xl--line-height: 1;
@@ -447,6 +447,7 @@
   --animate-ping: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
   --animate-pulse: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
   --animate-bounce: bounce 1s infinite;
+  --animate-shimmer: shimmer 1.6s linear infinite;
   --animate-popup-scale-in: popupScaleIn 150ms cubic-bezier(0.39, 0.57, 0.56, 1);
   --animate-popup-scale-out: popupScaleOut 110ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
   --animate-progress-indeterminate: progressIndeterminate 2100ms cubic-bezier(0.39, 0.57, 0.56, 1) infinite;
@@ -463,28 +464,38 @@
   --spacing-xs: 0.5rem;
   --spacing-xxs: 0.25rem;
   --text-big-number-md-font-size: 1.25rem;
-  --text-big-number-md-line-height: 1.20;
+  --text-big-number-md-line-height: 1.25;
+  --text-big-number-md-font-weight: 400;
   --text-big-number-md-font-family: Proto Mono;
   --text-big-number-sm-font-size: 1rem;
-  --text-big-number-sm-line-height: 1.20;
+  --text-big-number-sm-line-height: 1.25;
+  --text-big-number-sm-font-weight: 400;
   --text-big-number-sm-font-family: Proto Mono;
   --text-big-number-lg-font-size: 1.5rem;
-  --text-big-number-lg-line-height: 1.20;
+  --text-big-number-lg-line-height: 1.25;
+  --text-big-number-lg-font-weight: 400;
   --text-big-number-lg-font-family: Proto Mono;
   --text-heading-2xl-font-size: 1.875rem;
-  --text-heading-2xl-line-height: 1.1;
+  --text-heading-2xl-line-height: 1.25;
+  --text-heading-2xl-font-weight: 400;
   --text-heading-xl-font-size: 1.25rem;
-  --text-heading-xl-line-height: 1.1;
+  --text-heading-xl-line-height: 1.25;
+  --text-heading-xl-font-weight: 400;
   --text-heading-lg-font-size: 1.125rem;
-  --text-heading-lg-line-height: 1.2;
+  --text-heading-lg-line-height: 1.25;
+  --text-heading-lg-font-weight: 400;
   --text-heading-md-font-size: 1rem;
-  --text-heading-md-line-height: 1.3;
+  --text-heading-md-line-height: 1.25;
+  --text-heading-md-font-weight: 400;
   --text-heading-sm-font-size: 0.875rem;
-  --text-heading-sm-line-height: 1.4;
+  --text-heading-sm-line-height: 1.375;
+  --text-heading-sm-font-weight: 400;
   --text-heading-xs-font-size: 1rem;
-  --text-heading-xs-line-height: 1.4;
+  --text-heading-xs-line-height: 1.375;
+  --text-heading-xs-font-weight: 400;
   --text-heading-xxs-font-size: 0.875rem;
-  --text-heading-xxs-line-height: 1.4;
+  --text-heading-xxs-line-height: 1.375;
+  --text-heading-xxs-font-weight: 400;
   --text-label-lg-font-size: 1rem;
   --text-label-lg-line-height: 1.5;
   --text-label-lg-font-weight: 500;
@@ -502,38 +513,38 @@
   --text-body-sm-line-height: 1.5;
   --text-body-xs-font-size: 0.75rem;
   --text-body-xs-line-height: 1.5;
-  --text-tag-sm-font-size: 0.6875rem;
-  --text-tag-sm-line-height: 1;
+  --text-tag-sm-font-size: 0.75rem;
+  --text-tag-sm-line-height: 1.25;
   --text-tag-sm-font-weight: 600;
   --text-tag-md-font-size: 0.75rem;
-  --text-tag-md-line-height: 1;
+  --text-tag-md-line-height: 1.25;
   --text-tag-md-font-weight: 600;
-  --text-body-xxs-font-size: 0.625rem;
+  --text-body-xxs-font-size: 0.75rem;
   --text-body-xxs-line-height: 1.5;
   --text-overline-md-font-family: Proto Mono;
   --text-overline-md-font-size: 0.75rem;
-  --text-overline-md-line-height: 1.4;
+  --text-overline-md-line-height: 1.375;
   --text-overline-md-letter-spacing: 0.08em;
   --text-overline-md-text-transform: uppercase;
   --text-overline-sm-font-family: Proto Mono;
   --text-overline-sm-font-size: 0.75rem;
-  --text-overline-sm-line-height: 1.4;
+  --text-overline-sm-line-height: 1.375;
   --text-overline-sm-letter-spacing: 0.08em;
   --text-overline-sm-text-transform: uppercase;
   --text-overline-xs-font-family: Proto Mono;
-  --text-overline-xs-font-size: 0.625rem;
-  --text-overline-xs-line-height: 1.4;
+  --text-overline-xs-font-size: 0.75rem;
+  --text-overline-xs-line-height: 1.375;
   --text-overline-xs-letter-spacing: 0.08em;
   --text-overline-xs-text-transform: uppercase;
   --text-button-lg-font-family: Sora;
   --text-button-lg-font-size: 0.875rem;
-  --text-button-lg-font-weight: 600;
-  --text-button-lg-line-height: 1;
+  --text-button-lg-font-weight: 400;
+  --text-button-lg-line-height: 1.25;
   --text-button-lg-letter-spacing: 0;
   --text-button-md-font-family: Sora;
   --text-button-md-font-size: 0.75rem;
-  --text-button-md-font-weight: 600;
-  --text-button-md-line-height: 1;
+  --text-button-md-font-weight: 400;
+  --text-button-md-line-height: 1.25;
   --text-button-md-letter-spacing: 0;
   --text-link-font-size: inherit;
   --text-link-line-height: inherit;
@@ -560,8 +571,8 @@
 
   @media (min-width: 768px) {
     --text-big-number-md-font-size: 2.25rem;
-    --text-big-number-lg-font-size: 3.75rem;
-    --text-heading-2xl-font-size: 3.75rem;
+    --text-big-number-lg-font-size: 3.5rem;
+    --text-heading-2xl-font-size: 3.5rem;
     --text-heading-xl-font-size: 2.25rem;
     --text-heading-lg-font-size: 1.875rem;
     --text-heading-md-font-size: 1.5rem;
@@ -601,16 +612,16 @@
   .p-spacing-xxs { padding: var(--spacing-xxs); }
 
   /* ── Texts ── */
-  .text-big-number-md { font-size: var(--text-big-number-md-font-size); line-height: var(--text-big-number-md-line-height); font-family: var(--text-big-number-md-font-family); }
-  .text-big-number-sm { font-size: var(--text-big-number-sm-font-size); line-height: var(--text-big-number-sm-line-height); font-family: var(--text-big-number-sm-font-family); }
-  .text-big-number-lg { font-size: var(--text-big-number-lg-font-size); line-height: var(--text-big-number-lg-line-height); font-family: var(--text-big-number-lg-font-family); }
-  .text-heading-2xl { font-size: var(--text-heading-2xl-font-size); line-height: var(--text-heading-2xl-line-height); }
-  .text-heading-xl { font-size: var(--text-heading-xl-font-size); line-height: var(--text-heading-xl-line-height); }
-  .text-heading-lg { font-size: var(--text-heading-lg-font-size); line-height: var(--text-heading-lg-line-height); }
-  .text-heading-md { font-size: var(--text-heading-md-font-size); line-height: var(--text-heading-md-line-height); }
-  .text-heading-sm { font-size: var(--text-heading-sm-font-size); line-height: var(--text-heading-sm-line-height); }
-  .text-heading-xs { font-size: var(--text-heading-xs-font-size); line-height: var(--text-heading-xs-line-height); }
-  .text-heading-xxs { font-size: var(--text-heading-xxs-font-size); line-height: var(--text-heading-xxs-line-height); }
+  .text-big-number-md { font-size: var(--text-big-number-md-font-size); line-height: var(--text-big-number-md-line-height); font-weight: var(--text-big-number-md-font-weight); font-family: var(--text-big-number-md-font-family); }
+  .text-big-number-sm { font-size: var(--text-big-number-sm-font-size); line-height: var(--text-big-number-sm-line-height); font-weight: var(--text-big-number-sm-font-weight); font-family: var(--text-big-number-sm-font-family); }
+  .text-big-number-lg { font-size: var(--text-big-number-lg-font-size); line-height: var(--text-big-number-lg-line-height); font-weight: var(--text-big-number-lg-font-weight); font-family: var(--text-big-number-lg-font-family); }
+  .text-heading-2xl { font-size: var(--text-heading-2xl-font-size); line-height: var(--text-heading-2xl-line-height); font-weight: var(--text-heading-2xl-font-weight); }
+  .text-heading-xl { font-size: var(--text-heading-xl-font-size); line-height: var(--text-heading-xl-line-height); font-weight: var(--text-heading-xl-font-weight); }
+  .text-heading-lg { font-size: var(--text-heading-lg-font-size); line-height: var(--text-heading-lg-line-height); font-weight: var(--text-heading-lg-font-weight); }
+  .text-heading-md { font-size: var(--text-heading-md-font-size); line-height: var(--text-heading-md-line-height); font-weight: var(--text-heading-md-font-weight); }
+  .text-heading-sm { font-size: var(--text-heading-sm-font-size); line-height: var(--text-heading-sm-line-height); font-weight: var(--text-heading-sm-font-weight); }
+  .text-heading-xs { font-size: var(--text-heading-xs-font-size); line-height: var(--text-heading-xs-line-height); font-weight: var(--text-heading-xs-font-weight); }
+  .text-heading-xxs { font-size: var(--text-heading-xxs-font-size); line-height: var(--text-heading-xxs-line-height); font-weight: var(--text-heading-xxs-font-weight); }
   .text-label-lg { font-size: var(--text-label-lg-font-size); line-height: var(--text-label-lg-line-height); font-weight: var(--text-label-lg-font-weight); }
   .text-label-md { font-size: var(--text-label-md-font-size); line-height: var(--text-label-md-line-height); font-weight: var(--text-label-md-font-weight); }
   .text-label-sm { font-size: var(--text-label-sm-font-size); line-height: var(--text-label-sm-line-height); font-weight: var(--text-label-sm-font-weight); }

--- a/packages/theme/src/tokens/primitives/typography/font-size.js
+++ b/packages/theme/src/tokens/primitives/typography/font-size.js
@@ -17,7 +17,7 @@ export const fontSize = {
   '4xl--line-height': 'calc(2.5 / 2.25)',
   '5xl': '3rem',
   '5xl--line-height': '1',
-  '6xl': '3.75rem',
+  '6xl': '3.5rem',
   '6xl--line-height': '1',
   '7xl': '4.5rem',
   '7xl--line-height': '1',

--- a/packages/theme/src/tokens/semantic/texts.data.js
+++ b/packages/theme/src/tokens/semantic/texts.data.js
@@ -108,12 +108,12 @@ export const textsData = {
   'text-tag-sm': {
     fontSize: fontSize.xs,
     lineHeight: leading.tight,
-    fontWeight: fontWeight.semibold
+    fontWeight: fontWeight.normal
   },
   'text-tag-md': {
     fontSize: fontSize.xs,
     lineHeight: leading.tight,
-    fontWeight: fontWeight.semibold
+    fontWeight: fontWeight.normal
   },
   'text-body-xxs': {
     fontSize: fontSize.xs,

--- a/packages/theme/src/tokens/semantic/texts.data.js
+++ b/packages/theme/src/tokens/semantic/texts.data.js
@@ -16,129 +16,142 @@
  */
 
 import { fontFamily } from '../primitives/typography/font-family.js'
+import { fontSize } from '../primitives/typography/font-size.js'
+import { fontWeight } from '../primitives/typography/font-weight.js'
+import { leading } from '../primitives/typography/leading.js'
 
 export const textsData = {
   'text-big-number-md': {
-    fontSize: { _: '1.25rem', sm: '1.5rem', md: '2.25rem' },
-    lineHeight: '1.20',
+    fontSize: { _: fontSize.xl, sm: fontSize['2xl'], md: fontSize['4xl'] },
+    lineHeight: leading.tight,
+    fontWeight: fontWeight.normal,
     fontFamily: fontFamily.display
   },
   'text-big-number-sm': {
-    fontSize: { _: '1rem', sm: '1.25rem' },
-    lineHeight: '1.20',
+    fontSize: { _: fontSize.base, sm: fontSize.xl },
+    lineHeight: leading.tight,
+    fontWeight: fontWeight.normal,
     fontFamily: fontFamily.display
   },
   'text-big-number-lg': {
-    fontSize: { _: '1.5rem', sm: '2.25rem', md: '3.75rem' },
-    lineHeight: '1.20',
+    fontSize: { _: fontSize['2xl'], sm: fontSize['4xl'], md: fontSize['6xl'] },
+    lineHeight: leading.tight,
+    fontWeight: fontWeight.normal,
     fontFamily: fontFamily.display
   },
   'text-heading-2xl': {
-    fontSize: { _: '1.875rem', sm: '3rem', md: '3.75rem' },
-    lineHeight: '1.1'
+    fontSize: { _: fontSize['3xl'], sm: fontSize['5xl'], md: fontSize['6xl'] },
+    lineHeight: leading.tight,
+    fontWeight: fontWeight.normal
   },
   'text-heading-xl': {
-    fontSize: { _: '1.25rem', sm: '1.875rem', md: '2.25rem' },
-    lineHeight: '1.1'
+    fontSize: { _: fontSize.xl, sm: fontSize['3xl'], md: fontSize['4xl'] },
+    lineHeight: leading.tight,
+    fontWeight: fontWeight.normal
   },
   'text-heading-lg': {
-    fontSize: { _: '1.125rem', md: '1.875rem' },
-    lineHeight: '1.2'
+    fontSize: { _: fontSize.lg, md: fontSize['3xl'] },
+    lineHeight: leading.tight,
+    fontWeight: fontWeight.normal
   },
   'text-heading-md': {
-    fontSize: { _: '1rem', sm: '1.25rem', md: '1.5rem' },
-    lineHeight: '1.3'
+    fontSize: { _: fontSize.base, sm: fontSize.xl, md: fontSize['2xl'] },
+    lineHeight: leading.tight,
+    fontWeight: fontWeight.normal
   },
   'text-heading-sm': {
-    fontSize: { _: '0.875rem', sm: '1rem', md: '1.125rem' },
-    lineHeight: '1.4'
+    fontSize: { _: fontSize.sm, sm: fontSize.base, md: fontSize.lg },
+    lineHeight: leading.snug,
+    fontWeight: fontWeight.normal
   },
   'text-heading-xs': {
-    fontSize: '1rem',
-    lineHeight: '1.4'
+    fontSize: fontSize.base,
+    lineHeight: leading.snug,
+    fontWeight: fontWeight.normal
   },
   'text-heading-xxs': {
-    fontSize: '0.875rem',
-    lineHeight: '1.4'
+    fontSize: fontSize.sm,
+    lineHeight: leading.snug,
+    fontWeight: fontWeight.normal
   },
   'text-label-lg': {
-    fontSize: '1rem',
-    lineHeight: '1.5',
-    fontWeight: '500'
+    fontSize: fontSize.base,
+    lineHeight: leading.normal,
+    fontWeight: fontWeight.medium
   },
   'text-label-md': {
-    fontSize: '0.875rem',
-    lineHeight: '1.5',
-    fontWeight: '500'
+    fontSize: fontSize.sm,
+    lineHeight: leading.normal,
+    fontWeight: fontWeight.medium
   },
   'text-label-sm': {
-    fontSize: '0.75rem',
-    lineHeight: '1.5',
-    fontWeight: '500'
+    fontSize: fontSize.xs,
+    lineHeight: leading.normal,
+    fontWeight: fontWeight.medium
   },
   'text-body-lg': {
-    fontSize: { _: '1rem', md: '1.125rem' },
-    lineHeight: '1.5'
+    fontSize: { _: fontSize.base, md: fontSize.lg },
+    lineHeight: leading.normal
   },
   'text-body-md': {
-    fontSize: '1rem',
-    lineHeight: '1.5'
+    fontSize: fontSize.base,
+    lineHeight: leading.normal
   },
   'text-body-sm': {
-    fontSize: '0.875rem',
-    lineHeight: '1.5'
+    fontSize: fontSize.sm,
+    lineHeight: leading.normal
   },
   'text-body-xs': {
-    fontSize: '0.75rem',
-    lineHeight: '1.5'
+    fontSize: fontSize.xs,
+    lineHeight: leading.normal
   },
   'text-tag-sm': {
-    fontSize: '0.6875rem',
-    lineHeight: '1',
-    fontWeight: '600'
+    fontSize: fontSize.xs,
+    lineHeight: leading.tight,
+    fontWeight: fontWeight.semibold
   },
   'text-tag-md': {
-    fontSize: '0.75rem',
-    lineHeight: '1',
-    fontWeight: '600'
+    fontSize: fontSize.xs,
+    lineHeight: leading.tight,
+    fontWeight: fontWeight.semibold
   },
   'text-body-xxs': {
-    fontSize: '0.625rem',
-    lineHeight: '1.5'
+    fontSize: fontSize.xs,
+    lineHeight: leading.normal
   },
   'text-overline-md': {
     fontFamily: fontFamily.display,
-    fontSize: { _: '0.75rem', sm: '0.875rem' },
-    lineHeight: '1.4',
+    fontSize: { _: fontSize.xs, sm: fontSize.sm },
+    lineHeight: leading.snug,
     letterSpacing: '0.08em',
     textTransform: 'uppercase'
   },
   'text-overline-sm': {
     fontFamily: fontFamily.display,
-    fontSize: '0.75rem',
-    lineHeight: '1.4',
+    fontSize: fontSize.xs,
+    lineHeight: leading.snug,
     letterSpacing: '0.08em',
     textTransform: 'uppercase'
   },
   'text-overline-xs': {
     fontFamily: fontFamily.display,
-    fontSize: '0.625rem',
-    lineHeight: '1.4',
+    fontSize: fontSize.xs,
+    lineHeight: leading.snug,
     letterSpacing: '0.08em',
     textTransform: 'uppercase'
   },
   'text-button-lg': {
     fontFamily: fontFamily.sans,
-    fontSize: '0.875rem',
-    fontWeight: '600',
-    lineHeight: '1',
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.normal,
+    lineHeight: leading.tight,
     letterSpacing: '0'
   },
   'text-button-md': {
     fontFamily: fontFamily.sans,
-    fontSize: '0.75rem',
-    fontWeight: '600',
-    lineHeight: '1',
+    fontSize: fontSize.xs,
+    fontWeight: fontWeight.normal,
+    lineHeight: leading.tight,
     letterSpacing: '0'
   },
   /** Inline `<a>` in body/heading — inherits parent size; not the navigation Link component. */

--- a/packages/theme/src/tokens/semantic/texts.data.js
+++ b/packages/theme/src/tokens/semantic/texts.data.js
@@ -108,12 +108,12 @@ export const textsData = {
   'text-tag-sm': {
     fontSize: fontSize.xs,
     lineHeight: leading.tight,
-    fontWeight: fontWeight.normal
+    fontWeight: fontWeight.semibold
   },
   'text-tag-md': {
     fontSize: fontSize.xs,
     lineHeight: leading.tight,
-    fontWeight: fontWeight.normal
+    fontWeight: fontWeight.semibold
   },
   'text-body-xxs': {
     fontSize: fontSize.xs,


### PR DESCRIPTION
## Summary

Rewires the semantic typography tokens (`packages/theme/src/tokens/semantic/texts.data.js`) to consume the primitive typography aliases instead of hardcoded literals, and lowers the `6xl` font-size primitive.

- **font-weight** — every text type now declares a weight via the `fontWeight` alias. Types that previously had none get `fontWeight.normal` (400); existing weights are aliased: labels → `medium` (500), tags → `semibold` (600), buttons → `normal` (400). `text-link` is untouched (inherits).
- **line-height** — unitless ratios replaced with the `leading` alias, mapped to the nearest value (`tight` 1.25, `snug` 1.375, `normal` 1.5).
- **font-size** — replaced with the `fontSize` alias. Exact matches everywhere except the three sub-0.75rem sizes (`text-tag-sm`, `text-body-xxs`, `text-overline-xs`), which round up to `xs` (0.75rem).
- **`fontSize['6xl']`** `3.75rem` (60px) → `3.5rem` (56px), keeping the rem convention.
- Rebuilt `dist/v3` + `dist/v4`.

## Notes

Worth a reviewer's eye — aliasing to "nearest value" shifts some emitted output:
- `text-tag-*` / `text-button-*` line-height `1` → `1.25`.
- Headings at `1.1` → `1.25`.
- Sub-0.75rem sizes collapse into `xs`, so `text-body-xxs` == `text-body-xs` and `text-tag-sm` == `text-tag-md` in size. If those distinctions must be preserved, the `font-size` primitive needs smaller entries (e.g. a `2xs`).

No new dependencies. No breaking API changes (token class names unchanged).
