### PR TITLE
fix: extend InputText clickable area to full field (ENG-46736)

### DIFF
--- a/packages/webkit/src/components/inputs/input-text/input-text.vue
+++ b/packages/webkit/src/components/inputs/input-text/input-text.vue
@@ -93,7 +93,7 @@
   })
 
   const inputClasses = computed(() => [
-    'relative z-[1] w-full min-w-0 border-0 bg-transparent outline-none',
+    'relative z-[1] h-full w-full min-w-0 self-stretch border-0 bg-transparent outline-none',
     'text-[var(--text-default)] placeholder:text-[var(--text-muted)]',
     'disabled:cursor-not-allowed disabled:text-[var(--text-disabled)]',
     'read-only:cursor-default',


### PR DESCRIPTION
## Bug

**ENG-46736** — Clicking on the `InputText` field only focuses the input when the click lands exactly on the placeholder text line. The bordered surface has a dead band above and below the text where clicks hit the wrapper `<span>` without focusing the input. A previous fix regressed this behavior.

## Root cause

`packages/webkit/src/components/inputs/input-text/input-text.vue` renders:

- A `<span>` root wrapper that owns the row height (`h-8` / `h-10` / `h-12`) plus border and shape.
- An inner `<input>` centered with `inline-flex items-center`, with no height of its own.

Because the input is only as tall as its intrinsic line-height (and centered inside a taller wrapper), the wrapper exposes vertical padding whose clicks target the `<span>`, not the input. Native focus does not propagate from the wrapper to the input, so the field feels unclickable outside the placeholder line.

## Fix

Mirror the pattern used by `FieldTextArea` / `TextArea` in `core/form/`, where the input control itself owns the full clickable height (`w-full min-h-[…]`). We do the equivalent here without restructuring the DOM: stretch the `<input>` to the wrapper's full height via `h-full self-stretch`, so the input occupies the entire interior of the bordered surface and clicks anywhere inside the field focus it.

Only the inner input class list changes (one class array):

```diff
- 'relative z-[1] w-full min-w-0 border-0 bg-transparent outline-none',
+ 'relative z-[1] h-full w-full min-w-0 self-stretch border-0 bg-transparent outline-none',
```

The wrapper still owns visual dimensions, border, and focus-within ring; the input now covers 100% of the wrapper's inner box, so the whole field is a valid pointer target and native `<input>` focus semantics do the rest — no wrapper-level click handler needed.

## Checks run (repo root)

- `pnpm webkit:lint` — passes
- `pnpm webkit:type-check` — passes (`vue-tsc --noEmit`)
- `pnpm webkit:format:check` — passes
- `pnpm webkit:lint:style` — passes

## Refs

- Jira: ENG-46736