### PR TITLE
refactor(webkit)!: deploy-success step-click emits (event, index)

### DIFF
--- a/.specs/deploy-success.md
+++ b/.specs/deploy-success.md
@@ -62,7 +62,7 @@ const lines = [
 |---|---|---|
 | `action-click` | `MouseEvent` | Fires when the primary footer button is activated. |
 | `visit-click` | `MouseEvent` | Fires when the visit link is activated. |
-| `step-click` | `[index: number, event: MouseEvent]` | Fires when a next-step row is activated. |
+| `step-click` | `(event: MouseEvent, index: number)` | Fires when a next-step row is activated. `index` is the activated row's position. |
 
 ## Slots
 

--- a/apps/storybook/src/stories/components/templates/deploy-success/DeploySuccess.stories.js
+++ b/apps/storybook/src/stories/components/templates/deploy-success/DeploySuccess.stories.js
@@ -124,7 +124,7 @@ const meta = {
     onStepClick: {
       action: 'step-click',
       description: 'Fires when a next-step row is activated.',
-      table: { category: 'events', type: { summary: '[index: number, event: MouseEvent]' } }
+      table: { category: 'events', type: { summary: '(event: MouseEvent, index: number)' } }
     }
   },
   args: {

--- a/packages/webkit/src/components/templates/deploy-success/deploy-success.vue
+++ b/packages/webkit/src/components/templates/deploy-success/deploy-success.vue
@@ -78,7 +78,7 @@
   const emit = defineEmits<{
     'action-click': [event: MouseEvent]
     'visit-click': [event: MouseEvent]
-    'step-click': [index: number, event: MouseEvent]
+    'step-click': [event: MouseEvent, index: number]
   }>()
 
   defineSlots<{
@@ -98,7 +98,7 @@
 
   const onActionClick = (event: MouseEvent) => emit('action-click', event)
   const onVisitClick = (event: MouseEvent) => emit('visit-click', event)
-  const onStepClick = (index: number, event: MouseEvent) => emit('step-click', index, event)
+  const onStepClick = (event: MouseEvent, index: number) => emit('step-click', event, index)
 
   const GlobalHeaderLeft = GlobalHeader['Left']
   const GlobalHeaderBrand = GlobalHeader['Brand']
@@ -250,7 +250,7 @@
                       type="button"
                       :class="STEP_BUTTON_CLASS"
                       :disabled="disabled"
-                      @click="onStepClick(index, $event)"
+                      @click="onStepClick($event, index)"
                     >
                       <ItemMedia
                         media-kind="icon"


### PR DESCRIPTION
## Summary

Aligns **templates / deploy-success** to the `(event, item)` event-payloads standard (config PR #729). `step-click` had the arguments reversed; it now emits the DOM event first.

| Event | Before | After |
|---|---|---|
| `step-click` | `(index, event)` | `(event, index)` |

Self-contained (handler + template binding updated in the same file).

## Verified
`type-check` ✅ · `lint` ✅ · `validate-story-source --all` ✅

## ⚠️ Breaking
Argument order changed; handlers move from `@step-click="(index, event) => …"` to `(event, index) => …`. Major bump.