### PR TITLE
docs: make main the default branch base and PR target

### DIFF
--- a/.claude/commands/create-branch.md
+++ b/.claude/commands/create-branch.md
@@ -1,9 +1,9 @@
 ---
-description: Create a new working branch from `dev` (never `main`). Infers the branch type from the diff and prompts for the related issue (optional).
+description: Create a new working branch from `main`. Infers the branch type from the diff and prompts for the related issue (optional).
 argument-hint: [short description] [ENG-1234]
 ---
 
-You are running `/create-branch`. Cut a fresh branch off the latest `dev`, named from the change **type** + related **issue** + a short **slug**. **Never branch from `main`.**
+You are running `/create-branch`. Cut a fresh branch off the latest `main`, named from the change **type** + related **issue** + a short **slug**.
 
 **User input:** $ARGUMENTS
 
@@ -18,14 +18,14 @@ You are running `/create-branch`. Cut a fresh branch off the latest `dev`, named
 3. **Type.** Pick from the same enum the repo's commit convention uses: `feat` (default — new component/prop/event/export), `fix`, `hotfix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `ci`, `revert`.
 4. **Related issue (optional).** Ask: "Which issue does this relate to? (`ENG-1234`, or leave blank for `NO-ISSUE`)". A blank answer is fine — treat it as no issue. Do not block on it.
 5. **Create.**
-   - With an issue: `git checkout -b <type>/<ISSUE>-<slug> origin/dev`
-   - Without: `git checkout -b <type>/<slug> origin/dev`
+   - With an issue: `git checkout -b <type>/<ISSUE>-<slug> origin/main`
+   - Without: `git checkout -b <type>/<slug> origin/main`
 
    If uncommitted changes would block the checkout, **stop** and tell the user to commit or stash first — never discard their work.
-6. **Confirm.** Report the new branch name and that it is based on `origin/dev`.
+6. **Confirm.** Report the new branch name and that it is based on `origin/main`.
 
 ## Rules
 
-- Always base on `origin/dev`. If asked to branch from `main`, warn and use `dev` unless the user explicitly insists.
+- Always base on `origin/main`.
 - Branch name: lowercase kebab-case — `<type>/<ISSUE>-<slug>` (or `<type>/<slug>` when there is no issue). Example: `feat/ENG-46315-toast`.
 - Do not push or open a PR here — that is `/open-pr`'s job.

--- a/.claude/commands/open-pr.md
+++ b/.claude/commands/open-pr.md
@@ -1,16 +1,16 @@
 ---
-description: Open a PR to `dev`. Analyzes the diff to pick the Conventional Commit type/scope (drives the semantic-release bump), prompts for the related issue (optional), commits by context, pushes, and opens the PR.
+description: Open a PR to `main`. Analyzes the diff to pick the Conventional Commit type/scope (drives the semantic-release bump), prompts for the related issue (optional), commits by context, pushes, and opens the PR.
 argument-hint: [PR title or focus]
 ---
 
-You are running `/open-pr`. Land the current working changes as a pull request against `dev`, following the repo's commit + versioning conventions end to end.
+You are running `/open-pr`. Land the current working changes as a pull request against `main`, following the repo's commit + versioning conventions end to end.
 
 **User input:** $ARGUMENTS
 
 ## Source of truth
 
 - Commit format and type→bump: [`CONTRIBUTING.md`](../../CONTRIBUTING.md) § Commit convention and [`commitlint.config.js`](../../commitlint.config.js).
-- Release rules: `packages/<pkg>/.releaserc` (semantic-release; merges to `dev` cut the version).
+- Release rules: `packages/<pkg>/.releaserc` (semantic-release; merges to `main` cut the version).
 
 ## Steps
 
@@ -28,9 +28,9 @@ If the diff spans multiple packages, prefer **one commit per scope** (CONTRIBUTI
 ### 2. Related issue (optional)
 - Ask: "Which issue does this relate to? (`ENG-1234`, or leave blank for `NO-ISSUE`)". Blank → use `[NO-ISSUE]`.
 
-### 3. Ensure a `dev`-based branch
-- If on `dev`/`main` (or not on a `dev`-based feature branch), run the `/create-branch` flow (type from step 1, issue from step 2), carrying the working changes over.
-- **Never** open a PR directly from `main` or `dev`.
+### 3. Ensure a `main`-based feature branch
+- If on `main` (or not on a `main`-based feature branch), run the `/create-branch` flow (type from step 1, issue from step 2), carrying the working changes over.
+- **Never** open a PR directly from `main`.
 
 ### 4. Commit by context
 - **Split shared docs/rules from code.** If the diff mixes code with shared docs/rules/templates (`.claude/rules/*`, `.claude/skills/*`, `.specs/_template.md`, …), tell the user those belong in a **separate PR** and offer to split them out. A component's own new `.specs/<name>.md` stays with the component.
@@ -40,16 +40,16 @@ If the diff spans multiple packages, prefer **one commit per scope** (CONTRIBUTI
 - Let the hooks run — `commit-msg` runs commitlint and the header must pass. **Do not** use `--no-verify` to skip commitlint. If `pre-commit` (lint-staged) fails for an environmental reason, report it and ask the user before retrying.
 
 ### 5. Show the plan and confirm
-- Show the planned commit header(s), the implied version bump (minor/patch/major/none), and the target base (`dev`). Confirm with the user before pushing.
+- Show the planned commit header(s), the implied version bump (minor/patch/major/none), and the target base (`main`). Confirm with the user before pushing.
 
 ### 6. Push and open the PR
 - `git push -u origin <branch>`.
-- If a PR already exists for the branch, update it; otherwise `gh pr create --base dev --head <branch>`.
+- If a PR already exists for the branch, update it; otherwise `gh pr create --base main --head <branch>`.
 - **Title:** the conventional commit header (or `$ARGUMENTS`). **Body:** `## Summary` (what + why) and `## Notes`; call out any new dependency and any breaking change; reference the issue. No Figma links, no attribution footer.
 - Report the PR URL.
 
 ## Rules
 
-- The base branch is always `dev`.
+- The base branch is always `main`.
 - Commit and push only as part of this command (running it is the authorization). Do not commit unrelated changes.
 - Keep imports/exports in the public flat form per [`.claude/rules/imports.md`](../rules/imports.md) when the diff touches `package.json#exports` or stories.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -11,7 +11,7 @@ These commands are the **source of truth** for the process. This rule exists onl
 
 ## Conventions (already embedded in the flows — repeated here because they are non-negotiable)
 
-- **Default base is `main`.** The branch comes off `origin/main`, the PR targets `main`. Branching off `dev` and targeting `dev` remains valid when the change is meant to land on the integration branch first; the choice is the author's.
+- **Always base on `main`.** The branch comes off `origin/main`, the PR targets `main`.
 - **Branch name:** kebab-case `<type>/<ISSUE>-<slug>` (or `<type>/<slug>` without an issue). `type` comes from the same Conventional Commits enum ([`CONTRIBUTING.md`](../../CONTRIBUTING.md) § Commit convention / [`commitlint.config.js`](../../commitlint.config.js)). That enum must match every `packages/*/.releaserc` — see [`release-types.md`](./release-types.md).
 - **Commit:** Conventional Commits, commitlint-valid header. **Never** add `Co-Authored-By` or an attribution footer ("Generated with Claude"). **Never** `--no-verify` to skip commitlint.
 - **Commit/push only as part of `/open-pr`** — running the command is the authorization. Do not commit unrelated changes.
@@ -20,5 +20,5 @@ These commands are the **source of truth** for the process. This rule exists onl
 ## What not to do
 
 - Don't run `git checkout -b`, `git commit`, `git push`, or `gh pr create` "by hand" outside these flows when the request is to create a branch / open a PR.
-- Don't open a PR directly from `main` or `dev` (i.e. don't PR the shared branches themselves — feature branches are still required).
+- Don't open a PR directly from `main` — feature branches are still required.
 - Don't mark a change as breaking without confirming with the user first.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -11,7 +11,7 @@ These commands are the **source of truth** for the process. This rule exists onl
 
 ## Conventions (already embedded in the flows — repeated here because they are non-negotiable)
 
-- **Always base on `dev`.** The branch comes off `origin/dev`, the PR targets `dev`. **Never** `main`, never branch from `main`.
+- **Default base is `main`.** The branch comes off `origin/main`, the PR targets `main`. Branching off `dev` and targeting `dev` remains valid when the change is meant to land on the integration branch first; the choice is the author's.
 - **Branch name:** kebab-case `<type>/<ISSUE>-<slug>` (or `<type>/<slug>` without an issue). `type` comes from the same Conventional Commits enum ([`CONTRIBUTING.md`](../../CONTRIBUTING.md) § Commit convention / [`commitlint.config.js`](../../commitlint.config.js)). That enum must match every `packages/*/.releaserc` — see [`release-types.md`](./release-types.md).
 - **Commit:** Conventional Commits, commitlint-valid header. **Never** add `Co-Authored-By` or an attribution footer ("Generated with Claude"). **Never** `--no-verify` to skip commitlint.
 - **Commit/push only as part of `/open-pr`** — running the command is the authorization. Do not commit unrelated changes.
@@ -20,5 +20,5 @@ These commands are the **source of truth** for the process. This rule exists onl
 ## What not to do
 
 - Don't run `git checkout -b`, `git commit`, `git push`, or `gh pr create` "by hand" outside these flows when the request is to create a branch / open a PR.
-- Don't open a PR directly from `main` or `dev`.
+- Don't open a PR directly from `main` or `dev` (i.e. don't PR the shared branches themselves — feature branches are still required).
 - Don't mark a change as breaking without confirming with the user first.


### PR DESCRIPTION
## Summary

- `git-workflow.md` now defaults to `main` as branch base and PR target; `dev` remains valid when the author wants to land on the integration branch first.
- Clarifies the "don't open a PR from main/dev" line to mean the shared branches themselves — feature branches are still the required source.

## Rationale

The current epic (ENG-37511) work is being coordinated on `main`, so the "Never main" hard prohibition no longer reflects how the team is actually shipping. Softening to "default main, dev when appropriate" removes the ceremony without giving up branch discipline.