### PR TITLE
fix: refine switch locked state and default border (ENG-46737, ENG-46738)

### DIFF
--- a/packages/webkit/src/components/inputs/input-switch/input-switch.vue
+++ b/packages/webkit/src/components/inputs/input-switch/input-switch.vue
@@ -71,7 +71,8 @@
 
   const sharedClasses = [
     'group relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full',
-    'border border-transparent bg-[var(--bg-disabled)] data-[checked]:bg-[var(--primary)]',
+    'border border-[var(--border-default)] bg-[var(--bg-disabled)]',
+    'data-[checked]:border-[var(--primary)] data-[checked]:bg-[var(--primary)]',
     ...ghostLayerClasses,
     ...focusVisibleRingClasses,
     ...focusSuppressHoverGhostClasses,
@@ -79,10 +80,10 @@
   ]
 
   const disabledClasses =
-    'data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50'
+    'data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed data-[disabled]:border-[var(--border-default)] data-[disabled]:bg-[var(--bg-disabled)] data-[disabled]:opacity-50 data-[checked]:data-[disabled]:border-[var(--border-default)] data-[checked]:data-[disabled]:bg-[var(--bg-disabled)]'
 
   const handleClasses =
-    'pointer-events-none absolute left-0.5 top-1/2 z-[1] size-4 -translate-y-1/2 rounded-full bg-[var(--bg-surface)] shadow-[var(--shadow-xs)] transition-transform duration-fast-02 ease-productive-entrance motion-reduce:transition-none group-data-[checked]:translate-x-4'
+    'pointer-events-none absolute left-0.5 top-1/2 z-[1] size-4 -translate-y-1/2 rounded-full bg-[var(--bg-surface)] shadow-[var(--shadow-xs)] transition-transform duration-fast-02 ease-productive-entrance motion-reduce:transition-none group-data-[checked]:translate-x-4 group-data-[disabled]:bg-[var(--text-disabled)] group-data-[disabled]:shadow-none'
 
   const rootClasses = computed(() => cn(sharedClasses, disabledClasses, attrs.class))
 </script>


### PR DESCRIPTION
## Bugs

- **ENG-46738 — [Switch] Adicionar border default.** The `InputSwitch` track had `border-transparent`, so the unchecked pill blended with any surface whose background matched `--bg-disabled` (very common on cards and dialogs). There was no visible edge without focus.
- **ENG-46737 — [Switch] Estado com cadeado está estranho visualmente.** The disabled ("locked") state reused the exact same track background as the enabled off state (`--bg-disabled`) and only added `opacity-50`. The white `--bg-surface` thumb over that low-contrast track produced a washed-out shape that read as "broken" rather than "locked", and was visually indistinguishable from the enabled off state.

## Root cause

`packages/webkit/src/components/inputs/input-switch/input-switch.vue` inherited a minimal token map (spec `.specs/input-switch.md` § Tokens defines only `track (off)`, `track (on)`, `handle`, `ring`) and did not encode a disabled treatment separate from the off state. Neighboring toggles (`radio-button.vue`) already implement the correct pattern with `--border-default` on the track and a `--text-disabled` indicator when locked.

## Fix

Aligns `InputSwitch` with the radio-button pattern using semantic tokens only:

- **Default border**: track now uses `border-[var(--border-default)]` in the off state and `data-[checked]:border-[var(--primary)]` when on, matching the primary track background.
- **Locked state**: `data-[disabled]:border-[var(--border-default)] data-[disabled]:bg-[var(--bg-disabled)] data-[disabled]:opacity-50`, with the same rule applied to `data-[checked]:data-[disabled]:` so a locked "on" switch also renders the disabled tokens rather than active primary.
- **Locked thumb**: `group-data-[disabled]:bg-[var(--text-disabled)] group-data-[disabled]:shadow-none` so the thumb reads as a muted knob instead of a floating white circle at 50% opacity.

No prop, event, slot or dependency changes. No hex, no Tailwind palette, no raw typography, no external positioning/animation libs. Variants remain on `data-*` attributes per `.claude/rules/styling.md`.

## Files touched

- `packages/webkit/src/components/inputs/input-switch/input-switch.vue`

`FieldSwitch` and `FieldSwitchBlock` were reviewed and require no change — they compose `InputSwitch` and inherit the fix.

## Checks run (repo root)

```
pnpm webkit:lint              # only failure is pre-existing (field-input-group.vue on main)
pnpm webkit:type-check        # only failures are pre-existing (drawer.vue, dropdown-menu.vue on main)
pnpm webkit:format:check      # only failures are pre-existing (menu-item, tag, factory, field-input-group)
pnpm webkit:lint:style        # clean
pnpm exec prettier --check .../input-switch.vue  # "All matched files use Prettier code style!"
pnpm --filter webkit exec vue-tsc --noEmit 2>&1 | grep -i switch  # no switch-related errors
```

Refs: ENG-46737, ENG-46738
Refs: https://aziontech.atlassian.net/browse/ENG-46737
Refs: https://aziontech.atlassian.net/browse/ENG-46738