### PR TITLE
fix: resolve InputGroup double focus and add size support (ENG-46733, ENG-46734)

### DIFF
--- a/packages/webkit/src/core/form/field-input-group/field-input-group.vue
+++ b/packages/webkit/src/core/form/field-input-group/field-input-group.vue
@@ -38,6 +38,11 @@
     inputClass: {
       type: String,
       default: ''
+    },
+    size: {
+      type: String,
+      default: 'medium',
+      validator: (value) => ['small', 'medium', 'large'].includes(value)
     }
   })
 
@@ -58,6 +63,12 @@
   const slots = useSlots()
   const hasIconSlot = !!slots.icon
 
+  const inputSizeClass = computed(() => {
+    if (props.size === 'small') return 'p-inputtext-sm'
+    if (props.size === 'large') return 'p-inputtext-lg'
+    return ''
+  })
+
   const {
     value: inputValue,
     errorMessage,
@@ -76,7 +87,10 @@
       :label="props.label"
       :isRequired="attrs.required"
     />
-    <div class="p-inputgroup">
+    <div
+      :data-size="size"
+      class="p-inputgroup rounded-[var(--shape-button)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[var(--ring-color)] focus-within:ring-offset-1 focus-within:ring-offset-[var(--bg-canvas)] [&_.p-inputtext:focus]:!shadow-none [&_.p-inputtext:focus]:!outline-none [&_.p-inputtext:enabled:focus]:!border-[var(--border-default)] data-[size=small]:[&_.p-inputgroup-addon]:py-[var(--spacing-1)] data-[size=small]:[&_.p-inputgroup-addon]:px-[var(--spacing-2)] data-[size=large]:[&_.p-inputgroup-addon]:py-[var(--spacing-3)] data-[size=large]:[&_.p-inputgroup-addon]:px-[var(--spacing-4)]"
+    >
       <div
         class="p-inputgroup-addon"
         v-if="hasIconSlot"
@@ -90,7 +104,7 @@
         :name="name"
         :readonly="readonly"
         :disabled="disabled"
-        :class="[{ 'p-invalid': errorMessage }, $attrs.class, inputClass]"
+        :class="[{ 'p-invalid': errorMessage }, inputSizeClass, $attrs.class, inputClass]"
         type="text"
         :placeholder="props.placeholder"
         @input="handleChange"


### PR DESCRIPTION
## Summary

Fixes two InputGroup bugs in a single PR.

### ENG-46733 — Double focus
- **Symptom:** When a nested input inside `.p-inputgroup` received focus, two focus indicators were visible at once: PrimeVue's `focused-input()` on `.p-inputtext` (outline + box-shadow + border color) and, visually, the neighbouring `.p-inputgroup-addon` still rendering its full border, producing a double-frame effect.
- **Root cause:** The wrapper had no focus affordance of its own; focus was applied at the child level while the wrapper's siblings kept their own borders.
- **Fix:** Move the focus indicator to the wrapper via `focus-within:ring-2 ring-[var(--ring-color)] ring-offset-1 ring-offset-[var(--bg-canvas)]` and suppress the inner `.p-inputtext` focus outline/box-shadow (and revert its border to `--border-default`) using arbitrary Tailwind child variants. One focus ring, one source of truth.

### ENG-46734 — Não suporta sizes
- **Symptom:** InputGroup did not adapt to a `'small' | 'medium' | 'large'` size contract, unlike the rest of the input family.
- **Fix:** Add a `size` prop (default `'medium'`, validated against `['small', 'medium', 'large']`, mirroring the canonical size contract already used by `input-text`, `input-number`, `select`, `button`, etc.). The prop:
  - Applies `p-inputtext-sm` / `p-inputtext-lg` to the inner PrimeVue input, hooking into the existing theme SCSS scaled font-size / padding.
  - Sets `data-size` on the wrapper, driving matching addon padding via `data-[size=small]:` / `data-[size=large]:` variants scoped to `.p-inputgroup-addon` — no JS class preset, no `<style>` block.

## Files touched
- `packages/webkit/src/core/form/field-input-group/field-input-group.vue`

## Checks run (all green)
- `pnpm webkit:lint`
- `pnpm webkit:type-check`
- `pnpm webkit:format:check`
- `pnpm webkit:lint:style`

## Refs
- ENG-46733
- ENG-46734