### PR TITLE
ci: remove autocommit and apply pr+gitTag

### DIFF
--- a/.github/workflows/package-icons.yml
+++ b/.github/workflows/package-icons.yml
@@ -46,3 +46,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_PKG }}
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Open version bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GIT_PKG }}
+        run: |
+          if git diff --quiet -- packages/icons/package.json; then
+            echo "No release published; skipping version bump PR."
+            exit 0
+          fi
+          VERSION="$(node -p "require('./packages/icons/package.json').version")"
+          BRANCH="ci/release-icons-${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add packages/icons/package.json packages/icons/CHANGELOG.md
+          git commit -m "ci(release): bump @aziontech/icons to ${VERSION}"
+          git push --force origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "ci(release): bump @aziontech/icons to ${VERSION} [skip ci]" \
+            --body "Automated follow-up to the @aziontech/icons@${VERSION} release: aligns package.json and CHANGELOG.md with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Ficons%40${VERSION} — Merging this PR does not trigger a new release (ci commits produce no version bump)."

--- a/.github/workflows/package-theme.yml
+++ b/.github/workflows/package-theme.yml
@@ -46,3 +46,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_PKG }}
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Open version bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GIT_PKG }}
+        run: |
+          if git diff --quiet -- packages/theme/package.json; then
+            echo "No release published; skipping version bump PR."
+            exit 0
+          fi
+          VERSION="$(node -p "require('./packages/theme/package.json').version")"
+          BRANCH="ci/release-theme-${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add packages/theme/package.json packages/theme/CHANGELOG.md
+          git commit -m "ci(release): bump @aziontech/theme to ${VERSION}"
+          git push --force origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "ci(release): bump @aziontech/theme to ${VERSION} [skip ci]" \
+            --body "Automated follow-up to the @aziontech/theme@${VERSION} release: aligns package.json and CHANGELOG.md with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Ftheme%40${VERSION} — Merging this PR does not trigger a new release (ci commits produce no version bump)."

--- a/.github/workflows/package-webkit.yml
+++ b/.github/workflows/package-webkit.yml
@@ -46,3 +46,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_PKG }}
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Open version bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GIT_PKG }}
+        run: |
+          if git diff --quiet -- packages/webkit/package.json; then
+            echo "No release published; skipping version bump PR."
+            exit 0
+          fi
+          VERSION="$(node -p "require('./packages/webkit/package.json').version")"
+          BRANCH="ci/release-webkit-${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add packages/webkit/package.json packages/webkit/CHANGELOG.md packages/webkit/catalog.json
+          git commit -m "ci(release): bump @aziontech/webkit to ${VERSION}"
+          git push --force origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "ci(release): bump @aziontech/webkit to ${VERSION} [skip ci]" \
+            --body "Automated follow-up to the @aziontech/webkit@${VERSION} release: aligns package.json, CHANGELOG.md and catalog.json with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Fwebkit%40${VERSION} — Merging this PR does not trigger a new release (ci commits produce no version bump)."

--- a/packages/icons/.releaserc
+++ b/packages/icons/.releaserc
@@ -56,16 +56,6 @@
       }
     ],
     [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "package.json",
-          "CHANGELOG.md"
-        ],
-        "message": "chore(release): @aziontech/icons ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "labels": false

--- a/packages/theme/.releaserc
+++ b/packages/theme/.releaserc
@@ -56,16 +56,6 @@
       }
     ],
     [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "package.json",
-          "CHANGELOG.md"
-        ],
-        "message": "chore(release): @aziontech/theme ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "labels": false

--- a/packages/webkit/.releaserc
+++ b/packages/webkit/.releaserc
@@ -56,17 +56,6 @@
       }
     ],
     [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "package.json",
-          "CHANGELOG.md",
-          "catalog.json"
-        ],
-        "message": "chore(release): @aziontech/webkit ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "labels": false


### PR DESCRIPTION
## Summary

Semantic-release stopped working when the `main` ruleset ("changes must be made through a pull request") started rejecting the direct push `@semantic-release/git` makes during `prepare`, killing every release before the tag / npm publish / GitHub Release could happen:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

Following semantic-release best practices (don't commit release artifacts back to protected branches), this PR removes the commit-back-to-`main` step entirely and replaces it with an automated version-bump pull request:

- **`packages/{webkit,theme,icons}/.releaserc`** — drop `@semantic-release/git`. Git tags remain the version source of truth; release notes keep landing on the GitHub Releases page (`@semantic-release/github`) and in `CHANGELOG.md`.
- **`.github/workflows/package-{webkit,theme,icons}.yml`** — new **Open version bump PR** step: after a successful publish it pushes a `ci/release-<pkg>-<version>` branch and opens a PR aligning `package.json` and `CHANGELOG.md` (plus the regenerated `catalog.json` for webkit) with the published version.

## Release flow after this change

1. A PR touching `packages/<pkg>/**` merges to `main` → the publish workflow runs.
2. semantic-release analyzes commits → generates notes → updates `CHANGELOG.md` and `package.json` in the runner's working tree → builds → pushes the version tag → publishes to npm (provenance) → creates the GitHub Release. **Nothing is pushed to `main`.**
3. The workflow opens the automated bump PR from the files semantic-release left behind; merging it re-aligns the repo with the published version.

## Notes

- **No release loops** — three independent layers: the bump commit type `ci(release)` maps to `release: false` in every `.releaserc`; the bump PR title carries `[skip ci]`, so the squash-merged commit doesn't trigger push workflows; and the step exits early when no release was published (`package.json` unchanged).
- The bump PR is created with `GIT_PKG` (PAT), so required checks run on it — the default `GITHUB_TOKEN` would not trigger them. Bump commits are authored as `github-actions[bot]`; the branch head commit intentionally has no `[skip ci]` so its checks run.
- Version truth is the git tag: the next release computes correctly even if a bump PR merges late, and npm always publishes the right version because `@semantic-release/npm` writes it during `prepare` (runner-only, `npmPublish: false` unchanged).
