### PR TITLE
refactor(webkit)!: chip click/remove emit (event, label)

### DIFF
--- a/.specs/chip.md
+++ b/.specs/chip.md
@@ -43,8 +43,8 @@ import Chip from '@aziontech/webkit/chip'
 
 | Event | Payload | Notes |
 |---|---|---|
-| `remove` | `MouseEvent` | Fires when `removable` is true and the remove button is activated (click / Enter / Space), after the chip's exit (fade-out) animation completes, so the parent removes the chip once it has animated out. |
-| `click` | `MouseEvent \| KeyboardEvent` | Fires only when `clickable` is true and the chip body is activated — by pointer, or `Enter` / `Space` while the root is focused. The trailing remove button stops propagation, so activating it emits `remove` only, never `click`. |
+| `remove` | `(event: MouseEvent, label: string)` | Fires when `removable` is true and the remove button is activated (click / Enter / Space), after the chip's exit (fade-out) animation completes, so the parent removes the chip once it has animated out. `label` is the chip's `label` prop, identifying which chip was removed. |
+| `click` | `(event: MouseEvent \| KeyboardEvent, label: string)` | Fires only when `clickable` is true and the chip body is activated — by pointer, or `Enter` / `Space` while the root is focused. `label` identifies which chip was clicked. The trailing remove button stops propagation, so activating it emits `remove` only, never `click`. |
 
 ## Slots
 

--- a/packages/webkit/src/components/inputs/chip/chip.vue
+++ b/packages/webkit/src/components/inputs/chip/chip.vue
@@ -28,8 +28,8 @@
   })
 
   const emit = defineEmits<{
-    remove: [event: MouseEvent]
-    click: [event: MouseEvent | KeyboardEvent]
+    remove: [event: MouseEvent, label: string]
+    click: [event: MouseEvent | KeyboardEvent, label: string]
   }>()
 
   defineSlots<{
@@ -60,7 +60,7 @@
 
   function handleAfterLeave() {
     if (pendingRemoveEvent) {
-      emit('remove', pendingRemoveEvent)
+      emit('remove', pendingRemoveEvent, props.label)
       pendingRemoveEvent = undefined
     }
   }
@@ -70,7 +70,7 @@
       return
     }
 
-    emit('click', event)
+    emit('click', event, props.label)
   }
 
   function onKeydown(event: KeyboardEvent) {
@@ -81,7 +81,7 @@
 
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
-      emit('click', event)
+      emit('click', event, props.label)
     }
   }
 </script>


### PR DESCRIPTION
## Summary

Aligns **inputs / chip** to the `(event, item)` event-payloads standard (config PR #729). `click` and `remove` now carry the chip's `label` as the second argument, so a consumer knows which chip was activated.

| Event | Before | After |
|---|---|---|
| `click` | `(event)` | `(event, label)` |
| `remove` | `(event)` | `(event, label)` |

The change is additive (the event was already the first argument), so existing internal consumers that read only the event keep working — this PR is independent of the data PR.

## Verified
`type-check` ✅ · `lint` ✅ · `validate-story-source --all` ✅

## ⚠️ Breaking
Payload gains a second argument; handlers relying on the exact arity should update. Major bump.