### PR TITLE
[NO-ISSUE] ci: run governance once per commit (drop push trigger on dev)

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main, dev]
   push:
-    branches: [main, dev]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Every commit landing on `dev` currently runs the Governance Pipeline **twice**: once via `push` on `dev` and once via `pull_request` synchronize on the standing `dev` → `main` release PR (see the duplicated checks on #768). This drops `dev` from the `push` trigger so each commit is validated once.

- `pull_request: [main, dev]` stays — it feeds the required status checks for feature PRs and for the release PR, and validates the merge ref.
- `push: [main]` stays — post-merge sanity run on `main` (fires with the release PR already closed, so it never duplicates).

## Notes

- No jobs in `governance.yml` branch on `github.event_name` / `github.ref`, so nothing depended on the push-on-dev run.
- `ci` type → no version bump.
- Caveat: a direct push to `dev` (outside a PR, with no open release PR) would skip governance; the repo flow is PR-only, and "require branch up to date" on `dev` covers the stale-merge gap.