### PR TITLE
refactor(webkit)!: navigation activation events emit (event, item)

### DIFF
--- a/.specs/breadcrumb-item.md
+++ b/.specs/breadcrumb-item.md
@@ -33,7 +33,7 @@ Single segment in a breadcrumb trail. Ancestor segments use muted label text and
 
 | Event | Payload | Notes |
 |---|---|---|
-| `click` | `MouseEvent` | Fires when the segment is activated (link or button). |
+| `click` | `(event: MouseEvent, item: { label: string; href: string })` | Fires when the segment is activated (link or button). `item` carries the segment's `label` and `href`. |
 
 ## Slots
 

--- a/.specs/breadcrumb.md
+++ b/.specs/breadcrumb.md
@@ -37,7 +37,7 @@ Shows the page hierarchy so users can navigate back to parent views. Composes `B
 
 | Event | Payload | Notes |
 |---|---|---|
-| `navigate` | `href: string` | Fires when an ancestor segment is activated. |
+| `navigate` | `(event: MouseEvent, href: string)` | Fires when an ancestor segment is activated. `event` is the activation event; `href` is the segment's destination. |
 
 ## Slots
 

--- a/.specs/dropdown.md
+++ b/.specs/dropdown.md
@@ -91,7 +91,7 @@ import DropdownOption from '@aziontech/webkit/dropdown-option'
 | Event | Payload | Notes |
 |---|---|---|
 | `update:open` | `boolean` | Fires on every open/closed transition; supports `v-model:open`. |
-| `select` | `{ value: string \| number; event: MouseEvent \| KeyboardEvent }` | Fires when an enabled option is activated (click, `Enter`/`Space`, or a `command` shortcut). The panel closes automatically and focus returns to the trigger when activated from inside the open panel. |
+| `select` | `(event: MouseEvent \| KeyboardEvent, value: string \| number)` | Fires when an enabled option is activated (click, `Enter`/`Space`, or a `command` shortcut). `event` is the activation event; `value` is the activated option's identifier. The panel closes automatically and focus returns to the trigger when activated from inside the open panel. |
 
 ## Slots
 

--- a/.specs/menu-item.md
+++ b/.specs/menu-item.md
@@ -25,7 +25,7 @@ Helps users move between views or sections. Migrated from the existing implement
 
 | Event | Payload | Notes |
 |---|---|---|
-| `click` | `event: MouseEvent` | — |
+| `click` | `(event: MouseEvent, item: { label: string; href: string })` | `item` carries the menu item's `label` and `href`, identifying which item was activated. |
 
 ## Slots
 

--- a/.specs/split-button.md
+++ b/.specs/split-button.md
@@ -61,7 +61,7 @@ const items = [
 | Event | Payload | Notes |
 |---|---|---|
 | `click` | `(event: MouseEvent, item: SplitButtonItem \| null)` | Fired by the primary command button on activation. `item` is the action currently mirrored on the primary segment when `updateLabelOnSelect` is on, otherwise `null`. Never fires while `disabled` or `loading`. |
-| `item-click` | `SplitButtonItem` | Fired when a menu action is selected; carries the matched `model` item. The menu cannot open while `disabled` or `loading`, so it never fires in those states. |
+| `item-click` | `(event: MouseEvent \| KeyboardEvent, item: SplitButtonItem)` | Fired when a menu action is selected. `event` is the pointer/keyboard event that activated the option; `item` is the matched `model` entry. The menu cannot open while `disabled` or `loading`, so it never fires in those states. |
 
 ## Slots
 

--- a/apps/storybook/src/stories/components/actions/split-button/SplitButton.stories.js
+++ b/apps/storybook/src/stories/components/actions/split-button/SplitButton.stories.js
@@ -113,8 +113,12 @@ const meta = {
     },
     onItemClick: {
       action: 'item-click',
-      description: 'Fired when a menu action is selected; carries the matched model item.',
-      table: { category: 'events', type: { summary: 'SplitButtonItem' } }
+      description:
+        'Fired when a menu action is selected; carries the activation event and the matched model item.',
+      table: {
+        category: 'events',
+        type: { summary: '(event: MouseEvent | KeyboardEvent, item: SplitButtonItem)' }
+      }
     }
   },
   args: {

--- a/apps/storybook/src/stories/components/navigation/Breadcrumb.stories.js
+++ b/apps/storybook/src/stories/components/navigation/Breadcrumb.stories.js
@@ -43,8 +43,11 @@ const meta = {
     },
     onNavigate: {
       action: 'navigate',
-      description: 'Fires when an ancestor segment is activated.',
-      table: { type: { summary: 'string' }, category: 'events' }
+      description: 'Fires when an ancestor segment is activated; carries the event and the href.',
+      table: {
+        type: { summary: '(event: MouseEvent, href: string)' },
+        category: 'events'
+      }
     },
     default: {
       control: false,

--- a/apps/storybook/src/stories/components/navigation/BreadcrumbItem.stories.js
+++ b/apps/storybook/src/stories/components/navigation/BreadcrumbItem.stories.js
@@ -56,8 +56,11 @@ const meta = {
     },
     onClick: {
       action: 'click',
-      description: 'Fires when the segment is activated.',
-      table: { type: { summary: 'MouseEvent' }, category: 'events' }
+      description: 'Fires when the segment is activated; carries the segment label and href.',
+      table: {
+        type: { summary: '(event: MouseEvent, item: { label: string; href: string })' },
+        category: 'events'
+      }
     }
   },
   args: {

--- a/apps/storybook/src/stories/components/navigation/MenuItem.stories.js
+++ b/apps/storybook/src/stories/components/navigation/MenuItem.stories.js
@@ -108,9 +108,9 @@ const meta = {
     },
     onClick: {
       action: 'click',
-      description: 'Emitted when an option row is activated.',
+      description: 'Emitted when an option row is activated; carries the item label and href.',
       table: {
-        type: { summary: '(event: MouseEvent) => void' },
+        type: { summary: '(event: MouseEvent, item: { label: string; href: string })' },
         category: 'events'
       }
     },

--- a/apps/storybook/src/stories/components/navigation/dropdown/Dropdown.stories.js
+++ b/apps/storybook/src/stories/components/navigation/dropdown/Dropdown.stories.js
@@ -100,7 +100,7 @@ const meta = {
       description: 'Fires when an enabled option is activated. The panel closes automatically.',
       table: {
         category: 'events',
-        type: { summary: '{ value: string | number; event: MouseEvent | KeyboardEvent }' }
+        type: { summary: '(event: MouseEvent | KeyboardEvent, value: string | number)' }
       }
     }
   },

--- a/packages/webkit/src/components/actions/split-button/split-button.vue
+++ b/packages/webkit/src/components/actions/split-button/split-button.vue
@@ -56,7 +56,7 @@
 
   const emit = defineEmits<{
     click: [event: MouseEvent, item: SplitButtonItem | null]
-    'item-click': [item: SplitButtonItem]
+    'item-click': [event: MouseEvent | KeyboardEvent, item: SplitButtonItem]
   }>()
 
   const attrs = useAttrs()
@@ -97,14 +97,14 @@
     emit('click', event, selectedItem.value)
   }
 
-  function onSelect(payload: { value: string | number }) {
-    const item = props.model.find((entry) => optionValue(entry) === String(payload.value))
+  function onSelect(event: MouseEvent | KeyboardEvent, value: string | number) {
+    const item = props.model.find((entry) => optionValue(entry) === String(value))
 
     if (item) {
       if (props.updateLabelOnSelect) {
         selectedValue.value = optionValue(item)
       }
-      emit('item-click', item)
+      emit('item-click', event, item)
     }
   }
 </script>

--- a/packages/webkit/src/components/navigation/breadcrumb-item/breadcrumb-item.vue
+++ b/packages/webkit/src/components/navigation/breadcrumb-item/breadcrumb-item.vue
@@ -37,7 +37,7 @@
   })
 
   const emit = defineEmits<{
-    click: [event: MouseEvent]
+    click: [event: MouseEvent, item: { label: string; href: string }]
   }>()
 
   const attrs = useAttrs()
@@ -61,7 +61,7 @@
       return
     }
 
-    emit('click', event)
+    emit('click', event, { label: props.label, href: props.href })
   }
 </script>
 

--- a/packages/webkit/src/components/navigation/breadcrumb/breadcrumb.vue
+++ b/packages/webkit/src/components/navigation/breadcrumb/breadcrumb.vue
@@ -32,7 +32,7 @@
   })
 
   const emit = defineEmits<{
-    navigate: [href: string]
+    navigate: [event: MouseEvent, href: string]
   }>()
 
   defineSlots<{
@@ -71,14 +71,17 @@
     () => resolvedItems.value.length > 1 && firstItem.value !== lastItem.value
   )
 
-  const handleItemClick = (href: string) => {
-    emit('navigate', href)
+  const handleItemClick = (event: MouseEvent, href: string) => {
+    emit('navigate', event, href)
   }
 
-  const onOverflowSelect = (payload: { value: string | number }) => {
-    const href = typeof payload?.value === 'string' ? payload.value : undefined
+  const onOverflowSelect = (
+    event: globalThis.MouseEvent | globalThis.KeyboardEvent,
+    value: string | number
+  ) => {
+    const href = typeof value === 'string' ? value : undefined
     if (href) {
-      handleItemClick(href)
+      handleItemClick(event as MouseEvent, href)
     }
   }
 </script>
@@ -110,7 +113,7 @@
                 :icon="item.icon"
                 :class="item.current ? 'text-[var(--text-default)]' : undefined"
                 :data-testid="`${testId}__item-${index}`"
-                @click="() => !item.current && handleItemClick(item.href ?? '#')"
+                @click="(event) => !item.current && handleItemClick(event, item.href ?? '#')"
               />
             </li>
             <BreadcrumbSeparator
@@ -136,7 +139,9 @@
                 firstItem.current && !showDistinctEnds ? 'text-[var(--text-default)]' : undefined
               "
               :data-testid="`${testId}__item-0`"
-              @click="() => !firstItem.current && handleItemClick(firstItem.href ?? '#')"
+              @click="
+                (event) => !firstItem.current && handleItemClick(event, firstItem.href ?? '#')
+              "
             />
           </li>
 
@@ -194,7 +199,9 @@
                 :icon="lastItem.icon"
                 class="text-[var(--text-default)]"
                 :data-testid="`${testId}__item-last`"
-                @click="() => !lastItem.current && handleItemClick(lastItem.href ?? '#')"
+                @click="
+                  (event) => !lastItem.current && handleItemClick(event, lastItem.href ?? '#')
+                "
               />
             </li>
           </template>

--- a/packages/webkit/src/components/navigation/dropdown/dropdown.vue
+++ b/packages/webkit/src/components/navigation/dropdown/dropdown.vue
@@ -49,14 +49,9 @@
     disabled: false
   })
 
-  export interface DropdownSelectPayload {
-    value: DropdownOptionValue
-    event: globalThis.MouseEvent | globalThis.KeyboardEvent
-  }
-
   const emit = defineEmits<{
     'update:open': [value: boolean]
-    select: [payload: DropdownSelectPayload]
+    select: [event: globalThis.MouseEvent | globalThis.KeyboardEvent, value: DropdownOptionValue]
   }>()
 
   const openModel = defineModel<boolean | undefined>('open', { default: undefined })
@@ -171,7 +166,7 @@
     event: globalThis.MouseEvent | globalThis.KeyboardEvent
   ) {
     const wasOpen = isOpenState.value
-    emit('select', { value, event })
+    emit('select', event, value)
     if (wasOpen) {
       setOpen(false)
       focusTrigger()

--- a/packages/webkit/src/components/navigation/menu-item/menu-item.vue
+++ b/packages/webkit/src/components/navigation/menu-item/menu-item.vue
@@ -47,7 +47,7 @@
   })
 
   const emit = defineEmits<{
-    click: [event: MouseEvent]
+    click: [event: MouseEvent, item: { label: string; href: string }]
   }>()
 
   defineSlots<{
@@ -126,7 +126,7 @@
       return
     }
 
-    emit('click', event)
+    emit('click', event, { label: props.label, href: props.href })
   }
 </script>
 

--- a/packages/webkit/src/components/navigation/tab-view/tab-view-item.vue
+++ b/packages/webkit/src/components/navigation/tab-view/tab-view-item.vue
@@ -31,8 +31,8 @@
   })
 
   const emit = defineEmits<{
-    click: [payload: globalThis.MouseEvent]
-    close: [payload: globalThis.MouseEvent | globalThis.KeyboardEvent]
+    click: [event: globalThis.MouseEvent, value: TabViewValue | string]
+    close: [event: globalThis.MouseEvent | globalThis.KeyboardEvent, value: TabViewValue | string]
   }>()
 
   defineSlots<{
@@ -113,7 +113,7 @@
     }
 
     context?.setValue(resolvedValue.value)
-    emit('click', event)
+    emit('click', event, resolvedValue.value)
   }
 
   const onCloseClick = (event: globalThis.MouseEvent | globalThis.KeyboardEvent) => {
@@ -123,7 +123,7 @@
       return
     }
 
-    emit('close', event)
+    emit('close', event, resolvedValue.value)
   }
 
   onMounted(() => {


### PR DESCRIPTION
## Summary

Aligns **navigation** components to the `(event, item)` event-payloads standard (see the config PR #729). `split-button` (actions) is included because it composes `Dropdown` and consumes its `select` event — the two must ship together.

| Component | Event | Before | After |
|---|---|---|---|
| dropdown | `select` | `({ value, event })` | `(event, value)` |
| split-button | `item-click` | `(item)` | `(event, item)` |
| menu-item | `click` | `(event)` | `(event, { label, href })` |
| breadcrumb-item | `click` | `(event)` | `(event, { label, href })` |
| breadcrumb | `navigate` | `(href)` | `(event, href)` |
| tab-view-item | `click`/`close` | `(event)` | `(event, value)` |

Internal consumers updated (split-button + breadcrumb consume dropdown/select; breadcrumb consumes breadcrumb-item/click). Specs + Storybook argTypes updated to match.

## Verified
`type-check` ✅ · `lint` ✅ · `validate-story-source --all` ✅

## ⚠️ Breaking
Activation events now emit the DOM `event` first. Handlers move from e.g. `@item-click="(item) => …"` to `@item-click="(event, item) => …"`. Major bump.