### PR TITLE
ci(release): bump @aziontech/theme to 4.1.0 [skip ci]

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [4.1.0](https://github.com/aziontech/webkit/compare/@aziontech/theme@4.0.0...@aziontech/theme@4.1.0) (2026-07-23)
+
+
+### Features
+
+* webkit init hardening, toast service auto-mount, and motion token adoption ([#772](https://github.com/aziontech/webkit/issues/772)) ([5534fb2](https://github.com/aziontech/webkit/commit/5534fb2f570729c79728b33b561082b65d5d44af))
+
+
+### Bug Fixes
+
+* bump fast-uri version from 4.1.0 to 4.1.1 ([#773](https://github.com/aziontech/webkit/issues/773)) ([2f43cbb](https://github.com/aziontech/webkit/commit/2f43cbb0e128fdc8fbea16b6ed04bcf63356b08f))
+
 ## [2.6.0](https://github.com/aziontech/webkit/compare/@aziontech/theme@2.5.0...@aziontech/theme@2.6.0) (2026-06-17)
 
 ### Features

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aziontech/theme",
   "type": "module",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": "aziontech",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Automated follow-up to the @aziontech/theme@4.1.0 release: aligns package.json and CHANGELOG.md with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Ftheme%404.1.0 — Merging this PR does not trigger a new release (ci commits produce no version bump).