### PR TITLE
fix: bump fast-uri version from 4.1.0 to 4.1.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ overrides:
   form-data: '>=4.0.6'
   undici: '>=7.28.0'
   vite: '>=6.4.3'
-  fast-uri: '>=3.1.2'
+  fast-uri: '>=4.1.1'
   '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
   ws: '>=8.21.0'
   qs: '>=6.15.2'
@@ -3923,8 +3923,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@4.1.0:
-    resolution: {integrity: sha512-ZodJ2cRiLVWGi9IgPb3mbgSqM4CD3LexCHkuv0FfBXHJI1ADfucTD06m6clO2Cy5RZYsw/SiCVl/dyrFI/SYWA==}
+  fast-uri@4.1.1:
+    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -10184,7 +10184,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.0
+      fast-uri: 4.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11777,7 +11777,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@4.1.0: {}
+  fast-uri@4.1.1: {}
 
   fastest-levenshtein@1.0.16: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,7 +33,7 @@ overrides:
   form-data: ">=4.0.6"
   undici: ">=7.28.0"
   vite: ">=6.4.3"
-  fast-uri: ">=3.1.2"
+  fast-uri: ">=4.1.1"
   "@babel/plugin-transform-modules-systemjs": ">=7.29.4"
   ws: ">=8.21.0"
   qs: ">=6.15.2"


### PR DESCRIPTION
`Fix` to audit scan.

```
Run pnpm audit
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ fast-uri vulnerable to host confusion via literal      │
│                     │ backslash authority delimiter                          │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ fast-uri                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=4.0.0 <=4.1.0                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=4.1.1                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@commitlint/cli>@commitlint/load>@commitlint/config- │
│                     │ validator>ajv>fast-uri                                 │
│                     │                                                        │
│                     │ .>@commitlint/cli>@commitlint/load>@commitlint/        │
│                     │ resolve-extends>@commitlint/config-validator>ajv>fast- │
│                     │ uri                                                    │
│                     │                                                        │
│                     │ .>stylelint>table>ajv>fast-uri                         │
│                     │                                                        │
│                     │ ... Found 16 paths, run `pnpm why fast-uri` for more   │
│                     │ information                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-v2hh-gcrm-f6hx      │
└─────────────────────┴────────────────────────────────────────────────────────┘
1 vulnerabilities found
Severity: 1 high
Error: Process completed with exit code 1.
```