### PR TITLE
fix: mcp hono server  overwrite version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ overrides:
   qs: '>=6.15.2'
   '@babel/core': '>=7.29.1 <8'
   js-yaml: '>=4.1.2'
+  '@hono/node-server': '>=2.0.5'
 
 importers:
 
@@ -1048,9 +1049,9 @@ packages:
   '@hapi/topo@6.0.2':
     resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -8235,7 +8236,7 @@ snapshots:
     dependencies:
       '@hapi/hoek': 11.0.7
 
-  '@hono/node-server@1.19.14(hono@4.12.30)':
+  '@hono/node-server@2.0.10(hono@4.12.30)':
     dependencies:
       hono: 4.12.30
 
@@ -8500,7 +8501,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.30)
+      '@hono/node-server': 2.0.10(hono@4.12.30)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,3 +36,4 @@ overrides:
   qs: ">=6.15.2"
   "@babel/core": ">=7.29.1 <8"
   js-yaml: ">=4.1.2"
+  "@hono/node-server": ">=2.0.5"


### PR DESCRIPTION
Fix for audit error:
https://github.com/aziontech/webkit/actions/runs/29862231010/job/88741608722?pr=769

```
Run pnpm audit
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ moderate            │ Node.js Adapter for Hono: Path traversal in            │
│                     │ `serve-static` on Windows via encoded backslash        │
│                     │ (`%5C`)                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ @hono/node-server                                      │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <2.0.5                                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=2.0.5                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ packages__webkit>@modelcontextprotocol/sdk>@hono/node- │
│                     │ server                                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-frvp-7c67-39w9      │
└─────────────────────┴────────────────────────────��───────────────────────────┘
1 vulnerabilities found
Severity: 1 moderate
Error: Process completed with exit code 1.
```