### PR TITLE
fix: normalize input z-index to semantic tokens (ENG-46735)

### DIFF
--- a/packages/theme/dist/v3/globals.css
+++ b/packages/theme/dist/v3/globals.css
@@ -464,6 +464,11 @@
     --spacing-xs: 0.5rem;
     --spacing-xxs: 0.25rem;
 
+    /* ── Z-indices ── */
+    --z-input-field: 1;
+    --z-input-popup: 10;
+    --z-input-overlay: 1100;
+
     /* ── Texts ── */
     --text-big-number-md-font-size: 1.25rem;
     --text-big-number-md-line-height: 1.20;

--- a/packages/theme/dist/v3/globals.scss
+++ b/packages/theme/dist/v3/globals.scss
@@ -464,6 +464,11 @@
     --spacing-xs: 0.5rem;
     --spacing-xxs: 0.25rem;
 
+    /* ── Z-indices ── */
+    --z-input-field: 1;
+    --z-input-popup: 10;
+    --z-input-overlay: 1100;
+
     /* ── Texts ── */
     --text-big-number-md-font-size: 1.25rem;
     --text-big-number-md-line-height: 1.20;

--- a/packages/theme/dist/v4/globals.css
+++ b/packages/theme/dist/v4/globals.css
@@ -460,6 +460,9 @@
   --spacing-sm: 0.75rem;
   --spacing-xs: 0.5rem;
   --spacing-xxs: 0.25rem;
+  --z-input-field: 1;
+  --z-input-popup: 10;
+  --z-input-overlay: 1100;
   --text-big-number-md-font-size: 1.25rem;
   --text-big-number-md-line-height: 1.20;
   --text-big-number-md-font-family: Proto Mono;

--- a/packages/theme/dist/v4/globals.scss
+++ b/packages/theme/dist/v4/globals.scss
@@ -460,6 +460,9 @@
   --spacing-sm: 0.75rem;
   --spacing-xs: 0.5rem;
   --spacing-xxs: 0.25rem;
+  --z-input-field: 1;
+  --z-input-popup: 10;
+  --z-input-overlay: 1100;
   --text-big-number-md-font-size: 1.25rem;
   --text-big-number-md-line-height: 1.20;
   --text-big-number-md-font-family: Proto Mono;

--- a/packages/theme/src/scripts/build-tokens.mjs
+++ b/packages/theme/src/scripts/build-tokens.mjs
@@ -34,6 +34,7 @@ import { compileThemeCss } from './compile-theme.js';
 import { containersData } from '../tokens/semantic/containers.data.js';
 import { spacingsData } from '../tokens/semantic/spacings.data.js';
 import { textsData } from '../tokens/semantic/texts.data.js';
+import { zIndicesData } from '../tokens/semantic/z-indices.data.js';
 import { semanticColors } from '../tokens/semantic/colors.js';
 import { createCssVars } from './css-vars.js';
 
@@ -104,6 +105,7 @@ const buildFlatModel = () => ({
   primitives: flattenPrimitives(),
   containers: flattenSingleValue(containersData, (k) => `--container-${k}`),
   spacings: flattenSingleValue(spacingsData, (k) => `--${k}`),
+  zIndices: flattenSingleValue(zIndicesData, (k) => `--${k}`),
   texts: flattenBundle(textsData),
   semanticColors: buildSemanticColorVars(),
 });
@@ -175,6 +177,7 @@ const emitCssV3 = () => {
     { title: 'Primitives', vars: m.primitives },
     { title: 'Containers', vars: m.containers._ || {} },
     { title: 'Spacings', vars: m.spacings._ || {} },
+    { title: 'Z-indices', vars: m.zIndices._ || {} },
     { title: 'Texts', vars: m.texts._ || {} },
     { title: 'Semantic colors', vars: m.semanticColors.light },
   ];
@@ -189,6 +192,7 @@ const emitCssV3 = () => {
     const merged = {
       ...(m.containers[bp] || {}),
       ...(m.spacings[bp] || {}),
+      ...(m.zIndices[bp] || {}),
       ...(m.texts[bp] || {}),
     };
     if (Object.keys(merged).length > 0) mediaBlocks.push(emitMediaBlockV3(bp, merged));
@@ -333,6 +337,7 @@ const emitCssV4 = () => {
     ...rootPrimitiveVars,
     ...(m.containers._ || {}),
     ...(m.spacings._ || {}),
+    ...(m.zIndices._ || {}),
     ...(m.texts._ || {}),
   };
 
@@ -341,6 +346,7 @@ const emitCssV4 = () => {
     const merged = {
       ...(m.containers[bp] || {}),
       ...(m.spacings[bp] || {}),
+      ...(m.zIndices[bp] || {}),
       ...(m.texts[bp] || {}),
     };
     if (Object.keys(merged).length === 0) continue;

--- a/packages/theme/src/tokens/semantic/z-indices.data.js
+++ b/packages/theme/src/tokens/semantic/z-indices.data.js
@@ -1,0 +1,30 @@
+/**
+ * Declarative z-index tokens.
+ *
+ * Intra-input stacking:
+ *
+ *   - `z-input-field`   → native field / interactive foreground (e.g. an
+ *                          `<input>` or trigger button) sitting above the
+ *                          input's own background surface, icons, and
+ *                          adornments so keyboard/mouse focus is never
+ *                          hijacked by a decorative sibling.
+ *   - `z-input-popup`   → inline (non-teleported) overlays anchored to the
+ *                          input — dropdown menus, option lists, popovers —
+ *                          that must sit above surrounding form content but
+ *                          within the current stacking context.
+ *   - `z-input-overlay` → teleported overlays (rendered under `<body>` via
+ *                          `<Teleport>`) that must clear application chrome
+ *                          such as drawers, modals, and fixed headers.
+ *
+ * Values are intentionally small and well-spaced to make future additions
+ * obvious. Consume as `z-[var(--z-input-*)]` in components — do not
+ * introduce ad-hoc numeric z-index in input `.vue` files.
+ */
+
+export const zIndicesData = {
+  'z-input-field': { _: '1' },
+  'z-input-popup': { _: '10' },
+  'z-input-overlay': { _: '1100' },
+};
+
+export default { zIndicesData };

--- a/packages/webkit/src/components/inputs/dropdown/dropdown.vue
+++ b/packages/webkit/src/components/inputs/dropdown/dropdown.vue
@@ -353,7 +353,7 @@
       top: `${rect.bottom + 4}px`,
       left: `${rect.left}px`,
       width: `${rect.width}px`,
-      zIndex: 1100
+      zIndex: 'var(--z-input-overlay)'
     }
   }
 
@@ -558,7 +558,7 @@
       <button
         type="button"
         role="combobox"
-        class="relative z-[1] flex min-w-0 flex-1 items-center gap-[var(--spacing-xs)] border-0 bg-transparent p-0 text-left outline-none disabled:cursor-not-allowed"
+        class="relative z-[var(--z-input-field)] flex min-w-0 flex-1 items-center gap-[var(--spacing-xs)] border-0 bg-transparent p-0 text-left outline-none disabled:cursor-not-allowed"
         :disabled="disabled || loading"
         :aria-expanded="isOpen"
         aria-haspopup="listbox"
@@ -602,7 +602,7 @@
       <button
         v-if="showClear && hasValue && !disabled && !loading"
         type="button"
-        class="relative z-[1] inline-flex shrink-0 items-center justify-center border-0 bg-transparent p-0 text-[var(--text-muted)] hover:text-[var(--text-default)]"
+        class="relative z-[var(--z-input-field)] inline-flex shrink-0 items-center justify-center border-0 bg-transparent p-0 text-[var(--text-muted)] hover:text-[var(--text-default)]"
         :aria-label="`Clear ${placeholder ?? 'selection'}`"
         :data-testid="`${testId}__clear`"
         @click="clearValue"
@@ -626,7 +626,8 @@
           :class="[
             ...panelClasses,
             'webkit-dropdown-panel-motion',
-            !useTeleport && 'absolute left-0 top-full z-10 mt-[var(--spacing-xxs)] w-full'
+            !useTeleport &&
+              'absolute left-0 top-full z-[var(--z-input-popup)] mt-[var(--spacing-xxs)] w-full'
           ]"
           :style="useTeleport ? panelStyle : undefined"
           :data-testid="`${testId}__panel`"

--- a/packages/webkit/src/components/inputs/input-switch/input-switch.vue
+++ b/packages/webkit/src/components/inputs/input-switch/input-switch.vue
@@ -82,7 +82,7 @@
     'data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50'
 
   const handleClasses =
-    'pointer-events-none absolute left-0.5 top-1/2 z-[1] size-4 -translate-y-1/2 rounded-full bg-[var(--bg-surface)] shadow-[var(--shadow-xs)] transition-transform duration-fast-02 ease-productive-entrance motion-reduce:transition-none group-data-[checked]:translate-x-4'
+    'pointer-events-none absolute left-0.5 top-1/2 z-[var(--z-input-field)] size-4 -translate-y-1/2 rounded-full bg-[var(--bg-surface)] shadow-[var(--shadow-xs)] transition-transform duration-fast-02 ease-productive-entrance motion-reduce:transition-none group-data-[checked]:translate-x-4'
 
   const rootClasses = computed(() => cn(sharedClasses, disabledClasses, attrs.class))
 </script>

--- a/packages/webkit/src/components/inputs/input-text/input-text.vue
+++ b/packages/webkit/src/components/inputs/input-text/input-text.vue
@@ -93,7 +93,7 @@
   })
 
   const inputClasses = computed(() => [
-    'relative z-[1] w-full min-w-0 border-0 bg-transparent outline-none',
+    'relative z-[var(--z-input-field)] w-full min-w-0 border-0 bg-transparent outline-none',
     'text-[var(--text-default)] placeholder:text-[var(--text-muted)]',
     'disabled:cursor-not-allowed disabled:text-[var(--text-disabled)]',
     'read-only:cursor-default',


### PR DESCRIPTION
## Summary

Audits every explicit z-index across the webkit input components and replaces the magic numbers (`z-[1]`, `z-10`, `zIndex: 1100`) with three semantic tokens declared in `@aziontech/theme`.

**Scope note.** This PR is **not** the Select-in-Drawer stacking fix (that's ENG-46731, tracked in a separate PR). This one is focused on internal, per-input stacking: field foreground above icons/adornments, inline popup layer, teleported overlay layer.

## Audit

Grep sweep of `packages/webkit/src/components/inputs/` and `packages/webkit/src/core/form/` for `z-[\d`, `z-\d+`, `zIndex`, `--z-`:

| File | Line | Before | After | Concern |
| --- | ---: | --- | --- | --- |
| `inputs/input-text/input-text.vue` | 96 | `z-[1]` | `z-[var(--z-input-field)]` | native `<input>` above surface / icons |
| `inputs/input-switch/input-switch.vue` | 85 | `z-[1]` | `z-[var(--z-input-field)]` | switch thumb above track |
| `inputs/dropdown/dropdown.vue` | 356 | `zIndex: 1100` | `zIndex: 'var(--z-input-overlay)'` | teleported dropdown panel |
| `inputs/dropdown/dropdown.vue` | 561 | `z-[1]` | `z-[var(--z-input-field)]` | trigger button foreground |
| `inputs/dropdown/dropdown.vue` | 605 | `z-[1]` | `z-[var(--z-input-field)]` | clear-selection icon button |
| `inputs/dropdown/dropdown.vue` | 629 | `z-10` | `z-[var(--z-input-popup)]` | inline (non-teleported) dropdown panel |

`core/form/` had no explicit z-index — nothing to normalize there.

## Tokens

New file: `packages/theme/src/tokens/semantic/z-indices.data.js`

| Token | Value | Purpose |
| --- | ---: | --- |
| `--z-input-field` | `1` | Native field / interactive foreground above the input's own background surface, icons, and adornments — so keyboard/mouse focus is never hijacked by a decorative sibling. |
| `--z-input-popup` | `10` | Inline (non-teleported) overlays anchored to the input — dropdown menus, option lists — sitting above surrounding form content but inside the current stacking context. |
| `--z-input-overlay` | `1100` | Teleported overlays (rendered under `<body>` via `<Teleport>`) that must clear application chrome such as drawers, modals, and fixed headers. |

Values match the pre-existing magic numbers exactly — this is a naming refactor, no visual regression expected.

Wired into `build-tokens.mjs` alongside the existing `spacings`/`containers`/`texts` declarative sources so the vars are emitted into `dist/v3/globals.css`, `dist/v3/globals.scss`, `dist/v4/globals.css`, `dist/v4/globals.scss`.

## Rationale

- Removes six magic-number z-index literals from three input components.
- Names the three real stacking layers (field / inline popup / teleported overlay) so future inputs have an obvious slot to pick.
- Keeps values identical to prior behavior — no runtime regression.
- Follows the design-system rule: values in inputs come from `var(--*)` tokens, never HEX/magic literals.

## Checks

- `pnpm theme:build:tokens` — passes (`✓ v3 → …`, `✓ v4 → …`).
- `pnpm webkit:lint` — passes.
- `pnpm webkit:lint:style` — passes.
- `pnpm webkit:format:check` — three unrelated files flagged (pre-existing on main): `overlay/dropdown-menu/factory.ts`, `navigation/menu-item/menu-item.vue`, `tag/tag.vue`. All touched files in this PR are formatted.
- `pnpm webkit:type-check` — pre-existing errors on `overlay/drawer/drawer.vue` and `overlay/dropdown-menu/dropdown-menu.vue` (unchanged by this PR). No new errors introduced.

## Jira

Refs: ENG-46735