### PR TITLE
[NO-ISSUE] feat: webkit init hardening, toast service auto-mount, and motion token adoption

### DIFF
--- a/.claude/hooks/_lib/spec.mjs
+++ b/.claude/hooks/_lib/spec.mjs
@@ -93,6 +93,9 @@ export function validateFrontmatter(fm) {
       errors.push('figma.node_id: must match <num>:<num>')
     }
   }
+  if (fm.setup !== undefined && (typeof fm.setup !== 'string' || !fm.setup.trim())) {
+    errors.push('setup: must be a non-empty string when present')
+  }
   return errors
 }
 

--- a/.claude/hooks/_lib/standards.mjs
+++ b/.claude/hooks/_lib/standards.mjs
@@ -66,9 +66,10 @@ export const STANDARDS = [
       { surface: 'write-time', by: 'validate-tokens' },
       { surface: 'ci', by: 'check-authoring' },
       { surface: 'lint', by: 'no-hardcoded-color' },
+      { surface: 'lint', by: 'no-hardcoded-motion' },
       { surface: 'lint', by: 'no-style-override' }
     ],
-    note: 'The ratchet runs the same token-checks engine repo-wide, so an editor push cannot bypass the hook; consumers get the color/override lints.'
+    note: 'The ratchet runs the same token-checks engine repo-wide, so an editor push cannot bypass the hook; consumers get the color/motion/override lints.'
   },
   {
     id: 'dependencies',

--- a/.specs/_schema.json
+++ b/.specs/_schema.json
@@ -82,6 +82,11 @@
       "type": "boolean",
       "description": "When true, this component is intentionally personalizable: the consumer may pass class/style to its root, so no-style-override allows it (a documented style seam, e.g. a layout/container wrapper)."
     },
+    "setup": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One-time app-level wiring the component needs before first use (e.g. installing a plugin in the app entry). Surfaced by build-catalog.mjs into catalog.json so the MCP can steer consumers through it."
+    },
     "created": {
       "type": "string",
       "format": "date"

--- a/.specs/toast.md
+++ b/.specs/toast.md
@@ -4,12 +4,13 @@ category: feedback
 structure: composition
 status: approved
 spec_version: 1
+setup: "One-time app-level wiring before the first toast() call — service (recommended): import { ToastPlugin } from '@aziontech/webkit/toast' and chain .use(ToastPlugin) onto createApp() in the app entry; the plugin mounts the toast region automatically. Alternative: mount a Toaster component once near the app root. `webkit doctor` flags toast usage with no wired region."
 figma:
   url: https://www.figma.com/design/t97pXRs7xME3SJDs5iZ5RF/Webkit?node-id=478-938
   node_id: 478:938
-checksum: c68746e63dc5815cf542ed26f75b33bbec3b7749fb196ea5e8d78ac605ce5689
+checksum: cabba791be74b5dc7773877c1631197ead9fdb650779837aef9142427dd127ba
 created: 2026-06-23
-last_updated: 2026-06-29
+last_updated: 2026-07-21
 ---
 
 # Toast — Component Spec
@@ -41,12 +42,12 @@ import Button from '@aziontech/webkit/button'
 </template>
 ```
 
-**2. Service (install once in main.js)** — `app.use(ToastPlugin)` registers `<Toaster>` as a global component and exposes the imperative API as `this.$toast` (Options API / templates) and through `inject`; inside `setup` use `useToast()` to get the same API:
+**2. Service (install once in main.js)** — `app.use(ToastPlugin)` mounts the toast region automatically on a dedicated host element (no manual `<Toaster />` needed; the vnode shares the app's context, and the host is torn down on `app.unmount()`), registers `<Toaster>` as a global component, and exposes the imperative API as `this.$toast` (Options API / templates) and through `inject`; inside `setup` use `useToast()` to get the same API. Region defaults (position, duration, …) ride the plugin options. A manually mounted `<Toaster />` alongside the plugin is harmless — the store activates only the first registered region, so toasts never render twice. SSR-safe: without a DOM the auto-mount is skipped:
 
 ```ts
 // main.js
 import { ToastPlugin } from '@aziontech/webkit/toast'
-app.use(ToastPlugin)
+app.use(ToastPlugin, { position: 'bottom-right' })
 ```
 
 ```vue

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,6 +3,10 @@
   "plugins": ["stylelint-order"],
   "rules": {
     "at-rule-no-unknown": null,
+    "scss/at-rule-no-unknown": [
+      true,
+      { "ignoreAtRules": ["source", "theme", "utility", "custom-variant", "plugin", "reference"] }
+    ],
     "selector-class-pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$",
     "no-descending-specificity": [true, { "severity": "warning" }],
     "declaration-block-no-duplicate-properties": true,

--- a/apps/storybook/src/stories/foundations/Motion.stories.js
+++ b/apps/storybook/src/stories/foundations/Motion.stories.js
@@ -1,0 +1,150 @@
+import { animate, curve, duration, useWhen } from '@aziontech/theme/animations'
+
+import { CodeBlock, PageContainer, PageHeader } from '../../foundations/components/layout/index.js'
+
+// Rows straight from the theme token source — the page can never drift from the catalog.
+const durationRows = Object.entries(duration).map(([name, value]) => ({
+  name: `duration-${name}`,
+  value,
+  ms: Number.parseInt(value, 10)
+}))
+
+const curveRows = Object.entries(curve).map(([name, value]) => ({ name: `ease-${name}`, value }))
+
+const animationRows = Object.entries(animate).map(([name, value]) => ({
+  id: name,
+  className: `animate-${name}`,
+  value,
+  useWhen: useWhen[name] ?? '',
+  loops: /\binfinite\b/.test(value)
+}))
+
+const PANEL_RECIPE = `<Transition
+  enter-active-class="animate-slide-in-left motion-reduce:animate-none"
+  leave-active-class="animate-slide-out-left motion-reduce:animate-none"
+>
+  <aside v-if="sidebarOpen">...</aside>
+</Transition>`
+
+export default {
+  title: 'Foundations/Motion',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    controls: { disable: true },
+    actions: { disable: true },
+    docs: {
+      description: {
+        component:
+          'The motion foundations catalog: every `animate-*` utility with its timing, its purpose, and a replayable preview — plus the `duration-*` and `ease-*` tokens they are built from. Motion confirms an action or guides attention, never decorates; every motion-bearing class pairs with a `motion-reduce:*` escape.'
+      },
+      canvas: { sourceState: 'none' }
+    }
+  }
+}
+
+export const Overview = {
+  name: 'Overview',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Complete motion reference. Click Replay on a one-shot animation to run it again; looping utilities run continuously. Timing always comes from the `duration-*` / `ease-*` tokens — never a hardcoded millisecond or an inline cubic-bezier.'
+      }
+    }
+  },
+  render: () => ({
+    components: { PageContainer, PageHeader, CodeBlock },
+    data() {
+      return { replayKeys: {}, durationRows, curveRows, animationRows, PANEL_RECIPE }
+    },
+    methods: {
+      replay(id) {
+        this.replayKeys = { ...this.replayKeys, [id]: (this.replayKeys[id] || 0) + 1 }
+      }
+    },
+    template: /* html */ `
+      <PageContainer>
+        <PageHeader title="Motion">
+          Every animation in the system comes from this catalog: an <code>animate-*</code> utility built from
+          the duration and easing tokens below. Pair every motion-bearing class with a
+          <code>motion-reduce:*</code> escape on the same class string.
+        </PageHeader>
+
+        <section class="mb-[var(--spacing-xxl)]">
+          <h2 class="m-0 mb-[var(--spacing-md)] text-heading-lg text-[var(--text-default)]">Animations</h2>
+          <div class="flex flex-col gap-[var(--spacing-sm)]">
+            <div
+              v-for="row in animationRows"
+              :key="row.id"
+              class="flex items-center gap-[var(--spacing-md)] rounded-[var(--shape-card)] border border-[var(--border-default)] bg-[var(--bg-surface)] p-[var(--spacing-sm)]"
+            >
+              <div class="flex h-16 w-24 shrink-0 items-center justify-center overflow-hidden rounded-[var(--shape-elements)] bg-[var(--bg-canvas)]">
+                <div
+                  :key="replayKeys[row.id] || 0"
+                  class="h-8 w-8 rounded-[var(--shape-elements)] bg-[var(--primary)] motion-reduce:animate-none"
+                  :class="row.className"
+                ></div>
+              </div>
+              <div class="min-w-0 flex-1">
+                <div class="flex flex-wrap items-baseline gap-x-[var(--spacing-sm)]">
+                  <code class="text-body-md font-medium text-[var(--text-default)]">{{ row.className }}</code>
+                  <code class="text-body-sm text-[var(--text-secondary)]">{{ row.value }}</code>
+                </div>
+                <p class="m-0 mt-[var(--spacing-xxs)] text-body-sm text-[var(--text-secondary)]">{{ row.useWhen }}</p>
+              </div>
+              <button
+                v-if="!row.loops"
+                type="button"
+                class="shrink-0 cursor-pointer rounded-[var(--shape-elements)] border border-[var(--border-default)] bg-transparent px-[var(--spacing-sm)] py-[var(--spacing-xxs)] text-body-sm text-[var(--text-default)] hover:bg-[var(--bg-hover)]"
+                @click="replay(row.id)"
+              >
+                Replay
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <section class="mb-[var(--spacing-xxl)]">
+          <h2 class="m-0 mb-[var(--spacing-md)] text-heading-lg text-[var(--text-default)]">The panel recipe</h2>
+          <p class="m-0 mb-[var(--spacing-sm)] max-w-prose text-body-md text-[var(--text-secondary)]">
+            A <code>v-if</code> region never animates by itself. Wrap it in a Vue Transition and hand the
+            enter/leave phases to a catalogued pair — <code>animate-slide-in-left</code> /
+            <code>animate-slide-out-left</code> for a sidebar, the <code>-right</code> pair for drawers,
+            <code>animate-fade-in/out</code> for in-place content.
+          </p>
+          <CodeBlock :code="PANEL_RECIPE" language="html" />
+        </section>
+
+        <section class="mb-[var(--spacing-xxl)]">
+          <h2 class="m-0 mb-[var(--spacing-md)] text-heading-lg text-[var(--text-default)]">Duration tokens</h2>
+          <div class="flex flex-col gap-[var(--spacing-xs)]">
+            <div
+              v-for="row in durationRows"
+              :key="row.name"
+              class="flex items-center gap-[var(--spacing-md)]"
+            >
+              <code class="w-56 shrink-0 text-body-sm text-[var(--text-default)]">{{ row.name }}</code>
+              <code class="w-20 shrink-0 text-body-sm text-[var(--text-secondary)]">{{ row.value }}</code>
+              <div class="h-2 rounded-full bg-[var(--primary)]" :style="{ width: Math.min(row.ms / 8, 420) + 'px' }"></div>
+            </div>
+          </div>
+        </section>
+
+        <section class="mb-[var(--spacing-xxl)]">
+          <h2 class="m-0 mb-[var(--spacing-md)] text-heading-lg text-[var(--text-default)]">Easing curves</h2>
+          <div class="flex flex-col gap-[var(--spacing-xs)]">
+            <div v-for="row in curveRows" :key="row.name" class="flex items-center gap-[var(--spacing-md)]">
+              <code class="w-56 shrink-0 text-body-sm text-[var(--text-default)]">{{ row.name }}</code>
+              <code class="text-body-sm text-[var(--text-secondary)]">{{ row.value }}</code>
+            </div>
+          </div>
+          <p class="m-0 mt-[var(--spacing-sm)] max-w-prose text-body-sm text-[var(--text-secondary)]">
+            Entrances decelerate (productive/expressive entrance), exits accelerate (productive/expressive exit).
+            Interaction feedback stays at or under duration-moderate-01 (150ms).
+          </p>
+        </section>
+      </PageContainer>
+    `
+  })
+}

--- a/apps/storybook/src/stories/foundations/Motion.stories.js
+++ b/apps/storybook/src/stories/foundations/Motion.stories.js
@@ -11,12 +11,47 @@ const durationRows = Object.entries(duration).map(([name, value]) => ({
 
 const curveRows = Object.entries(curve).map(([name, value]) => ({ name: `ease-${name}`, value }))
 
+// Some utilities are invisible on the default primary square: shimmer animates
+// background-position (needs a gradient + background-size), the progress pair animates
+// inset-inline-* (needs a positioned bar inside the track), slide-down reveals height
+// (needs inner content to measure), and highlight-fade paints a background tint meant
+// for text rows. Each gets a preview shape that actually shows the motion.
+const DEFAULT_PREVIEW_CLASS = 'h-8 w-8 rounded-[var(--shape-elements)] bg-[var(--primary)]'
+
+const PREVIEW_OVERRIDES = {
+  shimmer: {
+    class: 'h-8 w-20 rounded-[var(--shape-elements)]',
+    style: {
+      background:
+        'linear-gradient(90deg, var(--bg-surface) 25%, var(--surface-hover) 50%, var(--bg-surface) 75%)',
+      backgroundSize: '200% 100%'
+    }
+  },
+  'slide-down': {
+    class: 'w-8 overflow-hidden rounded-[var(--shape-elements)] bg-[var(--primary)]',
+    style: { interpolateSize: 'allow-keywords' },
+    inner: true
+  },
+  'highlight-fade': {
+    class:
+      'rounded-[var(--shape-elements)] px-[var(--spacing-xs)] py-[var(--spacing-xxs)] text-body-sm text-[var(--text-default)]',
+    text: 'Updated row'
+  },
+  'progress-indeterminate': {
+    class: 'absolute top-1/2 h-2 -translate-y-1/2 rounded-full bg-[var(--primary)]'
+  },
+  'progress-indeterminate-short': {
+    class: 'absolute top-1/2 h-2 -translate-y-1/2 rounded-full bg-[var(--primary)]'
+  }
+}
+
 const animationRows = Object.entries(animate).map(([name, value]) => ({
   id: name,
   className: `animate-${name}`,
   value,
   useWhen: useWhen[name] ?? '',
-  loops: /\binfinite\b/.test(value)
+  loops: /\binfinite\b/.test(value),
+  preview: PREVIEW_OVERRIDES[name]
 }))
 
 const PANEL_RECIPE = `<Transition
@@ -56,7 +91,14 @@ export const Overview = {
   render: () => ({
     components: { PageContainer, PageHeader, CodeBlock },
     data() {
-      return { replayKeys: {}, durationRows, curveRows, animationRows, PANEL_RECIPE }
+      return {
+        replayKeys: {},
+        durationRows,
+        curveRows,
+        animationRows,
+        PANEL_RECIPE,
+        DEFAULT_PREVIEW_CLASS
+      }
     },
     methods: {
       replay(id) {
@@ -79,12 +121,16 @@ export const Overview = {
               :key="row.id"
               class="flex items-center gap-[var(--spacing-md)] rounded-[var(--shape-card)] border border-[var(--border-default)] bg-[var(--bg-surface)] p-[var(--spacing-sm)]"
             >
-              <div class="flex h-16 w-24 shrink-0 items-center justify-center overflow-hidden rounded-[var(--shape-elements)] bg-[var(--bg-canvas)]">
+              <div class="relative flex h-16 w-24 shrink-0 items-center justify-center overflow-hidden rounded-[var(--shape-elements)] bg-[var(--bg-canvas)]">
                 <div
                   :key="replayKeys[row.id] || 0"
-                  class="h-8 w-8 rounded-[var(--shape-elements)] bg-[var(--primary)] motion-reduce:animate-none"
-                  :class="row.className"
-                ></div>
+                  class="motion-reduce:animate-none"
+                  :class="[row.preview?.class || DEFAULT_PREVIEW_CLASS, row.className]"
+                  :style="row.preview?.style"
+                >
+                  <template v-if="row.preview?.text">{{ row.preview.text }}</template>
+                  <div v-else-if="row.preview?.inner" class="h-8 w-8"></div>
+                </div>
               </div>
               <div class="min-w-0 flex-1">
                 <div class="flex flex-wrap items-baseline gap-x-[var(--spacing-sm)]">

--- a/packages/theme/dist/v4/globals.css
+++ b/packages/theme/dist/v4/globals.css
@@ -407,6 +407,10 @@
   --animate-highlight-fade: highlight ease-in forwards;
   --animate-popup-scale-in: popupScaleIn 150ms cubic-bezier(0.39, 0.57, 0.56, 1);
   --animate-popup-scale-out: popupScaleOut 110ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
+  --animate-slide-in-left: slideInLeft 240ms cubic-bezier(0.39, 0.57, 0.56, 1);
+  --animate-slide-out-left: slideOutLeft 150ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
+  --animate-slide-in-right: slideInRight 240ms cubic-bezier(0.39, 0.57, 0.56, 1);
+  --animate-slide-out-right: slideOutRight 150ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
   --animate-progress-indeterminate: progressIndeterminate 2100ms cubic-bezier(0.39, 0.57, 0.56, 1) infinite;
   --animate-progress-indeterminate-short: progressIndeterminateShort 2100ms cubic-bezier(0.17, 0.84, 0.44, 1) 1100ms infinite;
 }
@@ -648,6 +652,10 @@
   --animate-highlight-fade: highlight ease-in forwards;
   --animate-popup-scale-in: popupScaleIn 150ms cubic-bezier(0.39, 0.57, 0.56, 1);
   --animate-popup-scale-out: popupScaleOut 110ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
+  --animate-slide-in-left: slideInLeft 240ms cubic-bezier(0.39, 0.57, 0.56, 1);
+  --animate-slide-out-left: slideOutLeft 150ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
+  --animate-slide-in-right: slideInRight 240ms cubic-bezier(0.39, 0.57, 0.56, 1);
+  --animate-slide-out-right: slideOutRight 150ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
   --animate-progress-indeterminate: progressIndeterminate 2100ms cubic-bezier(0.39, 0.57, 0.56, 1) infinite;
   --animate-progress-indeterminate-short: progressIndeterminateShort 2100ms cubic-bezier(0.17, 0.84, 0.44, 1) 1100ms infinite;
   --ring-offset: 0.5px;
@@ -977,6 +985,26 @@
 @keyframes popupScaleOut {
   0% { opacity: 1; transform: scale(1); }
   100% { opacity: 0; transform: scale(0.95); }
+}
+
+@keyframes slideInLeft {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(0); }
+}
+
+@keyframes slideOutLeft {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-100%); }
+}
+
+@keyframes slideInRight {
+  0% { transform: translateX(100%); }
+  100% { transform: translateX(0); }
+}
+
+@keyframes slideOutRight {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(100%); }
 }
 
 @keyframes progressIndeterminate {

--- a/packages/theme/dist/v4/globals.scss
+++ b/packages/theme/dist/v4/globals.scss
@@ -407,6 +407,10 @@
   --animate-highlight-fade: highlight ease-in forwards;
   --animate-popup-scale-in: popupScaleIn 150ms cubic-bezier(0.39, 0.57, 0.56, 1);
   --animate-popup-scale-out: popupScaleOut 110ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
+  --animate-slide-in-left: slideInLeft 240ms cubic-bezier(0.39, 0.57, 0.56, 1);
+  --animate-slide-out-left: slideOutLeft 150ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
+  --animate-slide-in-right: slideInRight 240ms cubic-bezier(0.39, 0.57, 0.56, 1);
+  --animate-slide-out-right: slideOutRight 150ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
   --animate-progress-indeterminate: progressIndeterminate 2100ms cubic-bezier(0.39, 0.57, 0.56, 1) infinite;
   --animate-progress-indeterminate-short: progressIndeterminateShort 2100ms cubic-bezier(0.17, 0.84, 0.44, 1) 1100ms infinite;
 }
@@ -648,6 +652,10 @@
   --animate-highlight-fade: highlight ease-in forwards;
   --animate-popup-scale-in: popupScaleIn 150ms cubic-bezier(0.39, 0.57, 0.56, 1);
   --animate-popup-scale-out: popupScaleOut 110ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
+  --animate-slide-in-left: slideInLeft 240ms cubic-bezier(0.39, 0.57, 0.56, 1);
+  --animate-slide-out-left: slideOutLeft 150ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
+  --animate-slide-in-right: slideInRight 240ms cubic-bezier(0.39, 0.57, 0.56, 1);
+  --animate-slide-out-right: slideOutRight 150ms cubic-bezier(0.55, 0.09, 0.68, 0.53);
   --animate-progress-indeterminate: progressIndeterminate 2100ms cubic-bezier(0.39, 0.57, 0.56, 1) infinite;
   --animate-progress-indeterminate-short: progressIndeterminateShort 2100ms cubic-bezier(0.17, 0.84, 0.44, 1) 1100ms infinite;
   --ring-offset: 0.5px;
@@ -977,6 +985,26 @@
 @keyframes popupScaleOut {
   0% { opacity: 1; transform: scale(1); }
   100% { opacity: 0; transform: scale(0.95); }
+}
+
+@keyframes slideInLeft {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(0); }
+}
+
+@keyframes slideOutLeft {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-100%); }
+}
+
+@keyframes slideInRight {
+  0% { transform: translateX(100%); }
+  100% { transform: translateX(0); }
+}
+
+@keyframes slideOutRight {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(100%); }
 }
 
 @keyframes progressIndeterminate {

--- a/packages/theme/src/tokens/primitives/animations/animate.js
+++ b/packages/theme/src/tokens/primitives/animations/animate.js
@@ -29,8 +29,6 @@ export const animate = {
   'highlight-fade': 'highlight ease-in forwards',
   'popup-scale-in': `popupScaleIn ${duration['moderate-01']} ${curve['productive-entrance']}`,
   'popup-scale-out': `popupScaleOut ${duration['fast-02']} ${curve['productive-exit']}`,
-  // Lateral panels (sidebar / drawer): the panel slides from its anchored edge.
-  // Entrance is a touch longer than popups (larger surface); exit is quicker.
   'slide-in-left': `slideInLeft ${duration['moderate-02']} ${curve['productive-entrance']}`,
   'slide-out-left': `slideOutLeft ${duration['moderate-01']} ${curve['productive-exit']}`,
   'slide-in-right': `slideInRight ${duration['moderate-02']} ${curve['productive-entrance']}`,
@@ -39,11 +37,6 @@ export const animate = {
   'progress-indeterminate-short': `progressIndeterminateShort ${duration['slow-04']} ${curve['expressive-entrance']} ${duration['slow-03']} infinite`
 }
 
-/**
- * When to reach for each `animate-*` utility — the guidance half of the catalog,
- * surfaced to consumers by the webkit MCP (`list_tokens`) and the Storybook
- * Foundations/Motion page. Every `animate` key has an entry; keep them in sync.
- */
 export const useWhen = {
   spin: 'Indeterminate circular spinners (loading icons).',
   ping: 'One-off attention ring radiating from a small element (notification dot).',

--- a/packages/theme/src/tokens/primitives/animations/animate.js
+++ b/packages/theme/src/tokens/primitives/animations/animate.js
@@ -29,8 +29,43 @@ export const animate = {
   'highlight-fade': 'highlight ease-in forwards',
   'popup-scale-in': `popupScaleIn ${duration['moderate-01']} ${curve['productive-entrance']}`,
   'popup-scale-out': `popupScaleOut ${duration['fast-02']} ${curve['productive-exit']}`,
+  // Lateral panels (sidebar / drawer): the panel slides from its anchored edge.
+  // Entrance is a touch longer than popups (larger surface); exit is quicker.
+  'slide-in-left': `slideInLeft ${duration['moderate-02']} ${curve['productive-entrance']}`,
+  'slide-out-left': `slideOutLeft ${duration['moderate-01']} ${curve['productive-exit']}`,
+  'slide-in-right': `slideInRight ${duration['moderate-02']} ${curve['productive-entrance']}`,
+  'slide-out-right': `slideOutRight ${duration['moderate-01']} ${curve['productive-exit']}`,
   'progress-indeterminate': `progressIndeterminate ${duration['slow-04']} ${curve['productive-entrance']} infinite`,
   'progress-indeterminate-short': `progressIndeterminateShort ${duration['slow-04']} ${curve['expressive-entrance']} ${duration['slow-03']} infinite`
 }
 
-export default { animate, curve, duration }
+/**
+ * When to reach for each `animate-*` utility — the guidance half of the catalog,
+ * surfaced to consumers by the webkit MCP (`list_tokens`) and the Storybook
+ * Foundations/Motion page. Every `animate` key has an entry; keep them in sync.
+ */
+export const useWhen = {
+  spin: 'Indeterminate circular spinners (loading icons).',
+  ping: 'One-off attention ring radiating from a small element (notification dot).',
+  pulse: 'Skeleton/placeholder opacity pulse while content loads.',
+  bounce: 'Playful attention bounce (scroll-down hints); use sparingly.',
+  shimmer: 'Skeleton shimmer sweep while content loads.',
+  blink: 'Text caret / terminal cursor blink.',
+  'fade-in': 'Content or backdrop appearing in place (no directional origin).',
+  'fade-out': 'Content or backdrop leaving in place (pair of fade-in).',
+  'slide-down': 'Vertical disclosure expanding (accordion panel, expandable row).',
+  'highlight-fade': 'Row/item briefly highlighted after an update (recently changed).',
+  'popup-scale-in':
+    'Anchored overlays opening (dropdown, popover, tooltip, menu); set --popup-origin.',
+  'popup-scale-out': 'Anchored overlays closing (pair of popup-scale-in).',
+  'slide-in-left':
+    'Left-anchored panel entering (sidebar, navigation drawer). Wrap the v-if region in a Vue Transition with enter-active-class.',
+  'slide-out-left':
+    'Left-anchored panel leaving (pair of slide-in-left; use as leave-active-class).',
+  'slide-in-right': 'Right-anchored panel entering (settings/detail drawer).',
+  'slide-out-right': 'Right-anchored panel leaving (pair of slide-in-right).',
+  'progress-indeterminate': 'Indeterminate linear progress bar (primary sweep).',
+  'progress-indeterminate-short': 'Indeterminate linear progress bar (secondary short sweep).'
+}
+
+export default { animate, curve, duration, useWhen }

--- a/packages/theme/src/tokens/primitives/animations/keyframes.js
+++ b/packages/theme/src/tokens/primitives/animations/keyframes.js
@@ -14,47 +14,63 @@
 export const keyframes = {
   fadeIn: {
     '0%': 'opacity: 0',
-    '100%': 'opacity: 1',
+    '100%': 'opacity: 1'
   },
   fadeOut: {
     '0%': 'opacity: 1',
-    '100%': 'opacity: 0',
+    '100%': 'opacity: 0'
   },
   slideDown: {
     '0%': 'height: 0',
-    '100%': 'height: auto',
+    '100%': 'height: auto'
   },
   blink: {
     '0%, 100%': 'opacity: 1',
-    '50%': 'opacity: 0',
+    '50%': 'opacity: 0'
   },
   highlight: {
     '0%': 'background-color: var(--surface-hover); font-weight: 500',
-    '100%': 'background-color: var(--surface-hover); font-weight: 500',
+    '100%': 'background-color: var(--surface-hover); font-weight: 500'
   },
   shimmer: {
     '0%': 'background-position: 200% 0',
-    '100%': 'background-position: -200% 0',
+    '100%': 'background-position: -200% 0'
   },
   popupScaleIn: {
     '0%': 'opacity: 0; transform: scale(0.95)',
-    '100%': 'opacity: 1; transform: scale(1)',
+    '100%': 'opacity: 1; transform: scale(1)'
   },
   popupScaleOut: {
     '0%': 'opacity: 1; transform: scale(1)',
-    '100%': 'opacity: 0; transform: scale(0.95)',
+    '100%': 'opacity: 0; transform: scale(0.95)'
+  },
+  slideInLeft: {
+    '0%': 'transform: translateX(-100%)',
+    '100%': 'transform: translateX(0)'
+  },
+  slideOutLeft: {
+    '0%': 'transform: translateX(0)',
+    '100%': 'transform: translateX(-100%)'
+  },
+  slideInRight: {
+    '0%': 'transform: translateX(100%)',
+    '100%': 'transform: translateX(0)'
+  },
+  slideOutRight: {
+    '0%': 'transform: translateX(0)',
+    '100%': 'transform: translateX(100%)'
   },
   progressIndeterminate: {
     '0%': 'inset-inline-start: -35%; inset-inline-end: 100%',
     '60%': 'inset-inline-start: 100%; inset-inline-end: -90%',
-    '100%': 'inset-inline-start: 100%; inset-inline-end: -90%',
+    '100%': 'inset-inline-start: 100%; inset-inline-end: -90%'
   },
   progressIndeterminateShort: {
     '0%': 'inset-inline-start: -200%; inset-inline-end: 100%',
     '60%': 'inset-inline-start: 107%; inset-inline-end: -8%',
-    '100%': 'inset-inline-start: 107%; inset-inline-end: -8%',
-  },
-};
+    '100%': 'inset-inline-start: 107%; inset-inline-end: -8%'
+  }
+}
 
 /**
  * Utilities that need CSS properties beyond the `animation` shorthand
@@ -63,7 +79,7 @@ export const keyframes = {
  */
 export const animateExtras = {
   'animate-popup-scale-in': { 'transform-origin': 'var(--popup-origin, center)' },
-  'animate-popup-scale-out': { 'transform-origin': 'var(--popup-origin, center)' },
-};
+  'animate-popup-scale-out': { 'transform-origin': 'var(--popup-origin, center)' }
+}
 
-export default { keyframes, animateExtras };
+export default { keyframes, animateExtras }

--- a/packages/webkit/catalog.json
+++ b/packages/webkit/catalog.json
@@ -55,6 +55,10 @@
       "--animate-pulse",
       "--animate-shimmer",
       "--animate-slide-down",
+      "--animate-slide-in-left",
+      "--animate-slide-in-right",
+      "--animate-slide-out-left",
+      "--animate-slide-out-right",
       "--animate-spin",
       "--aspect-video",
       "--bg-active",
@@ -721,6 +725,10 @@
         "--animate-pulse",
         "--animate-shimmer",
         "--animate-slide-down",
+        "--animate-slide-in-left",
+        "--animate-slide-in-right",
+        "--animate-slide-out-left",
+        "--animate-slide-out-right",
         "--animate-spin"
       ],
       "aspect": [
@@ -1416,8 +1424,86 @@
       "pulse",
       "shimmer",
       "slide-down",
+      "slide-in-left",
+      "slide-in-right",
+      "slide-out-left",
+      "slide-out-right",
       "spin"
-    ]
+    ],
+    "animationGuide": {
+      "blink": {
+        "value": "blink 1s step-end infinite",
+        "useWhen": "Text caret / terminal cursor blink."
+      },
+      "bounce": {
+        "value": "bounce 1s infinite",
+        "useWhen": "Playful attention bounce (scroll-down hints); use sparingly."
+      },
+      "fade-in": {
+        "value": "fadeIn 220ms ease-in-out",
+        "useWhen": "Content or backdrop appearing in place (no directional origin)."
+      },
+      "fade-out": {
+        "value": "fadeOut 220ms ease-in-out",
+        "useWhen": "Content or backdrop leaving in place (pair of fade-in)."
+      },
+      "highlight-fade": {
+        "value": "highlight ease-in forwards",
+        "useWhen": "Row/item briefly highlighted after an update (recently changed)."
+      },
+      "ping": {
+        "value": "ping 1s cubic-bezier(0, 0, 0.2, 1) infinite",
+        "useWhen": "One-off attention ring radiating from a small element (notification dot)."
+      },
+      "popup-scale-in": {
+        "value": "popupScaleIn 150ms cubic-bezier(0.39, 0.57, 0.56, 1)",
+        "useWhen": "Anchored overlays opening (dropdown, popover, tooltip, menu); set --popup-origin."
+      },
+      "popup-scale-out": {
+        "value": "popupScaleOut 110ms cubic-bezier(0.55, 0.09, 0.68, 0.53)",
+        "useWhen": "Anchored overlays closing (pair of popup-scale-in)."
+      },
+      "progress-indeterminate": {
+        "value": "progressIndeterminate 2100ms cubic-bezier(0.39, 0.57, 0.56, 1) infinite",
+        "useWhen": "Indeterminate linear progress bar (primary sweep)."
+      },
+      "progress-indeterminate-short": {
+        "value": "progressIndeterminateShort 2100ms cubic-bezier(0.17, 0.84, 0.44, 1) 1100ms infinite",
+        "useWhen": "Indeterminate linear progress bar (secondary short sweep)."
+      },
+      "pulse": {
+        "value": "pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite",
+        "useWhen": "Skeleton/placeholder opacity pulse while content loads."
+      },
+      "shimmer": {
+        "value": "shimmer 1.6s linear infinite",
+        "useWhen": "Skeleton shimmer sweep while content loads."
+      },
+      "slide-down": {
+        "value": "slideDown 220ms ease-in-out",
+        "useWhen": "Vertical disclosure expanding (accordion panel, expandable row)."
+      },
+      "slide-in-left": {
+        "value": "slideInLeft 240ms cubic-bezier(0.39, 0.57, 0.56, 1)",
+        "useWhen": "Left-anchored panel entering (sidebar, navigation drawer). Wrap the v-if region in a Vue Transition with enter-active-class."
+      },
+      "slide-in-right": {
+        "value": "slideInRight 240ms cubic-bezier(0.39, 0.57, 0.56, 1)",
+        "useWhen": "Right-anchored panel entering (settings/detail drawer)."
+      },
+      "slide-out-left": {
+        "value": "slideOutLeft 150ms cubic-bezier(0.55, 0.09, 0.68, 0.53)",
+        "useWhen": "Left-anchored panel leaving (pair of slide-in-left; use as leave-active-class)."
+      },
+      "slide-out-right": {
+        "value": "slideOutRight 150ms cubic-bezier(0.55, 0.09, 0.68, 0.53)",
+        "useWhen": "Right-anchored panel leaving (pair of slide-in-right)."
+      },
+      "spin": {
+        "value": "spin 1s linear infinite",
+        "useWhen": "Indeterminate circular spinners (loading icons)."
+      }
+    }
   },
   "vocabulary": {
     "props": [
@@ -1526,6 +1612,12 @@
       "target": "./src/stylelint-config.js",
       "kind": "other",
       "treeShakeableImport": "@aziontech/webkit/stylelint-config"
+    },
+    "styles": {
+      "import": "@aziontech/webkit/styles",
+      "target": "./src/styles.css",
+      "kind": "other",
+      "treeShakeableImport": "@aziontech/webkit/styles"
     },
     "overline": {
       "import": "@aziontech/webkit/overline",
@@ -4272,7 +4364,8 @@
           "notes": "Optional override for a single toast's body. `toast` is the store entry (`{ id, type, message, description?, action?, duration }`); `dismiss` dismisses that entry. When omitted, the `Toaster` composes `ToastItem` + `Title`/`Description`/`Action`/`Close` from the entry."
         }
       ],
-      "purpose": "A transient, non-blocking notification system: mount the `<Toaster>` region **once** near the application root, then raise notifications imperatively from anywhere via the exported `toast()` function (`toast('Saved')`) and its type shortcuts (`toast.success`, `toast.error`, `toast.info`, `toast.warning`, `toast.loading`, `toast.promise`, `toast.dismiss`). Each notification is a self-dismissing card that stacks in a corner, animates in and out, and is announced to assistive technology — without stealing focus. Unlike the sibling [`Message`](./message.md), which is an **inline** banner the consumer places in the document flow and controls with `v-model`-style props, Toast is a **transient overlay** stack driven by an imperative call and a shared reactive store, so the call site needs no local visibility state and no markup of its own. The card surface, typography, and severity icons follow the Figma design (see `figma` in the frontmatter). The interaction model follows the established mount-once toast pattern (a single anchored region + imperative trigger + auto-dismiss stack that groups collapsed and expands on hover), built on our tokens, our semantic animation utilities, and our composition/compound-API conventions per [`.claude/rules/migration.md`](../.claude/rules/migration.md); nothing is inherited from any external library. Each severity tints only its leading **icon** via the matching `-contrast` token (`var(--success-contrast)` / `var(--warning-contrast)` / `var(--danger-contrast)` / `var(--info-contrast)`) over the shared `var(--bg-surface-raised)` surface."
+      "purpose": "A transient, non-blocking notification system: mount the `<Toaster>` region **once** near the application root, then raise notifications imperatively from anywhere via the exported `toast()` function (`toast('Saved')`) and its type shortcuts (`toast.success`, `toast.error`, `toast.info`, `toast.warning`, `toast.loading`, `toast.promise`, `toast.dismiss`). Each notification is a self-dismissing card that stacks in a corner, animates in and out, and is announced to assistive technology — without stealing focus. Unlike the sibling [`Message`](./message.md), which is an **inline** banner the consumer places in the document flow and controls with `v-model`-style props, Toast is a **transient overlay** stack driven by an imperative call and a shared reactive store, so the call site needs no local visibility state and no markup of its own. The card surface, typography, and severity icons follow the Figma design (see `figma` in the frontmatter). The interaction model follows the established mount-once toast pattern (a single anchored region + imperative trigger + auto-dismiss stack that groups collapsed and expands on hover), built on our tokens, our semantic animation utilities, and our composition/compound-API conventions per [`.claude/rules/migration.md`](../.claude/rules/migration.md); nothing is inherited from any external library. Each severity tints only its leading **icon** via the matching `-contrast` token (`var(--success-contrast)` / `var(--warning-contrast)` / `var(--danger-contrast)` / `var(--info-contrast)`) over the shared `var(--bg-surface-raised)` surface.",
+      "setup": "One-time app-level wiring before the first toast() call — service (recommended): import { ToastPlugin } from '@aziontech/webkit/toast' and chain .use(ToastPlugin) onto createApp() in the app entry; the plugin mounts the toast region automatically. Alternative: mount a Toaster component once near the app root. `webkit doctor` flags toast usage with no wired region."
     },
     "toast-root": {
       "import": "@aziontech/webkit/toast-root",
@@ -4327,7 +4420,8 @@
           "notes": "Optional override for a single toast's body. `toast` is the store entry (`{ id, type, message, description?, action?, duration }`); `dismiss` dismisses that entry. When omitted, the `Toaster` composes `ToastItem` + `Title`/`Description`/`Action`/`Close` from the entry."
         }
       ],
-      "purpose": "A transient, non-blocking notification system: mount the `<Toaster>` region **once** near the application root, then raise notifications imperatively from anywhere via the exported `toast()` function (`toast('Saved')`) and its type shortcuts (`toast.success`, `toast.error`, `toast.info`, `toast.warning`, `toast.loading`, `toast.promise`, `toast.dismiss`). Each notification is a self-dismissing card that stacks in a corner, animates in and out, and is announced to assistive technology — without stealing focus. Unlike the sibling [`Message`](./message.md), which is an **inline** banner the consumer places in the document flow and controls with `v-model`-style props, Toast is a **transient overlay** stack driven by an imperative call and a shared reactive store, so the call site needs no local visibility state and no markup of its own. The card surface, typography, and severity icons follow the Figma design (see `figma` in the frontmatter). The interaction model follows the established mount-once toast pattern (a single anchored region + imperative trigger + auto-dismiss stack that groups collapsed and expands on hover), built on our tokens, our semantic animation utilities, and our composition/compound-API conventions per [`.claude/rules/migration.md`](../.claude/rules/migration.md); nothing is inherited from any external library. Each severity tints only its leading **icon** via the matching `-contrast` token (`var(--success-contrast)` / `var(--warning-contrast)` / `var(--danger-contrast)` / `var(--info-contrast)`) over the shared `var(--bg-surface-raised)` surface."
+      "purpose": "A transient, non-blocking notification system: mount the `<Toaster>` region **once** near the application root, then raise notifications imperatively from anywhere via the exported `toast()` function (`toast('Saved')`) and its type shortcuts (`toast.success`, `toast.error`, `toast.info`, `toast.warning`, `toast.loading`, `toast.promise`, `toast.dismiss`). Each notification is a self-dismissing card that stacks in a corner, animates in and out, and is announced to assistive technology — without stealing focus. Unlike the sibling [`Message`](./message.md), which is an **inline** banner the consumer places in the document flow and controls with `v-model`-style props, Toast is a **transient overlay** stack driven by an imperative call and a shared reactive store, so the call site needs no local visibility state and no markup of its own. The card surface, typography, and severity icons follow the Figma design (see `figma` in the frontmatter). The interaction model follows the established mount-once toast pattern (a single anchored region + imperative trigger + auto-dismiss stack that groups collapsed and expands on hover), built on our tokens, our semantic animation utilities, and our composition/compound-API conventions per [`.claude/rules/migration.md`](../.claude/rules/migration.md); nothing is inherited from any external library. Each severity tints only its leading **icon** via the matching `-contrast` token (`var(--success-contrast)` / `var(--warning-contrast)` / `var(--danger-contrast)` / `var(--info-contrast)`) over the shared `var(--bg-surface-raised)` surface.",
+      "setup": "One-time app-level wiring before the first toast() call — service (recommended): import { ToastPlugin } from '@aziontech/webkit/toast' and chain .use(ToastPlugin) onto createApp() in the app entry; the plugin mounts the toast region automatically. Alternative: mount a Toaster component once near the app root. `webkit doctor` flags toast usage with no wired region."
     },
     "toast-item": {
       "import": "@aziontech/webkit/toast-item",

--- a/packages/webkit/cli-templates/claude/CLAUDE.fragment.md
+++ b/packages/webkit/cli-templates/claude/CLAUDE.fragment.md
@@ -28,6 +28,11 @@ layer you're in, because only one of them is optional:
   ARIA, no click handler without a key handler.
 - **Small bundles.** Prefer the `<name>-root` path (or specific sub-components), import icons
   individually, lazy-load heavy overlays.
+- **App-level setup at first use.** A few components declare a one-time wiring in their catalog
+  `setup` field (via the MCP's `get_component`). Toast: before the first `toast(...)` call, wire
+  `import { ToastPlugin } from '@aziontech/webkit/toast'` + `.use(ToastPlugin)` on `createApp()`
+  in the entry (the plugin mounts the region automatically); skip if already wired. `webkit doctor`
+  flags usage with missing setup.
 
 ### Enforced by lint (blocks — nothing here is a suggestion)
 

--- a/packages/webkit/cli-templates/claude/rules/webkit-motion.md
+++ b/packages/webkit/cli-templates/claude/rules/webkit-motion.md
@@ -62,3 +62,17 @@ shape; vertical disclosure uses `animate-slide-down`. Ask the webkit MCP
   `/webkit-motion-polish` review pass; where a stylelint rule can catch a raw `cubic-bezier(` or a
   bare `transition: all`, wire it as the mechanical floor. Suggestion is not the ceiling: what a lint
   can block, block.
+
+### Known `no-hardcoded-motion` gaps (review still owns these)
+
+The lint is a heuristic over class and style strings; three shapes are known to slip past it and
+stay a review concern:
+
+- **Tailwind arbitrary properties** bypass the timing check: in `[transition:opacity_200ms]` the
+  underscore defeats the word boundary, and `[animation-delay:2s]` sits outside the `animation:`
+  prefix — while `[transition:all]` is caught.
+- **Tailwind v4's dynamic numeric scale**: `duration-937` passes (only the bracketed
+  `duration-[937ms]` form is flagged).
+- **The `motion-reduce:` pairing check reads only the static `class` attribute** — when the escape
+  lives in a coexisting bound `:class` fragment, the static-side motion class is flagged even
+  though the element is correctly paired.

--- a/packages/webkit/cli-templates/claude/rules/webkit-motion.md
+++ b/packages/webkit/cli-templates/claude/rules/webkit-motion.md
@@ -21,6 +21,25 @@ always has a reduced-motion escape. This is the invariant behind the `/webkit-mo
 - For `data-state="open|closed"` overlay motion, read `duration` + `curve` from the tokens and emit
   the inline `transition` per phase; keep transform/opacity in classes, only timing inline.
 
+## The panel recipe (sidebar / drawer / any v-if region)
+
+A conditionally rendered region never animates by itself — wrap the `v-if` in a Vue `Transition`
+and hand the enter/leave phases to the catalogued utilities. For lateral panels the pair is
+`animate-slide-in-left` / `animate-slide-out-left` (right-anchored drawers use the `-right` pair):
+
+```vue
+<Transition
+  enter-active-class="animate-slide-in-left motion-reduce:animate-none"
+  leave-active-class="animate-slide-out-left motion-reduce:animate-none"
+>
+  <aside v-if="sidebarOpen">...</aside>
+</Transition>
+```
+
+Content or backdrops appearing in place use `animate-fade-in` / `animate-fade-out` in the same
+shape; vertical disclosure uses `animate-slide-down`. Ask the webkit MCP
+(`list_tokens` with category `animations`) for every utility, its timing, and when to use it.
+
 ## Never
 
 - A hardcoded duration (`duration-[180ms]`, `transition: opacity 200ms`) or an inline

--- a/packages/webkit/cli-templates/claude/skills/webkit-motion-polish/SKILL.md
+++ b/packages/webkit/cli-templates/claude/skills/webkit-motion-polish/SKILL.md
@@ -52,10 +52,29 @@ The `animate-*` utilities from the animation token catalog (listed by the webkit
 | `animate-fade-in` / `animate-fade-out`               | opacity in / out                                                 |
 | `animate-slide-down`                                 | height 0 → auto (the one catalogued height animation — see note) |
 | `animate-popup-scale-in` / `animate-popup-scale-out` | scale + fade for popovers/menus                                  |
+| `animate-slide-in-left` / `animate-slide-out-left`   | left-anchored panel enter/leave (sidebar, nav drawer)            |
+| `animate-slide-in-right` / `animate-slide-out-right` | right-anchored panel enter/leave (settings/detail drawer)        |
 | `animate-blink`                                      | caret/blink                                                      |
 | `animate-highlight-fade`                             | row-flash highlight                                              |
 
 For `animate-popup-scale-in/out`, set `--popup-origin` per instance to match the trigger anchor.
+
+### The panel recipe (sidebar / drawer / any v-if region)
+
+A conditionally rendered region never animates by itself — wrap the `v-if` in a Vue `Transition`
+and hand the phases to the catalogued pair:
+
+```vue
+<Transition
+  enter-active-class="animate-slide-in-left motion-reduce:animate-none"
+  leave-active-class="animate-slide-out-left motion-reduce:animate-none"
+>
+  <aside v-if="sidebarOpen">...</aside>
+</Transition>
+```
+
+Same shape with `animate-fade-in/out` for in-place content and backdrops, and
+`animate-slide-down` for vertical disclosure.
 
 ### Timing only from tokens
 

--- a/packages/webkit/cli-templates/claude/skills/webkit-motion-polish/SKILL.md
+++ b/packages/webkit/cli-templates/claude/skills/webkit-motion-polish/SKILL.md
@@ -2,7 +2,7 @@
 name: webkit-motion-polish
 description: Make motion smooth using only @aziontech/theme animate tokens — animate-* utilities, duration-*/ease-*/curve tokens, compositor-props-only, ≤150ms interaction feedback, and a mandatory motion-reduce escape on every motion class. No external animation library, no inline cubic-bezier, no hardcoded ms.
 status: active
-last_updated: 2026-07-20
+last_updated: 2026-07-22
 scope: general
 enforced_by: [webkit-motion, webkit-accessibility, ui-verify]
 ---

--- a/packages/webkit/cli-templates/claude/skills/webkit-usage/SKILL.md
+++ b/packages/webkit/cli-templates/claude/skills/webkit-usage/SKILL.md
@@ -3,7 +3,7 @@ name: webkit-usage
 description: Consume the @aziontech/webkit design system correctly. Use when adding or reviewing UI in a project that depends on @aziontech/webkit — how to find the right component, import it with the flat path, style with @aziontech/theme tokens, and keep bundles small.
 scope: general
 status: active
-last_updated: 2026-07-20
+last_updated: 2026-07-22
 enforced_by: [webkit-imports, webkit-tokens, webkit-prefer-over-custom, webkit-performance]
 ---
 

--- a/packages/webkit/cli-templates/claude/skills/webkit-usage/SKILL.md
+++ b/packages/webkit/cli-templates/claude/skills/webkit-usage/SKILL.md
@@ -22,6 +22,12 @@ Do not guess a component name or import path. Look it up.
    - Import/validation tools — confirm a subpath is real and get the canonical path.
 2. Read the catalog directly. `node_modules/@aziontech/webkit/catalog.json` has an `imports` object; every key is a real published subpath (`button`, `empty-state`, `table`, ...). If a subpath is not a key there, it does not exist.
 
+## App-level setup (`setup` in the catalog)
+
+A few components need **one-time wiring in the app entry before first use** — the catalog entry (and `get_component` on the MCP) carries it in a `setup` field. When `setup` is non-null, apply it BEFORE emitting code that uses the component, and check whether the project already has it (do not duplicate).
+
+- **Toast**: fire-from-anywhere (`toast.success('Saved')`) only renders if a region is mounted. Wire the service once in the entry — `import { ToastPlugin } from '@aziontech/webkit/toast'` and chain `.use(ToastPlugin)` onto `createApp()`; the plugin mounts the region automatically (options: `app.use(ToastPlugin, { position: 'top-right' })`). A manually mounted Toaster also counts — never add both blindly (the store keeps only the first region active, but one wiring is enough). `npx webkit doctor` flags toast usage with no wired region.
+
 ## Must Have
 
 - ✅ Flat import: `import Button from '@aziontech/webkit/button'`.

--- a/packages/webkit/docs/toolkit/cli.md
+++ b/packages/webkit/docs/toolkit/cli.md
@@ -10,16 +10,21 @@ It wires everything and then gets out of the way: after setup there are no extra
 
 ## What `init` does
 
-The plan is computed by reading your project first, then applied without ever clobbering your files — each step either writes something absent, merges/appends behind a marker, or just advises.
+The plan is computed by reading your project first, then applied without ever clobbering your files — each step either writes something absent, merges/appends behind a marker, patches once behind an idempotency check, or just advises.
 
-1. **Dependencies** recorded in `package.json` — `@aziontech/webkit`, `@aziontech/theme`, `@aziontech/icons`, plus dev tooling peers (`eslint`, `stylelint`, `vue-eslint-parser`, `@typescript-eslint/parser`, `postcss-html`, `postcss-scss`, `husky`). The ESLint plugin, Stylelint config, and MCP server all ship inside `@aziontech/webkit` (subpaths + bins), so no separate toolkit packages are added. It does not run an install — do that with your package manager.
+On a TTY (and without `--yes`), `init` first asks about the optional pieces — install the icon font? wire the entry imports automatically? — one Y/n question each. Piped/CI runs never prompt: they take the defaults (everything on) minus any `--no-*` flag.
+
+1. **Dependencies** recorded in `package.json` — `@aziontech/webkit`, `@aziontech/theme`, `@aziontech/icons` (unless `--no-icons`), plus dev tooling peers (`eslint`, `stylelint`, `vue-eslint-parser`, `@typescript-eslint/parser`, `postcss-html`, `postcss-scss`, `husky`). The ESLint plugin, Stylelint config, and MCP server all ship inside `@aziontech/webkit` (subpaths + bins), so no separate toolkit packages are added. It does not run an install — do that with your package manager.
 2. **`eslint.config.mjs`** (flat, ESM) wiring the webkit preset — or a merge snippet if an ESLint config already exists.
 3. **`.stylelintrc.json`** extending the webkit config, with the `.vue` / `.scss` custom syntaxes wired — or a merge snippet if a Stylelint config already exists.
-4. **`.mcp.json`** — the `webkit` MCP server merged in (other servers untouched).
-5. **`prepare` script + `.husky/pre-commit`** — lint on commit. The install runs `prepare` (husky), which activates the hooks.
-6. **`.claude/` bundle** — rules, the `webkit-usage` skill, and agents — only files that are missing.
-7. **`CLAUDE.md` fragment** — appended once, guarded by a marker.
-8. **Theme wiring advice** — if `src/main.*` lacks the theme import, it suggests adding it (never edits your entry file).
+4. **`src/webkit.css`** — the one CSS entry: `@import '@aziontech/theme'` (tokens + Tailwind v4 + fonts) and `@import '@aziontech/webkit/styles'`, which registers webkit's source with Tailwind so its component classes compile. Both resolve by package name — no `../node_modules` path in your CSS (the `@source` ships inside the package and resolves relative to it, so hoisting/workspace layouts can't break it).
+5. **`.mcp.json`** — the `webkit` MCP server merged in (other servers untouched).
+6. **`prepare` script + `.husky/pre-commit`** — lint on commit. The install runs `prepare` (husky), which activates the hooks.
+7. **`.claude/` bundle** — rules, the `webkit-usage` skill, and agents — only files that are missing.
+8. **`CLAUDE.md` fragment** — appended once, guarded by a marker.
+9. **Entry wiring** — `import './webkit.css'` and `import '@aziontech/icons'` prepended once to `src/main.*`; skipped when already imported, `--no-entry` prints the imports instead of editing the file.
+
+Feature-scoped setup is deliberately **not** part of `init`. A component that needs one-time app wiring (e.g. toast: `.use(ToastPlugin)` on `createApp()` — the plugin mounts the region automatically) declares it in its catalog entry's `setup` field, surfaced by the MCP's `get_component` / `get_best_practices` — so it is wired **just-in-time at first use**, by you or your AI, instead of preloading unused code for everyone. `doctor` backstops it mechanically (see below).
 
 ## Options
 
@@ -28,6 +33,9 @@ The plan is computed by reading your project first, then applied without ever cl
 | `--dry-run`     | Print the plan; write nothing.                                  |
 | `--strict`      | Strict ESLint preset (default).                                 |
 | `--recommended` | Recommended preset — every rule is still `error`, never `warn`. |
+| `-y`, `--yes`   | Accept every default; never prompt (CI / scripted runs).        |
+| `--no-icons`    | Skip `@aziontech/icons` (the icon font) and its entry import.   |
+| `--no-entry`    | Do not edit `src/main.*`; print the imports to add instead.     |
 
 Unknown flags are rejected (so a typo'd `--dryrun` never becomes a real write run).
 
@@ -41,9 +49,11 @@ The toolkit is fail-open by design (a missing catalog disables the lint rules ra
 
 - **webkit catalog** resolvable (`FAIL` = lint rules are disabled — install webkit or set `WEBKIT_CATALOG_PATH`);
 - **eslint / stylelint config** present;
+- **webkit.css** registers webkit with Tailwind (`@import '@aziontech/webkit/styles'`, or a legacy inline `@source`) — `FAIL` = unstyled components;
 - **mcp server** registered in `.mcp.json`;
 - **husky** `prepare` script + `.husky/pre-commit` lint block present;
-- **theme import** at the app entry;
+- **styles import** (`./webkit.css`) at the app entry, and the **icons import** when `@aziontech/icons` is a dependency;
+- **toast setup** — only when the source imports `@aziontech/webkit/toast`: a region must be wired (`.use(ToastPlugin)` in the entry, or a mounted Toaster), otherwise `WARN` with the exact fix;
 - **dependency versions** — the resolved installed version of each toolkit dependency, with a `WARN` for any still pinned as `latest` (and the suggested `^x.y.z` pin).
 
 It writes nothing and exits non-zero if any check is `FAIL` — safe to run in CI as a setup gate.

--- a/packages/webkit/docs/toolkit/eslint-plugin.md
+++ b/packages/webkit/docs/toolkit/eslint-plugin.md
@@ -38,19 +38,20 @@ Nothing out of standard is ever a warning — **every rule in every preset is `e
 
 ## Rules
 
-| Rule                         | What it catches                                                                                                                      |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `valid-import-path`          | An import of a subpath that is **not** a published export of the installed webkit version (with typo / singular↔plural suggestions). |
-| `no-deep-internal-import`    | Reaching into internals — `@aziontech/webkit/src/**` or a path deeper than a published entry point.                                  |
-| `no-barrel-import`           | A barrel import / re-export / dynamic `import()` from the bare package, which defeats tree-shaking.                                  |
-| `no-whole-icon-set-import`   | Importing the entire `@aziontech/icons` set instead of per-icon subpaths.                                                            |
-| `no-hardcoded-color`         | Hardcoded colors / raw palette / raw typography in class & style strings — use design tokens.                                        |
-| `prefer-tree-shakeable-root` | Importing a compound entry (`…/table`) when only the root `<Table>` is used — suggests the tree-shakeable `…/table-root`.            |
-| `no-deprecated-component`    | Importing a component the installed catalog marks `@deprecated` — names the replacement.                                             |
-| `prefer-webkit-component`    | Reaching for a foreign UI library (or hand-rolling) where a webkit component exists.                                                 |
-| `prefer-define-model`        | Hand-rolled `modelValue` prop + `update:modelValue` emit instead of `defineModel`.                                                   |
-| `no-style-override`          | Utility classes that fight a webkit component's internals instead of composing its slots / style seams.                              |
-| `authoring-standards`        | The shipped construction standards (typed props/emits/slots, composable surface, deprecation shape) — same engine the DS hooks run.  |
+| Rule                         | What it catches                                                                                                                                                                                                                                            |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `valid-import-path`          | An import of a subpath that is **not** a published export of the installed webkit version (with typo / singular↔plural suggestions).                                                                                                                       |
+| `no-deep-internal-import`    | Reaching into internals — `@aziontech/webkit/src/**` or a path deeper than a published entry point.                                                                                                                                                        |
+| `no-barrel-import`           | A barrel import / re-export / dynamic `import()` from the bare package, which defeats tree-shaking.                                                                                                                                                        |
+| `no-whole-icon-set-import`   | Importing the entire `@aziontech/icons` set instead of per-icon subpaths.                                                                                                                                                                                  |
+| `no-hardcoded-color`         | Hardcoded colors / raw palette / raw typography in class & style strings — use design tokens.                                                                                                                                                              |
+| `no-hardcoded-motion`        | Motion outside the animation catalog: `duration-[…]`/`ease-[…]`/`animate-[…]`, literal ms / `cubic-bezier()` / `transition: all` in style strings, an `animate-*` name the catalog doesn't ship, or a static motion class with no `motion-reduce:` escape. |
+| `prefer-tree-shakeable-root` | Importing a compound entry (`…/table`) when only the root `<Table>` is used — suggests the tree-shakeable `…/table-root`.                                                                                                                                  |
+| `no-deprecated-component`    | Importing a component the installed catalog marks `@deprecated` — names the replacement.                                                                                                                                                                   |
+| `prefer-webkit-component`    | Reaching for a foreign UI library (or hand-rolling) where a webkit component exists.                                                                                                                                                                       |
+| `prefer-define-model`        | Hand-rolled `modelValue` prop + `update:modelValue` emit instead of `defineModel`.                                                                                                                                                                         |
+| `no-style-override`          | Utility classes that fight a webkit component's internals instead of composing its slots / style seams.                                                                                                                                                    |
+| `authoring-standards`        | The shipped construction standards (typed props/emits/slots, composable surface, deprecation shape) — same engine the DS hooks run.                                                                                                                        |
 
 Deterministic import rules (`valid-import-path`, `no-deep-internal-import`, `no-barrel-import`, `no-whole-icon-set-import`, `prefer-tree-shakeable-root`) are **autofixable**.
 

--- a/packages/webkit/package.json
+++ b/packages/webkit/package.json
@@ -119,6 +119,7 @@
     "./docs/STYLEGUIDE.md": "./docs/STYLEGUIDE.md",
     "./eslint-plugin": "./src/eslint-plugin/index.js",
     "./stylelint-config": "./src/stylelint-config.js",
+    "./styles": "./src/styles.css",
     "./overline": "./src/components/overline/overline.vue",
     "./button": "./src/components/actions/button/button.vue",
     "./button-highlight": "./src/components/actions/button-highlight/button-highlight.vue",

--- a/packages/webkit/scripts/build-catalog.mjs
+++ b/packages/webkit/scripts/build-catalog.mjs
@@ -17,6 +17,10 @@ import { fileURLToPath } from 'node:url'
 
 import { parseSpecFile, getSection } from '../../../.claude/hooks/_lib/spec.mjs'
 import { vocabularySnapshot } from '../../../.claude/hooks/_lib/prop-vocabulary.mjs'
+import {
+  animate as themeAnimate,
+  useWhen as themeAnimateUseWhen
+} from '../../theme/src/tokens/primitives/animations/animate.js'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(SCRIPT_DIR, '../../..')
@@ -244,6 +248,13 @@ function _readSpec(subpath) {
     // actually deprecated — then no-deprecated-component steers to the replacement.
     deprecated: frontmatter.deprecated === true,
     replacedBy: frontmatter.replaced_by ?? null,
+    // App-level setup (frontmatter `setup:`): the one-time wiring a component needs before
+    // first use (e.g. toast's `.use(ToastPlugin)`). Surfaced by the MCP so the AI wires it
+    // just-in-time; `doctor` backstops it mechanically.
+    setup:
+      typeof frontmatter.setup === 'string' && frontmatter.setup.trim()
+        ? frontmatter.setup.trim()
+        : null,
     // Style seam (pillar 2): a component that INTENTIONALLY lets the consumer pass
     // class/style to its root (a layout/container wrapper). no-style-override reads this
     // to allow it. Opt-in via spec frontmatter `style_seam: true`; default false.
@@ -374,6 +385,7 @@ function build() {
       if (spec.deprecated) entry.deprecated = true
       if (spec.replacedBy) entry.replacedBy = spec.replacedBy
       if (spec.styleSeam) entry.styleSeam = true
+      if (spec.setup) entry.setup = spec.setup
     } else if (entry.kind === 'component') {
       entry.category = categoryFromTarget(target)
     }
@@ -441,7 +453,18 @@ function buildTokens() {
   }
   const animations = [...animSet].sort()
 
-  return { cssVars, typography, groups, animations }
+  // Animation guide: per-utility timing value + "when to use it" prose, read from the
+  // theme's own token source (single source of truth). The MCP surfaces this so a
+  // consumer (or its AI) picks the right utility — e.g. slide-in-left for a sidebar.
+  const animationGuide = {}
+  for (const name of animations) {
+    animationGuide[name] = {
+      value: themeAnimate[name] ?? null,
+      useWhen: themeAnimateUseWhen[name] ?? null
+    }
+  }
+
+  return { cssVars, typography, groups, animations, animationGuide }
 }
 
 const catalog = build()

--- a/packages/webkit/scripts/smoke-consume.mjs
+++ b/packages/webkit/scripts/smoke-consume.mjs
@@ -141,15 +141,19 @@ const install = () =>
     PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: 'false'
   })
 install() // base: vue + the three tarballs
-run('node', [join(app, 'node_modules/@aziontech/webkit/src/cli/cli.js'), 'init'], app)
+// --yes: accept every default (icons + toast + entry wiring) without prompting.
+run('node', [join(app, 'node_modules/@aziontech/webkit/src/cli/cli.js'), 'init', '--yes'], app)
 install() // pick up the style deps init added to package.json (tailwind/postcss/…)
 
-// main.ts must import the generated CSS entry (init only advises it — the consumer wires it).
-const mainPath = join(app, 'src/main.ts')
-writeFileSync(
-  mainPath,
-  `import './webkit.css'\nimport '@aziontech/icons'\n${readFileSync(mainPath, 'utf8')}`
-)
+// init must have wired the style/icon imports into main.ts itself (patch-entry).
+// Feature-scoped setup (toast) is deliberately NOT wired by init — it is just-in-time.
+const mainSrc = readFileSync(join(app, 'src/main.ts'), 'utf8')
+if (!mainSrc.includes('./webkit.css') || !mainSrc.includes('@aziontech/icons')) {
+  fail('init did not wire the design-system imports into src/main.ts (patch-entry).')
+}
+if (mainSrc.includes('ToastPlugin')) {
+  fail('init must not wire the toast plugin — toast setup is just-in-time (catalog + doctor).')
+}
 
 // ── 5. Build ────────────────────────────────────────────────────────────────
 run('pnpm', ['run', 'build'], app, { PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: 'false' })

--- a/packages/webkit/src/cli/apply.js
+++ b/packages/webkit/src/cli/apply.js
@@ -129,6 +129,38 @@ function applyAppend(projectDir, action) {
   return { action, result: 'appended', detail: action.path }
 }
 
+// Prepend the entry-file imports that are not already there. Bare-import presence is
+// checked by the module SPECIFIER (the quoted path), not the whole line, so
+// `import "./webkit.css"` with double quotes — or an import the user moved further
+// down — still counts as wired. Named imports are checked by IDENTIFIER (importing
+// something else from the same module must not satisfy them).
+function applyPatchEntry(projectDir, action) {
+  const target = join(projectDir, action.path)
+  if (!existsSync(target)) {
+    return { action, result: 'skipped', detail: `${action.path} missing` }
+  }
+  const src = readFileSync(target, 'utf8')
+  const missing = action.imports.filter((line) => {
+    const named = line.match(/import\s*\{\s*([A-Za-z_$][\w$]*)\s*\}/)?.[1]
+    if (named) return !new RegExp(`\\b${named}\\b`).test(src)
+    const spec = line.match(/['"]([^'"]+)['"]/)?.[1]
+    return spec ? !src.includes(spec) : !src.includes(line)
+  })
+  if (!missing.length) {
+    return {
+      action,
+      result: 'skipped',
+      detail: `${action.path} already has the design-system imports`
+    }
+  }
+  writeFileSync(target, `${missing.join('\n')}\n${src}`, 'utf8')
+  return {
+    action,
+    result: 'merged',
+    detail: `${action.path}: added ${missing.map((l) => l.match(/['"]([^'"]+)['"]/)?.[1] || l).join(', ')}`
+  }
+}
+
 function applyCopy(projectDir, action) {
   const target = join(projectDir, action.to)
   if (existsSync(target)) {
@@ -167,6 +199,9 @@ export function applyPlan(projectDir, plan) {
         break
       case 'copy':
         results.push(applyCopy(projectDir, action))
+        break
+      case 'patch-entry':
+        results.push(applyPatchEntry(projectDir, action))
         break
       case 'advise':
         results.push({ action, result: 'advised', detail: action.message })

--- a/packages/webkit/src/cli/apply.js
+++ b/packages/webkit/src/cli/apply.js
@@ -130,10 +130,11 @@ function applyAppend(projectDir, action) {
 }
 
 // Prepend the entry-file imports that are not already there. Bare-import presence is
-// checked by the module SPECIFIER (the quoted path), not the whole line, so
-// `import "./webkit.css"` with double quotes — or an import the user moved further
-// down — still counts as wired. Named imports are checked by IDENTIFIER (importing
-// something else from the same module must not satisfy them).
+// checked by a line-anchored import of the module SPECIFIER, so `import "./webkit.css"`
+// with double quotes — or an import the user moved further down — still counts as wired,
+// while a commented-out `// import './webkit.css'` or a superstring path ('../webkit.css')
+// does not. Named imports are checked by IDENTIFIER (importing something else from the
+// same module must not satisfy them).
 function applyPatchEntry(projectDir, action) {
   const target = join(projectDir, action.path)
   if (!existsSync(target)) {
@@ -144,7 +145,9 @@ function applyPatchEntry(projectDir, action) {
     const named = line.match(/import\s*\{\s*([A-Za-z_$][\w$]*)\s*\}/)?.[1]
     if (named) return !new RegExp(`\\b${named}\\b`).test(src)
     const spec = line.match(/['"]([^'"]+)['"]/)?.[1]
-    return spec ? !src.includes(spec) : !src.includes(line)
+    if (!spec) return !src.includes(line)
+    const escaped = spec.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    return !new RegExp(`^\\s*import\\s+['"]${escaped}['"]`, 'm').test(src)
   })
   if (!missing.length) {
     return {

--- a/packages/webkit/src/cli/cli.js
+++ b/packages/webkit/src/cli/cli.js
@@ -1,13 +1,18 @@
 #!/usr/bin/env node
 // @aziontech/webkit — bin name `webkit`.
 //
-//   npx @aziontech/webkit init [--dry-run] [--strict|--recommended]
+//   npx @aziontech/webkit init [--dry-run] [--strict|--recommended] [-y|--yes]
+//                              [--no-icons] [--no-entry]
 //   npx @aziontech/webkit doctor
 //
 // `init` wires the design system into an existing project in one command: dependencies,
-// lint configs, pre-commit, the webkit MCP, the Claude Code bundle, and a CLAUDE.md
-// fragment (`--dry-run` plans without writing; idempotent by design). `doctor` checks
-// that the wiring is healthy and reports resolved dependency versions.
+// lint configs, pre-commit, the webkit MCP, the Claude Code bundle, a CLAUDE.md fragment,
+// and the style imports at the app entry (`--dry-run` plans without writing; idempotent
+// by design). On a TTY it asks about the optional pieces — icons, entry wiring — unless
+// `--yes`. Feature-scoped setup (e.g. the toast service) is deliberately NOT part of
+// init: it is wired just-in-time at first use (the component's catalog `setup` recipe,
+// surfaced by the MCP and the Claude bundle), and `doctor` flags it when missing.
+// `doctor` checks that the wiring is healthy and reports resolved dependency versions.
 
 import { applyPlan } from './apply.js'
 import { planDoctor } from './doctor.js'
@@ -27,11 +32,27 @@ Options (init):
   --dry-run       Print the plan without writing anything.
   --strict        Use the strict ESLint preset (default; every rule is an error).
   --recommended   Use the recommended ESLint preset (also every rule an error).
+  -y, --yes       Accept every default; never prompt (CI / scripted runs).
+  --no-icons      Skip @aziontech/icons (the icon font) and its entry import.
+  --no-entry      Do not edit the app entry (src/main.*); print the imports instead.
   -h, --help      Show this help.
+
+Run interactively (a TTY, no --yes) and init asks about the optional pieces —
+icons, entry wiring — before writing anything.
 `
 
 const COMMANDS = new Set(['init', 'doctor'])
-const KNOWN_FLAGS = new Set(['--dry-run', '--strict', '--recommended', '-h', '--help'])
+const KNOWN_FLAGS = new Set([
+  '--dry-run',
+  '--strict',
+  '--recommended',
+  '--yes',
+  '-y',
+  '--no-icons',
+  '--no-entry',
+  '-h',
+  '--help'
+])
 
 function parseArgs(argv) {
   const args = argv.slice(2)
@@ -44,8 +65,44 @@ function parseArgs(argv) {
     unknown,
     dryRun: flags.has('--dry-run'),
     recommended: flags.has('--recommended') && !flags.has('--strict'),
+    yes: flags.has('--yes') || flags.has('-y'),
+    noIcons: flags.has('--no-icons'),
+    noEntry: flags.has('--no-entry'),
     help: flags.has('-h') || flags.has('--help')
   }
+}
+
+// Ask about the optional pieces — icons, entry wiring — one Y/n question each.
+// Only on a real TTY and without --yes: piped/CI runs never hang on a prompt, they take
+// the defaults (all on) minus any --no-* flag. A --no-* flag also suppresses its question.
+// Feature-scoped setup (toast, …) is not asked here — it is wired just-in-time at first
+// use, from the component's catalog `setup` recipe; `doctor` flags it when missing.
+async function resolveInitOptions(parsed) {
+  const opts = {
+    recommended: parsed.recommended,
+    icons: !parsed.noIcons,
+    wireEntry: !parsed.noEntry
+  }
+  const interactive = process.stdin.isTTY && process.stdout.isTTY && !parsed.yes
+  if (!interactive) return opts
+
+  const { createInterface } = await import('node:readline/promises')
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  const ask = async (question) => {
+    const answer = (await rl.question(`${question} [Y/n] `)).trim().toLowerCase()
+    return answer === '' || answer === 'y' || answer === 'yes'
+  }
+  try {
+    if (opts.icons) opts.icons = await ask('Install @aziontech/icons (the icon font)?')
+    if (opts.wireEntry) {
+      opts.wireEntry = await ask(
+        'Add the style imports to your app entry (src/main.*) automatically?'
+      )
+    }
+  } finally {
+    rl.close()
+  }
+  return opts
 }
 
 const DOCTOR_LABEL = { ok: 'OK   ', warn: 'WARN ', fail: 'FAIL ' }
@@ -101,14 +158,18 @@ function printPlan(plan) {
       case 'copy':
         process.stdout.write(`PLAN   copy ${action.to}\n`)
         break
+      case 'patch-entry':
+        process.stdout.write(`PLAN   patch ${action.path} (${action.imports.join(' · ')})\n`)
+        break
       default:
         process.stdout.write(`PLAN   ${action.type} ${action.path || ''}\n`)
     }
   }
 }
 
-function run(argv) {
-  const { command, dryRun, recommended, help, unknown } = parseArgs(argv)
+async function run(argv) {
+  const parsed = parseArgs(argv)
+  const { command, dryRun, recommended, help, unknown } = parsed
 
   if (help || !command) {
     process.stdout.write(HELP)
@@ -133,7 +194,8 @@ function run(argv) {
     return runDoctor(projectDir)
   }
 
-  const plan = planInit(projectDir, { recommended })
+  const initOpts = await resolveInitOptions(parsed)
+  const plan = planInit(projectDir, initOpts)
 
   process.stdout.write(
     `\n@aziontech/webkit init — ${recommended ? 'recommended' : 'strict'} preset${dryRun ? ' (dry run)' : ''}\n`
@@ -163,4 +225,12 @@ function run(argv) {
 
 // Set exitCode rather than process.exit() so buffered stdout flushes before exit
 // (process.exit can truncate piped output mid-write).
-process.exitCode = run(process.argv)
+run(process.argv).then(
+  (code) => {
+    process.exitCode = code
+  },
+  (err) => {
+    process.stderr.write(`${err?.message || err}\n`)
+    process.exitCode = 1
+  }
+)

--- a/packages/webkit/src/cli/cli.js
+++ b/packages/webkit/src/cli/cli.js
@@ -83,11 +83,18 @@ async function resolveInitOptions(parsed) {
     icons: !parsed.noIcons,
     wireEntry: !parsed.noEntry
   }
-  const interactive = process.stdin.isTTY && process.stdout.isTTY && !parsed.yes
+  // --dry-run implies --yes: a plan-only run prints the plan, it never prompts.
+  const interactive = process.stdin.isTTY && process.stdout.isTTY && !parsed.yes && !parsed.dryRun
   if (!interactive) return opts
 
   const { createInterface } = await import('node:readline/promises')
   const rl = createInterface({ input: process.stdin, output: process.stdout })
+  // Without a SIGINT listener, readline pauses the input stream on Ctrl+C and the
+  // pending question never resolves (per Node docs) — exit like an interrupted CLI.
+  rl.on('SIGINT', () => {
+    rl.close()
+    process.exit(130)
+  })
   const ask = async (question) => {
     const answer = (await rl.question(`${question} [Y/n] `)).trim().toLowerCase()
     return answer === '' || answer === 'y' || answer === 'yes'

--- a/packages/webkit/src/cli/doctor.js
+++ b/packages/webkit/src/cli/doctor.js
@@ -243,7 +243,9 @@ export function planDoctor(projectDir) {
   for (const file of srcFiles) {
     const src = read(file) || ''
     if (src.includes('@aziontech/webkit/toast')) usesToast = true
-    if (/\.use\(\s*ToastPlugin\s*[),]|<Toaster|<Toast\.Toaster/.test(src)) toastWired = true
+    if (/\.use\(\s*ToastPlugin\s*[),]|<Toaster[\s/>]|<Toast\.Toaster/.test(src)) {
+      toastWired = true
+    }
     if (usesToast && toastWired) break
   }
   if (usesToast) {

--- a/packages/webkit/src/cli/doctor.js
+++ b/packages/webkit/src/cli/doctor.js
@@ -8,13 +8,14 @@
 // wired and healthy in this project?" — the fail-open toolkit is otherwise silent about
 // a half-broken install.
 
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 
 import { readJsonStrict } from './apply.js'
 import {
   ALL_DEPS,
+  ENTRY_CANDIDATES,
   ESLINT_CONFIG_CANDIDATES,
   firstExisting,
   HUSKY_HOOK_MARKER,
@@ -25,7 +26,6 @@ import {
 } from './plan.js'
 
 const WEBKIT_PKGS = ['@aziontech/webkit']
-const ENTRY_CANDIDATES = ['src/main.ts', 'src/main.js', 'src/main.mts', 'src/main.mjs']
 
 /** Resolve the webkit catalog.json from the consumer project. */
 function resolveCatalog(projectDir) {
@@ -46,6 +46,29 @@ function resolveCatalog(projectDir) {
     }
   }
   return null
+}
+
+const SRC_EXTENSIONS = ['.vue', '.ts', '.js', '.mts', '.mjs', '.tsx', '.jsx']
+
+/** All source files under src/ (recursive; dotfolders skipped). */
+function listSrcFiles(projectDir) {
+  const files = []
+  const walk = (dir) => {
+    let entries = []
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.') || entry.name === 'node_modules') continue
+      const path = join(dir, entry.name)
+      if (entry.isDirectory()) walk(path)
+      else if (SRC_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) files.push(path)
+    }
+  }
+  walk(join(projectDir, 'src'))
+  return files
 }
 
 /** Installed version of `dep` under the project's node_modules, or null. */
@@ -114,17 +137,23 @@ export function planDoctor(projectDir) {
         : 'no stylelint config found — run `npx @aziontech/webkit init`.')
   )
 
-  // 3b. The CSS entry must `@source` webkit's source — under Tailwind v4 that is what compiles
-  //     webkit's component classes (node_modules is excluded from auto content-detection).
-  //     Without it the components render unstyled.
+  // 3b. The CSS entry must register webkit's source with Tailwind — under v4 that is what
+  //     compiles webkit's component classes (node_modules is excluded from auto
+  //     content-detection). The current form is `@import '@aziontech/webkit/styles'` (the
+  //     `@source` ships inside the package); a legacy inline `@source …@aziontech/webkit…`
+  //     still counts. Without either, the components render unstyled.
   const cssEntry = read(join(projectDir, 'src/webkit.css'))
-  const hasSource = Boolean(cssEntry && /@source\b[^\n]*@aziontech\/webkit/.test(cssEntry))
+  const hasSource = Boolean(
+    cssEntry &&
+    (/@import\b[^\n]*@aziontech\/webkit\/styles/.test(cssEntry) ||
+      /@source\b[^\n]*@aziontech\/webkit/.test(cssEntry))
+  )
   add(
     'webkit.css @source',
     hasSource ? 'ok' : 'fail',
     hasSource
-      ? 'src/webkit.css @sources @aziontech/webkit'
-      : 'src/webkit.css missing an @source for @aziontech/webkit — component classes will not compile (unstyled UI). Run `npx @aziontech/webkit init`.'
+      ? 'src/webkit.css registers webkit with Tailwind'
+      : "src/webkit.css does not register webkit with Tailwind (`@import '@aziontech/webkit/styles'`) — component classes will not compile (unstyled UI). Run `npx @aziontech/webkit init`."
   )
 
   // 3c. PostCSS config present — it runs Tailwind v4 (`@tailwindcss/postcss`) in the build.
@@ -187,7 +216,43 @@ export function planDoctor(projectDir) {
       styled ? 'ok' : 'warn',
       styled
         ? `imported in ${entry}`
-        : `add \`import './webkit.css'\` (theme tokens + fonts + Tailwind + the webkit @source) to ${entry}.`
+        : `add \`import './webkit.css'\` (theme tokens + fonts + Tailwind + the webkit source registration) to ${entry}.`
+    )
+    // Icon font — only meaningful when the project depends on @aziontech/icons.
+    const declaredIcons = Boolean(
+      pkg?.dependencies?.['@aziontech/icons'] || pkg?.devDependencies?.['@aziontech/icons']
+    )
+    if (declaredIcons) {
+      const iconsImported = src.includes('@aziontech/icons')
+      add(
+        'icons import',
+        iconsImported ? 'ok' : 'warn',
+        iconsImported
+          ? `imported in ${entry}`
+          : `@aziontech/icons is a dependency but not imported — add \`import '@aziontech/icons'\` to ${entry} (icon font).`
+      )
+    }
+  }
+
+  // 7b. Feature-scoped setup: toast. Only reported when the app actually imports the
+  //     toast family — then a region must exist (`.use(ToastPlugin)` in the entry, or a
+  //     manually mounted Toaster) or every `toast('…')` call silently renders nowhere.
+  const srcFiles = listSrcFiles(projectDir)
+  let usesToast = false
+  let toastWired = false
+  for (const file of srcFiles) {
+    const src = read(file) || ''
+    if (src.includes('@aziontech/webkit/toast')) usesToast = true
+    if (/\.use\(\s*ToastPlugin\s*[),]|<Toaster|<Toast\.Toaster/.test(src)) toastWired = true
+    if (usesToast && toastWired) break
+  }
+  if (usesToast) {
+    add(
+      'toast setup',
+      toastWired ? 'ok' : 'warn',
+      toastWired
+        ? 'toast region wired (ToastPlugin or a mounted Toaster)'
+        : "toast is imported but no region is wired — toasts will not render. Add `import { ToastPlugin } from '@aziontech/webkit/toast'` and chain `.use(ToastPlugin)` onto createApp() in your entry (the plugin mounts the region automatically)."
     )
   }
 

--- a/packages/webkit/src/cli/plan.js
+++ b/packages/webkit/src/cli/plan.js
@@ -13,6 +13,7 @@
 //   { type: 'merge-json', path, merge, description }       // deep-merge into a JSON file
 //   { type: 'append',    path, content, marker }          // append once, guarded by a marker
 //   { type: 'copy',      from, to }                        // copy a template file (only if missing)
+//   { type: 'patch-entry', path, imports }                 // prepend missing import lines to the app entry
 //   { type: 'advise',    message }                         // print-only; never touches disk
 //
 // `advise` actions carry no filesystem effect — they surface reminders and
@@ -34,7 +35,9 @@ const DEP_VERSION = 'latest'
 // The eslint plugin, stylelint config and MCP all ship INSIDE @aziontech/webkit
 // (subpaths + bins), so the consumer installs only the design-system package + tooling
 // peers — no separate @aziontech/* toolkit packages.
-const RUNTIME_DEPS = ['@aziontech/webkit', '@aziontech/theme', '@aziontech/icons']
+const RUNTIME_DEPS = ['@aziontech/webkit', '@aziontech/theme']
+// The icon font is optional — `init` asks (or takes `--no-icons`); most apps want it.
+const ICONS_DEP = '@aziontech/icons'
 
 const DEV_DEPS = [
   'eslint',
@@ -192,16 +195,19 @@ function postcssConfig() {
 
 // The CSS entry the consumer imports once (e.g. from src/main). `@import '@aziontech/theme'`
 // pulls the design system's Tailwind v4 stylesheet (tokens + `@import "tailwindcss"` + web
-// fonts) in one line; the `@source` then points Tailwind at webkit's SOURCE so its component
-// utility classes (data-[kind=…]:bg-[var(--…)]) are generated in the consumer's build —
-// node_modules is excluded from Tailwind's auto content-detection, so without this `@source`
-// the webkit components render UNSTYLED. The consumer's own src is auto-detected.
+// fonts) in one line; `@import '@aziontech/webkit/styles'` then registers webkit's SOURCE
+// with Tailwind (its `@source` lives inside the package and resolves relative to it) so the
+// component utility classes (data-[kind=…]:bg-[var(--…)]) are generated in the consumer's
+// build — node_modules is excluded from Tailwind's auto content-detection, so without it the
+// webkit components render UNSTYLED. Both imports resolve by package name: no relative
+// ../node_modules path, immune to hoisting / workspace layouts. The consumer's own src is
+// auto-detected.
 function styleEntryContent() {
   return `/* @aziontech/webkit design-system styles. Import this once from your app entry. */
 @import '@aziontech/theme';
 
-/* webkit is consumed as source — scan it so its component utility classes compile. */
-@source '../node_modules/@aziontech/webkit/src';
+/* webkit is consumed as source — this registers it with Tailwind so its component classes compile. */
+@import '@aziontech/webkit/styles';
 `
 }
 
@@ -247,14 +253,19 @@ function claudeFragment() {
  * @param {string} projectDir absolute path to the consumer project
  * @param {object} [opts]
  * @param {boolean} [opts.recommended] use the `recommended` eslint preset instead of `strict`
+ * @param {boolean} [opts.icons] install @aziontech/icons + wire its import (default true)
+ * @param {boolean} [opts.wireEntry] add the style imports to the app entry file (default true)
  * @returns {Array<object>} ordered list of actions (no disk writes)
  */
 export function planInit(projectDir, opts = {}) {
   const actions = []
   const severity = opts.recommended ? 'recommended' : 'strict'
+  const icons = opts.icons !== false
+  const wireEntry = opts.wireEntry !== false
 
   // 1. Dependencies (recorded only; apply never runs a package manager).
-  for (const dep of RUNTIME_DEPS) {
+  const runtimeDeps = icons ? [...RUNTIME_DEPS, ICONS_DEP] : RUNTIME_DEPS
+  for (const dep of runtimeDeps) {
     actions.push({ type: 'add-dep', dep, version: DEP_VERSION, dev: false })
   }
   for (const dep of DEV_DEPS) {
@@ -409,24 +420,32 @@ export function planInit(projectDir, opts = {}) {
     marker: CLAUDE_FRAGMENT_MARKER
   })
 
-  // 8. Best-effort entry-file advice — never rewrites their entry file. Points at the
-  //    generated src/webkit.css (which `@import`s the theme's v4 stylesheet + `@source`s
-  //    webkit) plus the icon font. Import webkit.css (not `@aziontech/theme` bare) so the
-  //    `@source` that compiles webkit's component classes is included.
-  const entry = firstExisting(projectDir, [
-    'src/main.ts',
-    'src/main.js',
-    'src/main.mts',
-    'src/main.mjs'
-  ])
-  if (entry) {
+  // 8. Wire the design-system imports into the app entry. Importing the generated
+  //    src/webkit.css (not `@aziontech/theme` bare) is what includes the `@source` that
+  //    compiles webkit's component classes — skipping this step is exactly the "installed
+  //    but unstyled" failure. By default the imports are PATCHED into the entry file
+  //    (prepended once, idempotent); `wireEntry: false` (`--no-entry`) falls back to advice.
+  //    Feature-scoped setup (e.g. the toast service) is deliberately NOT wired here — it is
+  //    installed just-in-time at first use from the component's catalog `setup` recipe, and
+  //    `doctor` flags it when missing.
+  const entry = firstExisting(projectDir, ENTRY_CANDIDATES)
+  const entryImports = ["import './webkit.css'"]
+  if (icons) entryImports.push("import '@aziontech/icons'")
+  if (entry && wireEntry) {
+    actions.push({ type: 'patch-entry', path: entry, imports: entryImports })
+  } else if (entry) {
     const src = read(join(projectDir, entry)) || ''
     if (!src.includes('webkit.css') && !src.includes('@aziontech/theme')) {
       actions.push({
         type: 'advise',
-        message: `Add the design-system styles to ${entry} (import once, near the top):\nimport './webkit.css'\nimport '@aziontech/icons'`
+        message: `Add the design-system imports to ${entry} (once, near the top):\n${entryImports.join('\n')}`
       })
     }
+  } else {
+    actions.push({
+      type: 'advise',
+      message: `No app entry found (src/main.ts|js|mts|mjs) — wire the design-system imports once at your entry:\n${entryImports.join('\n')}`
+    })
   }
 
   // 9. Theme selection — the tokens default to LIGHT (:root). Dark is opt-in via a
@@ -442,7 +461,13 @@ export function planInit(projectDir, opts = {}) {
 
 // Shared, side-effect-free helpers + constants reused by the doctor planner.
 export { firstExisting, read }
-export const ALL_DEPS = [...RUNTIME_DEPS, ...DEV_DEPS, ...STYLE_DEV_DEPS.map((d) => d.dep)]
+export const ALL_DEPS = [
+  ...RUNTIME_DEPS,
+  ICONS_DEP,
+  ...DEV_DEPS,
+  ...STYLE_DEV_DEPS.map((d) => d.dep)
+]
+export const ENTRY_CANDIDATES = ['src/main.ts', 'src/main.js', 'src/main.mts', 'src/main.mjs']
 export const TAILWIND_CONFIG_CANDIDATES = [
   'tailwind.config.js',
   'tailwind.config.cjs',
@@ -487,6 +512,7 @@ export const HUSKY_HOOK_MARKER = 'npx stylelint "**/*.{css,scss,vue}"'
 
 export const _internals = {
   RUNTIME_DEPS,
+  ICONS_DEP,
   DEV_DEPS,
   STYLE_DEV_DEPS,
   DEP_VERSION,

--- a/packages/webkit/src/components/feedback/toast/index.ts
+++ b/packages/webkit/src/components/feedback/toast/index.ts
@@ -81,7 +81,8 @@ export const ToastPlugin: Plugin = {
     if (typeof document === 'undefined') return
     const host = document.createElement('div')
     host.setAttribute('data-webkit-toaster', '')
-    document.body.appendChild(host)
+    // body can be null when use() runs from a non-deferred head script.
+    ;(document.body ?? document.documentElement).appendChild(host)
     // The SFC $props type is readonly without an index signature; createVNode wants Data.
     const vnode = createVNode(Toaster, options as Record<string, unknown> | undefined)
     vnode.appContext = app._context

--- a/packages/webkit/src/components/feedback/toast/index.ts
+++ b/packages/webkit/src/components/feedback/toast/index.ts
@@ -15,6 +15,7 @@
  * and the enter/leave transitions. See `.claude/rules/compound-api.md`.
  */
 import type { App, Plugin } from 'vue'
+import { createVNode, render } from 'vue'
 
 import ToastAction from './toast-action/toast-action.vue'
 import ToastClose from './toast-close/toast-close.vue'
@@ -56,18 +57,39 @@ export type {
   ToastStore,
   ToastType
 } from './use-toast-store'
+type ToasterProps = InstanceType<typeof Toaster>['$props']
+
 /**
  * Two ways to use the toast — both drive the SAME singleton stack:
  *  1. Direct: mount `<Toaster />` once, then `import { toast }`
  *     (or `useToast()`) and call it from anywhere.
- *  2. Service: `app.use(ToastPlugin)` in main.js registers `<Toaster>` globally
+ *  2. Service: `app.use(ToastPlugin)` in main.js MOUNTS the toast region
+ *     automatically (no manual `<Toaster />`), registers `<Toaster>` globally,
  *     and exposes the imperative API as `this.$toast` and via `inject`.
+ *     Region defaults ride the options arg: `app.use(ToastPlugin, { position: 'top-right' })`.
+ *
+ * A manually mounted `<Toaster />` alongside the plugin is harmless: the store
+ * activates only the first registered region, so toasts never render twice.
  */
 export const ToastPlugin: Plugin = {
-  install(app: App) {
+  install(app: App, options?: ToasterProps) {
     app.component('Toaster', Toaster)
     ;(app.config.globalProperties as { $toast: typeof toast }).$toast = toast
     app.provide('webkit-toast', toast)
+    // Auto-mount the region on a dedicated host, sharing the app's context so the
+    // region sees the app's provides/config. SSR-safe: skipped without a DOM.
+    if (typeof document === 'undefined') return
+    const host = document.createElement('div')
+    host.setAttribute('data-webkit-toaster', '')
+    document.body.appendChild(host)
+    // The SFC $props type is readonly without an index signature; createVNode wants Data.
+    const vnode = createVNode(Toaster, options as Record<string, unknown> | undefined)
+    vnode.appContext = app._context
+    render(vnode, host)
+    app.onUnmount(() => {
+      render(null, host)
+      host.remove()
+    })
   }
 }
 

--- a/packages/webkit/src/components/feedback/toast/toast.test.ts
+++ b/packages/webkit/src/components/feedback/toast/toast.test.ts
@@ -1,11 +1,11 @@
 import { composeStories } from '@storybook/vue3'
 import { render, within } from '@testing-library/vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, nextTick } from 'vue'
+import { createApp, defineComponent, nextTick } from 'vue'
 
 import * as stories from '../../../../../../apps/storybook/src/stories/components/feedback/toast/Toast.stories'
 import { expectNoA11yViolations } from '../../../test/axe'
-import Toast, { toast, Toaster, useToast, useToastStore } from './index'
+import Toast, { toast, Toaster, ToastPlugin, useToast, useToastStore } from './index'
 import ToastAction from './toast-action/toast-action.vue'
 import ToastClose from './toast-close/toast-close.vue'
 import ToastDescription from './toast-description/toast-description.vue'
@@ -321,6 +321,32 @@ describe('Toast (composition + imperative store)', () => {
 
       // The Default story renders a "Show toast" Button trigger in the canvas.
       expect(within(container).getByText('Show toast')).toBeTruthy()
+    })
+  })
+
+  describe('ToastPlugin (service mode)', () => {
+    it('app.use(ToastPlugin) auto-mounts the region, renders toasts, and tears down on unmount', async () => {
+      const app = createApp(defineComponent({ template: '<div />' }))
+      app.use(ToastPlugin, { position: 'bottom-right' })
+      const root = document.createElement('div')
+      document.body.appendChild(root)
+      app.mount(root)
+      await nextTick()
+      await nextTick()
+
+      // The plugin mounted the region itself — no manual Toaster anywhere.
+      expect(document.body.querySelector('[data-webkit-toaster]')).not.toBeNull()
+
+      toast('Raised through the service', { duration: 0 })
+      const region = await regionFor('bottom-right')
+      expect(region).not.toBeNull()
+      expect(within(region!).getByText('Raised through the service')).toBeTruthy()
+
+      // Unmounting the app removes the auto-mounted host (and its region with it).
+      app.unmount()
+      root.remove()
+      await nextTick()
+      expect(document.body.querySelector('[data-webkit-toaster]')).toBeNull()
     })
   })
 })

--- a/packages/webkit/src/eslint-plugin/catalog.js
+++ b/packages/webkit/src/eslint-plugin/catalog.js
@@ -92,6 +92,9 @@ function build(json) {
     version: json.webkitVersion || null,
     deniedPrefixes: json.deniedPrefixes || [],
     tokenRules,
+    // Raw token inventory (animations, cssVars, …) for rules that validate against the
+    // catalog (e.g. no-hardcoded-motion checks animate-* names against tokens.animations).
+    tokens: json.tokens || {},
     has: (sub) => set.has(sub),
     getEntry: (sub) => imports[sub] || null,
     /** Nearest published ancestor of a slash path, e.g. `table/x/y` → `table` if published. */
@@ -128,6 +131,7 @@ function empty() {
     version: null,
     deniedPrefixes: [],
     tokenRules: [],
+    tokens: {},
     has: () => false,
     getEntry: () => null,
     nearestPublishedPrefix: () => null,

--- a/packages/webkit/src/eslint-plugin/index.js
+++ b/packages/webkit/src/eslint-plugin/index.js
@@ -11,6 +11,7 @@ import noBarrelImport from './rules/no-barrel-import.js'
 import noDeepInternalImport from './rules/no-deep-internal-import.js'
 import noDeprecatedComponent from './rules/no-deprecated-component.js'
 import noHardcodedColor from './rules/no-hardcoded-color.js'
+import noHardcodedMotion from './rules/no-hardcoded-motion.js'
 import noStyleOverride from './rules/no-style-override.js'
 import noWholeIconSetImport from './rules/no-whole-icon-set-import.js'
 import preferDefineModel from './rules/prefer-define-model.js'
@@ -24,6 +25,7 @@ const rules = {
   'no-barrel-import': noBarrelImport,
   'no-whole-icon-set-import': noWholeIconSetImport,
   'no-hardcoded-color': noHardcodedColor,
+  'no-hardcoded-motion': noHardcodedMotion,
   'prefer-tree-shakeable-root': preferTreeShakeableRoot,
   'no-deprecated-component': noDeprecatedComponent,
   'prefer-webkit-component': preferWebkitComponent,
@@ -60,6 +62,7 @@ const RECOMMENDED = {
   'no-barrel-import': 'error',
   'no-deprecated-component': 'error',
   'no-hardcoded-color': 'error',
+  'no-hardcoded-motion': 'error',
   'prefer-tree-shakeable-root': 'error',
   'no-whole-icon-set-import': 'error',
   'prefer-webkit-component': 'error',

--- a/packages/webkit/src/eslint-plugin/rules/no-hardcoded-motion.js
+++ b/packages/webkit/src/eslint-plugin/rules/no-hardcoded-motion.js
@@ -1,0 +1,123 @@
+// Flags motion that bypasses the theme's animation catalog, in class & style strings, in
+// both <script> string literals and the SFC <template> (via vue-eslint-parser):
+//
+//   1. Arbitrary timing utilities — `duration-[180ms]`, `delay-[2s]`, `ease-[cubic-bezier(…)]`,
+//      `animate-[…]`: the values live in the theme tokens (`duration-*`, `ease-*`, `animate-*`).
+//   2. Literal timing in style strings — `transition: opacity 200ms`, `animation: spin 1.5s`,
+//      a raw `cubic-bezier(`, or a bare `transition: all`.
+//   3. An `animate-<name>` that does not exist in the installed catalog (typo or invented
+//      animation) — the valid names come from the webkit catalog (`tokens.animations`).
+//   4. A STATIC class attribute with motion (`animate-*` / `transition*`) and no
+//      `motion-reduce:` escape on the same class string. Only the static `class="…"` value is
+//      checked (it holds the full class list); bound fragments are skipped to avoid false
+//      positives when the escape lives in another fragment.
+//
+// Fail-open: no catalog → check 3 disables itself; the others are catalog-independent.
+// CSS/SCSS `<style>` blocks are owned by @aziontech/webkit/stylelint-config.
+
+import { loadCatalog } from '../catalog.js'
+import { ctxCwd, templateBodyVisitorFactory } from '../util.js'
+
+const ARBITRARY_TIMING = /\b(?:duration|delay|ease|animate)-\[[^\]]*\]/
+const STYLE_SIGNAL = /[:;]/
+const STYLE_LITERAL_TIMING = /\b(?:transition|animation)\s*:[^;]*?\b\d+(?:\.\d+)?m?s\b/
+const STYLE_CUBIC_BEZIER = /cubic-bezier\s*\(/
+const STYLE_TRANSITION_ALL = /\btransition\s*:\s*all\b/
+const ANIMATE_NAME = /\banimate-([a-z][a-z0-9-]*)/g
+// Tailwind transition utilities only (not arbitrary class names containing "transition").
+const TRANSITION_UTILITY =
+  /(?:^|[\s:'"`])transition(?:-(?:all|colors|opacity|shadow|transform))?(?=$|[\s'"`])/
+const MOTION_ESCAPE = /motion-reduce:/
+
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow motion outside the theme animation catalog: hardcoded timing, unknown animate-* names, and motion without a motion-reduce escape.'
+    },
+    schema: [],
+    messages: {
+      arbitrary:
+        'Hardcoded motion timing "{{sample}}". Timing lives in the theme tokens — use duration-* / ease-* / the catalogued animate-* utilities.',
+      styleTiming:
+        'Literal motion timing in a style string ("{{sample}}"). Read duration/curve from the theme tokens (var(--…) / the animate-* utilities) instead.',
+      unknownAnimation:
+        '"animate-{{name}}" is not in the webkit animation catalog. Pick a catalogued utility (ask the webkit MCP: list_tokens category "animations").',
+      pairing:
+        'Motion class without a reduced-motion escape. Pair it with motion-reduce:transition-none / motion-reduce:animate-none on the same class string.'
+    }
+  },
+  create(context) {
+    const catalog = loadCatalog(ctxCwd(context))
+    const animationNames = new Set(catalog?.tokens?.animations || [])
+
+    function scan(node, text) {
+      if (typeof text !== 'string' || !text) return
+
+      const arbitrary = text.match(ARBITRARY_TIMING)
+      if (arbitrary) {
+        context.report({ node, messageId: 'arbitrary', data: { sample: arbitrary[0] } })
+        return
+      }
+
+      if (STYLE_SIGNAL.test(text)) {
+        const styleHit =
+          text.match(STYLE_LITERAL_TIMING) ||
+          text.match(STYLE_TRANSITION_ALL) ||
+          text.match(STYLE_CUBIC_BEZIER)
+        if (styleHit) {
+          context.report({ node, messageId: 'styleTiming', data: { sample: styleHit[0] } })
+          return
+        }
+      }
+
+      if (animationNames.size) {
+        for (const m of text.matchAll(ANIMATE_NAME)) {
+          const name = m[1]
+          if (name === 'none' || animationNames.has(name)) continue
+          context.report({ node, messageId: 'unknownAnimation', data: { name } })
+          return
+        }
+      }
+    }
+
+    // The static class attribute holds the FULL class list, so the motion-reduce pairing
+    // can be checked reliably there (and only there).
+    function scanClassPairing(node, text) {
+      if (typeof text !== 'string' || !text) return
+      const hasAnimation = /\banimate-(?!none\b)[a-z]/.test(text)
+      const hasTransition = TRANSITION_UTILITY.test(text) && !/\btransition-none\b/.test(text)
+      if ((hasAnimation || hasTransition) && !MOTION_ESCAPE.test(text)) {
+        context.report({ node, messageId: 'pairing' })
+      }
+    }
+
+    const scriptVisitor = {
+      Literal(node) {
+        if (typeof node.value === 'string') scan(node, node.value)
+      },
+      TemplateElement(node) {
+        scan(node, node.value?.raw)
+      }
+    }
+
+    const defineTemplateBodyVisitor = templateBodyVisitorFactory(context)
+    if (!defineTemplateBodyVisitor) return scriptVisitor
+
+    const templateVisitor = {
+      VLiteral(node) {
+        scan(node, node.value)
+        if (node.parent?.key?.name === 'class') scanClassPairing(node, node.value)
+      },
+      Literal(node) {
+        if (typeof node.value === 'string') scan(node, node.value)
+      },
+      TemplateElement(node) {
+        scan(node, node.value?.raw)
+      }
+    }
+
+    return defineTemplateBodyVisitor(templateVisitor, scriptVisitor)
+  }
+}

--- a/packages/webkit/src/mcp/queries.js
+++ b/packages/webkit/src/mcp/queries.js
@@ -97,6 +97,21 @@ export function listTokens(catalog, { category } = {}) {
 
   if (category != null && String(category).length) {
     const key = String(category).toLowerCase().trim()
+    // Animations are their own catalog (utility classes, not CSS custom properties):
+    // each entry is `animate-<name>` + its timing value + when to reach for it.
+    if (key === 'animations' || key === 'animation' || key === 'animate' || key === 'motion') {
+      return {
+        ok: true,
+        available: true,
+        found: true,
+        category: 'animations',
+        tokens: (tokens.animations || []).map((name) => ({
+          class: `animate-${name}`,
+          ...(tokens.animationGuide?.[name] || {})
+        })),
+        hint: 'Every motion-bearing class pairs with a motion-reduce: fallback (e.g. `animate-slide-in-left motion-reduce:animate-none`). Panel/drawer open-close wraps the v-if region in a Vue Transition with enter-active-class / leave-active-class.'
+      }
+    }
     const group = tokens.groups[key]
     if (!group) {
       return {
@@ -104,8 +119,8 @@ export function listTokens(catalog, { category } = {}) {
         available: true,
         found: false,
         category: key,
-        groups: groupNames,
-        message: `No token group "${key}". Available groups: ${groupNames.join(', ')}.`
+        groups: [...groupNames, 'animations'],
+        message: `No token group "${key}". Available groups: ${groupNames.join(', ')}, animations.`
       }
     }
     return { ok: true, available: true, found: true, category: key, tokens: group }
@@ -114,10 +129,13 @@ export function listTokens(catalog, { category } = {}) {
   return {
     ok: true,
     available: true,
-    groups: groupNames.map((name) => ({ name, count: tokens.groups[name].length })),
+    groups: [
+      ...groupNames.map((name) => ({ name, count: tokens.groups[name].length })),
+      { name: 'animations', count: (tokens.animations || []).length }
+    ],
     typography: tokens.typography,
     vocabulary: catalog.vocabulary || null,
-    hint: 'Call list_tokens with a category (e.g. "primary", "bg", "text", "spacing", "radius", "shadow") for the CSS custom properties in that group.'
+    hint: 'Call list_tokens with a category (e.g. "primary", "bg", "text", "spacing", "radius", "shadow", "animations") for that group — "animations" returns each animate-* class with its timing and when to use it.'
   }
 }
 
@@ -157,6 +175,9 @@ export function getComponent(catalog, name) {
     rootOf: e.rootOf ?? null,
     // Usage guidance (B3) — helps the AI pick the RIGHT component, not just a valid one.
     purpose: e.purpose ?? null,
+    // One-time app-level wiring required before first use (null for most components).
+    // When set, apply it BEFORE emitting code that uses the component.
+    setup: e.setup ?? null,
     useWhen: e.useWhen ?? [],
     avoidWhen: e.avoidWhen ?? [],
     related: e.related ?? [],
@@ -192,6 +213,7 @@ export function getBestPractices(catalog, name) {
     found: true,
     name: key,
     purpose: e.purpose ?? null,
+    setup: e.setup ?? null,
     useWhen: e.useWhen ?? [],
     avoidWhen: e.avoidWhen ?? [],
     related: e.related ?? [],

--- a/packages/webkit/src/stylelint-config.js
+++ b/packages/webkit/src/stylelint-config.js
@@ -14,6 +14,9 @@
 const USE_TOKEN =
   'Use a design token from @aziontech/theme via var(--*) instead of a hardcoded color.'
 
+const USE_MOTION_TOKEN =
+  'Motion timing lives in the theme tokens: use the animate-* utilities or var(--duration-*/--ease-*) — never a literal ms/s, a raw cubic-bezier(), or transition: all.'
+
 export default {
   rules: {
     // Bans hex colors: `#fff`, `#ffffff`, `#ffffffff`. The message tells the
@@ -40,9 +43,17 @@ export default {
         '/^(color|background|background-color|border|border-color|outline|outline-color|fill|stroke|box-shadow|text-shadow)$/':
           [
             '/^(?!.*var\\().*\\b(black|white|red|green|blue|yellow|orange|purple|pink|gray|grey|silver|gold)\\b/i'
-          ]
+          ],
+        // Motion timing discipline (the styles-side of webkit/no-hardcoded-motion):
+        //  - a literal duration (200ms / 1.5s) in transition/animation — tokens only;
+        //  - a raw cubic-bezier() — the curves ship as --ease-* tokens;
+        //  - bare `transition: all` — always name the animated properties.
+        // A value that reads its timing from var(--…) passes untouched.
+        '/^(transition|transition-duration|transition-delay|animation|animation-duration|animation-delay)$/':
+          ['/(?<!var\\([^)]*)\\b\\d+(\\.\\d+)?m?s\\b/', '/cubic-bezier\\(/'],
+        '/^transition$/': ['/^all\\b/']
       },
-      { message: `${USE_TOKEN} Named colors are not allowed.` }
+      { message: `${USE_TOKEN} ${USE_MOTION_TOKEN}` }
     ]
   }
 }

--- a/packages/webkit/src/stylelint-config.js
+++ b/packages/webkit/src/stylelint-config.js
@@ -53,7 +53,14 @@ export default {
           ['/(?<!var\\([^)]*)\\b\\d+(\\.\\d+)?m?s\\b/', '/cubic-bezier\\(/'],
         '/^transition$/': ['/^all\\b/']
       },
-      { message: `${USE_TOKEN} ${USE_MOTION_TOKEN}` }
+      {
+        // One rule instance covers two disciplines; the message function routes each
+        // violation to its own guidance (stylelint passes the property as message args).
+        message: (prop) =>
+          /^(transition|animation)/.test(prop)
+            ? USE_MOTION_TOKEN
+            : `${USE_TOKEN} Named colors are not allowed.`
+      }
     ]
   }
 }

--- a/packages/webkit/src/styles.css
+++ b/packages/webkit/src/styles.css
@@ -1,0 +1,11 @@
+/*
+ * Registers webkit's source files with Tailwind v4 so the component utility classes
+ * (data-[kind=…]:bg-[var(--…)] …) compile in the consumer's build — node_modules is
+ * excluded from Tailwind's automatic content detection, so without this the components
+ * render UNSTYLED.
+ *
+ * `@source` resolves relative to THIS stylesheet, which lives inside the package, so the
+ * consumer imports it by name (`@import '@aziontech/webkit/styles'`) and never hardcodes
+ * a ../node_modules path — immune to hoisting, workspaces, and pnpm symlink layouts.
+ */
+@source './';

--- a/packages/webkit/test/cli/doctor.test.mjs
+++ b/packages/webkit/test/cli/doctor.test.mjs
@@ -96,6 +96,63 @@ test('doctor warns when a toolkit dependency is pinned as "latest" and reports i
   }
 })
 
+test('doctor warns when @aziontech/icons is a dependency but not imported at the entry', () => {
+  const dir = makeProject({
+    name: 'demo',
+    version: '1.0.0',
+    dependencies: { '@aziontech/icons': 'latest' }
+  })
+  try {
+    mkdirSync(join(dir, 'src'))
+    writeFileSync(join(dir, 'src/main.ts'), "import { createApp } from 'vue'\n")
+    let report = planDoctor(dir)
+    assert.equal(statusOf(report, 'icons import'), 'warn')
+
+    writeFileSync(join(dir, 'src/main.ts'), "import '@aziontech/icons'\n")
+    report = planDoctor(dir)
+    assert.equal(statusOf(report, 'icons import'), 'ok')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('doctor flags toast usage with no wired region, and passes once wired', () => {
+  const dir = makeProject()
+  try {
+    mkdirSync(join(dir, 'src/components'), { recursive: true })
+
+    // No toast anywhere → the check does not even appear.
+    writeFileSync(join(dir, 'src/main.ts'), "import { createApp } from 'vue'\n")
+    assert.equal(statusOf(planDoctor(dir), 'toast setup'), undefined)
+
+    // toast imported, no region wired → warn with the fix.
+    writeFileSync(
+      join(dir, 'src/components/save.ts'),
+      "import { toast } from '@aziontech/webkit/toast'\ntoast.success('Saved')\n"
+    )
+    const warned = planDoctor(dir).find((c) => c.check === 'toast setup')
+    assert.equal(warned.status, 'warn')
+    assert.match(warned.detail, /\.use\(ToastPlugin\)/)
+
+    // Service wiring in the entry → ok.
+    writeFileSync(
+      join(dir, 'src/main.ts'),
+      "import { ToastPlugin } from '@aziontech/webkit/toast'\nimport { createApp } from 'vue'\ncreateApp({}).use(ToastPlugin).mount('#app')\n"
+    )
+    assert.equal(statusOf(planDoctor(dir), 'toast setup'), 'ok')
+
+    // A manually mounted Toaster also counts.
+    writeFileSync(join(dir, 'src/main.ts'), "import { createApp } from 'vue'\n")
+    writeFileSync(
+      join(dir, 'src/components/App.vue'),
+      "<script setup>\nimport Toaster from '@aziontech/webkit/toast-root'\n</script>\n<template>\n  <Toaster />\n</template>\n"
+    )
+    assert.equal(statusOf(planDoctor(dir), 'toast setup'), 'ok')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('doctor reports a malformed .mcp.json as a failure, not a crash', () => {
   const dir = makeProject()
   try {

--- a/packages/webkit/test/cli/plan.test.mjs
+++ b/packages/webkit/test/cli/plan.test.mjs
@@ -1,11 +1,14 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { planInit, CLAUDE_FRAGMENT_MARKER, MCP_SERVER_NAME } from '../../src/cli/plan.js'
 import { applyPlan } from '../../src/cli/apply.js'
+
+const MAIN_TS =
+  "import { createApp } from 'vue'\nimport App from './App.vue'\ncreateApp(App).mount('#app')\n"
 
 function makeProject() {
   const dir = mkdtempSync(join(tmpdir(), 'webkit-cli-'))
@@ -13,6 +16,7 @@ function makeProject() {
     join(dir, 'package.json'),
     JSON.stringify({ name: 'demo', version: '1.0.0' }, null, 2)
   )
+  mkdirSync(join(dir, 'src'))
   return dir
 }
 
@@ -97,7 +101,11 @@ test('planInit wires the Tailwind + PostCSS pipeline and a CSS entry', () => {
     const twCfg = plan.find(
       (a) => a.type === 'write' && a.path && a.path.startsWith('tailwind.config')
     )
-    assert.equal(twCfg, undefined, 'Tailwind v4 is CSS-first — no tailwind.config should be written')
+    assert.equal(
+      twCfg,
+      undefined,
+      'Tailwind v4 is CSS-first — no tailwind.config should be written'
+    )
 
     const pcCfg = plan.find((a) => a.type === 'write' && a.path === 'postcss.config.mjs')
     assert.ok(pcCfg, 'expected postcss.config.mjs write action')
@@ -106,8 +114,14 @@ test('planInit wires the Tailwind + PostCSS pipeline and a CSS entry', () => {
     const cssEntry = plan.find((a) => a.type === 'write' && a.path === 'src/webkit.css')
     assert.ok(cssEntry, 'expected src/webkit.css write action')
     assert.match(cssEntry.content, /@import '@aziontech\/theme'/)
-    // Critically, it must @source webkit's source so component classes compile.
-    assert.match(cssEntry.content, /@source[^\n]*@aziontech\/webkit\/src/)
+    // Critically, it must register webkit's source so component classes compile — via the
+    // package-name import (the @source ships inside webkit), never a ../node_modules path.
+    assert.match(cssEntry.content, /@import '@aziontech\/webkit\/styles'/)
+    assert.doesNotMatch(
+      cssEntry.content,
+      /node_modules/,
+      'the CSS entry must not hardcode a node_modules path'
+    )
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -140,6 +154,102 @@ test('planInit advises the LIGHT default + data-theme dark opt-in', () => {
         /data-theme="dark"/.test(a.message)
     )
     assert.ok(advise, 'expected a theme-selection advice mentioning the dark opt-in')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('planInit patches the app entry with the style imports by default', () => {
+  const dir = makeProject()
+  try {
+    writeFileSync(join(dir, 'src/main.ts'), MAIN_TS, { flag: 'w' })
+    const plan = planInit(dir, {})
+    const patch = plan.find((a) => a.type === 'patch-entry')
+    assert.ok(patch, 'expected a patch-entry action for src/main.ts')
+    assert.equal(patch.path, 'src/main.ts')
+    assert.deepEqual(patch.imports, ["import './webkit.css'", "import '@aziontech/icons'"])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('wireEntry: false falls back to entry advice, never edits the file', () => {
+  const dir = makeProject()
+  try {
+    writeFileSync(join(dir, 'src/main.ts'), MAIN_TS, { flag: 'w' })
+    const plan = planInit(dir, { wireEntry: false })
+    assert.equal(
+      plan.find((a) => a.type === 'patch-entry'),
+      undefined,
+      'must not plan an entry patch with wireEntry: false'
+    )
+    const advise = plan.find(
+      (a) => a.type === 'advise' && /import '\.\/webkit\.css'/.test(a.message)
+    )
+    assert.ok(advise, 'expected the entry-imports advice')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('icons: false drops @aziontech/icons from deps and entry imports', () => {
+  const dir = makeProject()
+  try {
+    writeFileSync(join(dir, 'src/main.ts'), MAIN_TS, { flag: 'w' })
+    const plan = planInit(dir, { icons: false })
+    assert.ok(!findAddDeps(plan).includes('@aziontech/icons'), 'icons dep must be omitted')
+    const patch = plan.find((a) => a.type === 'patch-entry')
+    assert.deepEqual(patch.imports, ["import './webkit.css'"])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('planInit never wires feature-scoped setup (toast is just-in-time, not init)', () => {
+  const dir = makeProject()
+  try {
+    writeFileSync(join(dir, 'src/main.ts'), MAIN_TS)
+    const plan = planInit(dir, {})
+    const patch = plan.find((a) => a.type === 'patch-entry')
+    assert.equal(patch.use, undefined, 'patch-entry must not carry plugin wiring')
+    assert.ok(
+      !patch.imports.some((l) => l.includes('ToastPlugin')),
+      'init must not import ToastPlugin — toast setup is just-in-time (catalog `setup` + doctor)'
+    )
+    assert.ok(
+      !plan.some((a) => a.type === 'advise' && /ToastPlugin|Toaster/.test(a.message)),
+      'init must not advise toast setup'
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('applyPlan wires the entry imports once and is idempotent', () => {
+  const dir = makeProject()
+  try {
+    writeFileSync(join(dir, 'src/main.ts'), MAIN_TS, { flag: 'w' })
+    applyPlan(dir, planInit(dir, {}))
+
+    const wired = readFileSync(join(dir, 'src/main.ts'), 'utf8')
+    assert.ok(wired.startsWith("import './webkit.css'\nimport '@aziontech/icons'\n"))
+    assert.ok(wired.includes(MAIN_TS), 'original entry content must be preserved')
+
+    // Second run — no duplication.
+    applyPlan(dir, planInit(dir, {}))
+    const again = readFileSync(join(dir, 'src/main.ts'), 'utf8')
+    assert.equal(again, wired, 'entry file changed on the second run')
+
+    // A partially wired entry (double quotes, moved line) is completed, not duplicated.
+    writeFileSync(join(dir, 'src/main.ts'), `import "./webkit.css"\n${MAIN_TS}`)
+    applyPlan(dir, planInit(dir, {}))
+    const completed = readFileSync(join(dir, 'src/main.ts'), 'utf8')
+    assert.equal(completed.split('webkit.css').length - 1, 1, 'webkit.css import duplicated')
+    assert.equal(
+      completed.split('@aziontech/icons').length - 1,
+      1,
+      'icons import missing/duplicated'
+    )
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }

--- a/packages/webkit/test/eslint-plugin/fixtures/catalog.json
+++ b/packages/webkit/test/eslint-plugin/fixtures/catalog.json
@@ -59,5 +59,20 @@
       "parent": "table",
       "treeShakeableImport": "@aziontech/webkit/table-row"
     }
+  },
+  "tokens": {
+    "animations": [
+      "fade-in",
+      "fade-out",
+      "slide-down",
+      "slide-in-left",
+      "slide-out-left",
+      "slide-in-right",
+      "slide-out-right",
+      "popup-scale-in",
+      "popup-scale-out",
+      "pulse",
+      "spin"
+    ]
   }
 }

--- a/packages/webkit/test/eslint-plugin/rules.test.mjs
+++ b/packages/webkit/test/eslint-plugin/rules.test.mjs
@@ -17,6 +17,8 @@ const noWholeIconSetImport = (
 ).default
 const noHardcodedColor = (await import('../../src/eslint-plugin/rules/no-hardcoded-color.js'))
   .default
+const noHardcodedMotion = (await import('../../src/eslint-plugin/rules/no-hardcoded-motion.js'))
+  .default
 const preferTreeShakeableRoot = (
   await import('../../src/eslint-plugin/rules/prefer-tree-shakeable-root.js')
 ).default
@@ -178,6 +180,77 @@ test('no-hardcoded-color (script + template)', () => {
         code: '<template><div class="text-red-500">x</div></template>',
         filename: 'b.vue',
         errors: [{ messageId: 'token' }]
+      }
+    ]
+  })
+})
+
+test('no-hardcoded-motion (script + template)', () => {
+  js.run('no-hardcoded-motion', noHardcodedMotion, {
+    valid: [
+      // catalogued utility + tokens: fine
+      "const c = 'animate-slide-in-left motion-reduce:animate-none'",
+      "const c = 'transition-colors duration-150 ease-out motion-reduce:transition-none'",
+      // timing from tokens in a style string: fine
+      "const s = 'transition: opacity var(--duration-fast-01)'",
+      // arbitrary transition PROPERTY (not timing) is allowed — the width-collapse recipe
+      "const c = 'transition-[grid-template-columns]'"
+    ],
+    invalid: [
+      { code: "const c = 'duration-[180ms]'", errors: [{ messageId: 'arbitrary' }] },
+      {
+        code: "const c = 'ease-[cubic-bezier(0.4,0,0.2,1)]'",
+        errors: [{ messageId: 'arbitrary' }]
+      },
+      { code: "const c = 'animate-[wiggle_1s_ease-in-out]'", errors: [{ messageId: 'arbitrary' }] },
+      { code: "const s = 'transition: opacity 200ms'", errors: [{ messageId: 'styleTiming' }] },
+      { code: "const s = 'animation: spin 1.5s linear'", errors: [{ messageId: 'styleTiming' }] },
+      { code: "const s = 'transition: all'", errors: [{ messageId: 'styleTiming' }] },
+      // invented animation name → steered back to the catalog
+      { code: "const c = 'animate-wiggle'", errors: [{ messageId: 'unknownAnimation' }] }
+    ]
+  })
+  vue.run('no-hardcoded-motion', noHardcodedMotion, {
+    valid: [
+      // motion + escape on the same static class string
+      {
+        code: '<template><aside class="animate-slide-in-left motion-reduce:animate-none">x</aside></template>',
+        filename: 'a.vue'
+      },
+      // no motion at all
+      {
+        code: '<template><div class="text-body-sm">x</div></template>',
+        filename: 'b.vue'
+      },
+      // transition-none IS the escape — not motion
+      {
+        code: '<template><div class="transition-none">x</div></template>',
+        filename: 'c.vue'
+      }
+    ],
+    invalid: [
+      // static class with motion and no reduced-motion escape
+      {
+        code: '<template><aside class="animate-slide-in-left">x</aside></template>',
+        filename: 'd.vue',
+        errors: [{ messageId: 'pairing' }]
+      },
+      {
+        code: '<template><div class="transition-colors duration-150 ease-out">x</div></template>',
+        filename: 'e.vue',
+        errors: [{ messageId: 'pairing' }]
+      },
+      // arbitrary timing in a template class
+      {
+        code: '<template><div class="duration-[180ms] motion-reduce:transition-none">x</div></template>',
+        filename: 'f.vue',
+        errors: [{ messageId: 'arbitrary' }]
+      },
+      // inline style timing
+      {
+        code: '<template><div style="transition: opacity 200ms">x</div></template>',
+        filename: 'g.vue',
+        errors: [{ messageId: 'styleTiming' }]
       }
     ]
   })

--- a/packages/webkit/test/mcp/queries.test.mjs
+++ b/packages/webkit/test/mcp/queries.test.mjs
@@ -105,7 +105,9 @@ test('listTokens surfaces the animations catalog with timing + use-when', () => 
 })
 
 test('every animate-* utility has a useWhen entry (guidance stays in sync with the catalog)', async () => {
-  const { animate, useWhen } = await import('@aziontech/theme/animations')
+  const { animate, useWhen } = await import(
+    '../../../theme/src/tokens/primitives/animations/animate.js'
+  )
   for (const name of Object.keys(animate)) {
     assert.ok(
       typeof useWhen[name] === 'string' && useWhen[name].length > 0,

--- a/packages/webkit/test/mcp/queries.test.mjs
+++ b/packages/webkit/test/mcp/queries.test.mjs
@@ -4,9 +4,7 @@ import test from 'node:test'
 
 // Point the loader at the real generated catalog (version-locked, deterministic).
 // Set BEFORE importing the loader so the first resolve honors the override.
-process.env.WEBKIT_CATALOG_PATH = fileURLToPath(
-  new URL('../../catalog.json', import.meta.url)
-)
+process.env.WEBKIT_CATALOG_PATH = fileURLToPath(new URL('../../catalog.json', import.meta.url))
 
 const { loadCatalog, _resetCatalogCache } = await import('../../src/mcp/catalog.js')
 const {
@@ -89,6 +87,27 @@ test('listTokens reports an unknown category with the available groups', () => {
   assert.equal(res.ok, false)
   assert.equal(res.found, false)
   assert.ok(Array.isArray(res.groups) && res.groups.length > 0)
+  assert.ok(res.groups.includes('animations'), 'animations must be advertised as a group')
+})
+
+test('listTokens surfaces the animations catalog with timing + use-when', () => {
+  const res = listTokens(catalog, { category: 'animations' })
+  assert.equal(res.ok, true)
+  assert.equal(res.found, true)
+  const slideIn = res.tokens.find((t) => t.class === 'animate-slide-in-left')
+  assert.ok(slideIn, 'expected animate-slide-in-left in the animations catalog')
+  assert.match(slideIn.value, /slideInLeft/)
+  assert.match(slideIn.useWhen, /sidebar/i)
+  assert.match(res.hint, /motion-reduce/)
+  // The index (no category) also advertises the animations group.
+  const index = listTokens(catalog)
+  assert.ok(index.groups.some((g) => g.name === 'animations' && g.count > 0))
+})
+
+test('getComponent surfaces app-level setup for toast', () => {
+  const res = getComponent(catalog, 'toast')
+  assert.equal(res.found, true)
+  assert.match(res.setup, /ToastPlugin/)
 })
 
 test('getComponent surfaces usage guidance fields (purpose + when/related/best-practices)', () => {
@@ -155,8 +174,10 @@ test('suggestComponent resolves a table-ish need to table', () => {
   const byTypo = suggestComponent(catalog, 'datatable')
   // "datatable" contains "table" → substring/word match, or fuzzy fallback.
   const resolved = byTypo.best?.name
-  assert.ok(resolved === 'table' || byTypo.alternatives.some((a) => a.name === 'table'),
-    `expected datatable to resolve to table, got ${resolved}`)
+  assert.ok(
+    resolved === 'table' || byTypo.alternatives.some((a) => a.name === 'table'),
+    `expected datatable to resolve to table, got ${resolved}`
+  )
 })
 
 test('searchComponents finds a component by substring', () => {

--- a/packages/webkit/test/mcp/queries.test.mjs
+++ b/packages/webkit/test/mcp/queries.test.mjs
@@ -104,6 +104,16 @@ test('listTokens surfaces the animations catalog with timing + use-when', () => 
   assert.ok(index.groups.some((g) => g.name === 'animations' && g.count > 0))
 })
 
+test('every animate-* utility has a useWhen entry (guidance stays in sync with the catalog)', async () => {
+  const { animate, useWhen } = await import('@aziontech/theme/animations')
+  for (const name of Object.keys(animate)) {
+    assert.ok(
+      typeof useWhen[name] === 'string' && useWhen[name].length > 0,
+      `animate-${name} has no useWhen entry — add it in packages/theme/src/tokens/primitives/animations/animate.js`
+    )
+  }
+})
+
 test('getComponent surfaces app-level setup for toast', () => {
   const res = getComponent(catalog, 'toast')
   assert.equal(res.found, true)

--- a/packages/webkit/test/stylelint-config/config.test.mjs
+++ b/packages/webkit/test/stylelint-config/config.test.mjs
@@ -37,7 +37,10 @@ test('allows a design token via var(--*)', async () => {
 test('flags a raw color function (function-disallowed-list)', async () => {
   const warnings = await lint('a{color:rgb(0,0,0)}')
   assert.ok(warnings.length > 0, 'expected at least one warning for rgb()')
-  assert.ok(firedBy(warnings, 'function-disallowed-list'), 'expected function-disallowed-list to fire')
+  assert.ok(
+    firedBy(warnings, 'function-disallowed-list'),
+    'expected function-disallowed-list to fire'
+  )
 })
 
 test('flags a named color on a color property (declaration-property-value-disallowed-list)', async () => {
@@ -51,6 +54,45 @@ test('flags a named color on a color property (declaration-property-value-disall
 test('leaves safe keyword values alone (currentColor / transparent / inherit)', async () => {
   for (const value of ['currentColor', 'transparent', 'inherit']) {
     const warnings = await lint(`a{color:${value}}`)
-    assert.equal(warnings.length, 0, `expected no warnings for ${value}, got: ${JSON.stringify(warnings)}`)
+    assert.equal(
+      warnings.length,
+      0,
+      `expected no warnings for ${value}, got: ${JSON.stringify(warnings)}`
+    )
+  }
+})
+
+test('flags literal motion timing / raw cubic-bezier / transition: all', async () => {
+  for (const decl of [
+    'transition:opacity 200ms',
+    'transition-duration:1.5s',
+    'animation:spin 1s linear',
+    'transition:opacity 240ms cubic-bezier(0.4,0,0.2,1)',
+    'transition:all'
+  ]) {
+    const warnings = await lint(`a{${decl}}`)
+    assert.ok(
+      firedBy(warnings, 'declaration-property-value-disallowed-list'),
+      `expected the motion discipline to fire for "${decl}"`
+    )
+    assert.match(
+      warnings.find((w) => w.rule === 'declaration-property-value-disallowed-list').text,
+      /animate-\*|duration/
+    )
+  }
+})
+
+test('allows motion timing read from tokens (var(--duration-*/--ease-*))', async () => {
+  for (const decl of [
+    'transition:opacity var(--duration-fast-01) var(--ease-productive-entrance)',
+    'transition:transform var(--duration-moderate-01)',
+    'animation-duration:var(--duration-slow-01)'
+  ]) {
+    const warnings = await lint(`a{${decl}}`)
+    assert.equal(
+      warnings.length,
+      0,
+      `expected no warnings for "${decl}", got: ${JSON.stringify(warnings)}`
+    )
   }
 })

--- a/packages/webkit/test/stylelint-config/config.test.mjs
+++ b/packages/webkit/test/stylelint-config/config.test.mjs
@@ -49,6 +49,9 @@ test('flags a named color on a color property (declaration-property-value-disall
     firedBy(warnings, 'declaration-property-value-disallowed-list'),
     'expected declaration-property-value-disallowed-list to fire for a named color'
   )
+  const text = warnings.find((w) => w.rule === 'declaration-property-value-disallowed-list').text
+  assert.match(text, /Named colors are not allowed/)
+  assert.doesNotMatch(text, /animate-\*/, 'a color violation must not carry motion guidance')
 })
 
 test('leaves safe keyword values alone (currentColor / transparent / inherit)', async () => {
@@ -75,9 +78,12 @@ test('flags literal motion timing / raw cubic-bezier / transition: all', async (
       firedBy(warnings, 'declaration-property-value-disallowed-list'),
       `expected the motion discipline to fire for "${decl}"`
     )
-    assert.match(
-      warnings.find((w) => w.rule === 'declaration-property-value-disallowed-list').text,
-      /animate-\*|duration/
+    const text = warnings.find((w) => w.rule === 'declaration-property-value-disallowed-list').text
+    assert.match(text, /animate-\*|duration/)
+    assert.doesNotMatch(
+      text,
+      /Named colors/,
+      'a motion violation must not lead with color guidance'
     )
   }
 })


### PR DESCRIPTION
## Summary

Closes the three gaps found while exercising `webkit init` against a fresh consumer project (unstyled app after init, toasts silently not rendering, and a sidebar nobody knew how to animate) — by making init complete the install, moving feature-scoped setup to just-in-time, and making the animation tokens discoverable **and** enforced.

### `webkit init` — completes the install
- Interactive Y/n prompts on a TTY (icons, entry wiring); `--yes`, `--no-icons`, `--no-entry` for scripted runs. Piped/CI runs never prompt.
- **Entry wiring is now a patch, not advice**: `import './webkit.css'` + `import '@aziontech/icons'` are prepended once (idempotent, quote-style aware) to `src/main.*` — the "installed but unstyled" failure can no longer happen.
- **`@aziontech/webkit/styles`** (new export): the Tailwind `@source` now ships inside the package and the generated `webkit.css` imports it by package name — no more `@source '../node_modules/...'` hardcoded in the consumer's CSS (immune to hoisting/workspace layouts).
- `doctor` gains checks: styles/icons imports at the entry, webkit registered with Tailwind, and **toast setup** (warns with the exact fix when `@aziontech/webkit/toast` is imported but no region is wired).

### Toast — standard Vue service, wired just-in-time
- `ToastPlugin.install()` now **mounts the toast region automatically** (`createVNode` + the app's context, torn down on `app.unmount()`, SSR-safe): `app.use(ToastPlugin)` in `main.ts` is the whole setup. Options ride the plugin: `app.use(ToastPlugin, { position: 'top-right' })`. A manually mounted `<Toaster />` stays harmless (the store activates one region).
- Init deliberately does **not** wire it: the component declares its one-time wiring in a new catalog `setup` field (from spec frontmatter), surfaced by the MCP's `get_component`/`get_best_practices`, documented in the shipped bundle, and backstopped by the `doctor` check above.

### Motion — consumers can find and must use the animation tokens
- **Theme**: new lateral-panel animations `animate-slide-in-left/out-left` and `slide-in-right/out-right` (timings from the duration/curve tokens), plus a `useWhen` map documenting every `animate-*` utility next to its definition.
- **Catalog/MCP**: `tokens.animationGuide` (class + timing + use-when per animation) and a new `list_tokens` category `animations`.
- **Guidance**: the panel recipe (Vue `<Transition>` + the catalogued pair + `motion-reduce:` escape) added to the shipped `webkit-motion` rule and `webkit-motion-polish` skill.
- **Storybook**: new **Foundations/Motion** page — every animation with a replayable preview, the duration/curve token tables, and the panel recipe.
- **Enforcement**: new `webkit/no-hardcoded-motion` ESLint rule (arbitrary `duration-[…]`/`ease-[…]`/`animate-[…]`, literal ms / `cubic-bezier()` / `transition: all` in style strings, `animate-*` names not in the catalog, motion classes without a `motion-reduce:` escape) + the stylelint mirror for CSS declarations. Registered in the standards registry (no orphan gate).

## Notes

- Validated end-to-end against a real consumer app via a local registry: init wires the entry by itself, the build emits the component classes and icon fonts, the sidebar animates with `animate-slide-in-left/out-left` (verified in Chromium, including `prefers-reduced-motion` → `animation: none`), and the new lint flags all three violation classes in consumer code.
- Toolkit suite 96/96 (CLI, MCP, eslint-plugin, stylelint, standards invariant), toast browser suite 21/21, Storybook build green, doc-standards ratchet clean.
- `.specs/toast.md` is updated with the auto-mount Service contract (checksum recomputed); `@keyframes` for the new animations are transform-only.
- No new dependencies. No breaking changes: `ToastPlugin.install()` gains behavior (auto-mount); a manual `<Toaster />` still renders no duplicate region — but see the upgrade note below for who owns the region's props.

## Upgrade note — toast auto-mount

If you already install the plugin **and** mount a `<Toaster position="…" />` manually, the plugin's auto-mounted region now registers first and becomes the active one — the props on your manual `<Toaster>` silently stop applying. Move them to the plugin: `app.use(ToastPlugin, { position: '…' })` (and drop the manual `<Toaster>`; keeping it is harmless but inert). Consumers using only one of the two patterns are unaffected.

