### PR TITLE
ci(release): bump @aziontech/webkit to 4.1.0 [skip ci]

### DIFF
--- a/packages/webkit/CHANGELOG.md
+++ b/packages/webkit/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [4.1.0](https://github.com/aziontech/webkit/compare/@aziontech/webkit@4.0.0...@aziontech/webkit@4.1.0) (2026-07-23)
+
+### Features
+
+- webkit init hardening, toast service auto-mount, and motion token adoption ([#772](https://github.com/aziontech/webkit/issues/772)) ([5534fb2](https://github.com/aziontech/webkit/commit/5534fb2f570729c79728b33b561082b65d5d44af))
+
+### Bug Fixes
+
+- bump fast-uri version from 4.1.0 to 4.1.1 ([#773](https://github.com/aziontech/webkit/issues/773)) ([2f43cbb](https://github.com/aziontech/webkit/commit/2f43cbb0e128fdc8fbea16b6ed04bcf63356b08f))
+
 ## [3.9.0](https://github.com/aziontech/webkit/compare/@aziontech/webkit@3.8.0...@aziontech/webkit@3.9.0) (2026-06-18)
 
 ### Features

--- a/packages/webkit/catalog.json
+++ b/packages/webkit/catalog.json
@@ -1,6 +1,6 @@
 {
   "package": "@aziontech/webkit",
-  "webkitVersion": "4.0.0",
+  "webkitVersion": "4.1.0",
   "deniedPrefixes": [
     "@aziontech/webkit/src/"
   ],

--- a/packages/webkit/package.json
+++ b/packages/webkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/webkit",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Reusable UI components and design system utilities for building Azion web interfaces.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated follow-up to the @aziontech/webkit@4.1.0 release: aligns package.json, CHANGELOG.md and catalog.json with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Fwebkit%404.1.0 — Merging this PR does not trigger a new release (ci commits produce no version bump).