### PR TITLE
[NO-ISSUE] feat: derive spec name from the Figma frame in /spec-create

### DIFF
--- a/.claude/agents/figma-extractor.md
+++ b/.claude/agents/figma-extractor.md
@@ -15,7 +15,7 @@ You are the `figma-extractor` sub-agent. You execute the `figma-discover` skill 
 
 1. Load the `figma:figma-use` skill (mandatory MCP prerequisite).
 2. Call `mcp__plugin_figma_figma__get_variable_defs` on the spec's `figma.node_id`.
-3. Call `mcp__plugin_figma_figma__get_design_context` on the same node.
+3. Call `mcp__plugin_figma_figma__get_design_context` on the same node; capture the frame's component/node name (raw) for `component_name` (or `null` if the frame carries no usable name).
 4. Normalize the response into the JSON shape defined by the skill.
 
 ## What you may NOT do
@@ -32,6 +32,7 @@ JSON only:
 ```json
 {
   "figma_node": "<url-or-nodeId>",
+  "component_name": "<raw frame name, or null>",
   "variables": [{ "name": "...", "value": "...", "kind": "color|typography|spacing|radius|shadow|container" }],
   "regions": ["header", "body", "footer", "actions"],
   "states": ["default", "hover", "active", "focus", "disabled"]

--- a/.claude/commands/spec-create.md
+++ b/.claude/commands/spec-create.md
@@ -1,6 +1,6 @@
 ---
 description: Draft a `.specs/<name>.md` for a new webkit component interactively. Status starts at `draft`; review the file, mark `status: approved`, then run `/component-create <name>`.
-argument-hint: <name> [--category <category>] [--figma <url>]
+argument-hint: [<name>] [--category <category>] [--figma <url>]
 ---
 
 You are creating a new component spec for `.specs/<name>.md`. Follow the `spec-create` skill in `.claude/skills/spec-create/SKILL.md` exactly.
@@ -11,7 +11,7 @@ You are creating a new component spec for `.specs/<name>.md`. Follow the `spec-c
 
 `spec-create` has **two distinct paths**. Detect the mode from the arguments (and confirm with the user before drafting):
 
-- **Mode A — Figma-driven** (`--figma <url>` present). The Figma frame is the source of truth: extract tokens/regions/states, map them to DESIGN.md, and ask the user only where the frame is silent (behavior, a11y intent, story list).
+- **Mode A — Figma-driven** (`--figma <url>` present). The Figma frame is the source of truth: extract tokens/regions/states, map them to DESIGN.md, and ask the user only where the frame is silent (behavior, a11y intent, story list). The component **name** is derived from the frame's component name (normalized to kebab, confirmed with the user); passing `<name>` is **optional** here and, when given, overrides the frame.
 - **Mode B — Name + Category** (no `--figma`; the user is building **without** a design). There is **no** ground truth, so invention risk is highest. This mode is deliberately **more blocking**: it **always asks** about every section, one at a time, **never infers** props/events/tokens, and refuses to write until each mandatory section has a real answer (**no silent `TBD`**). `--category` is required here (ask + confirm if missing).
 
 If `--figma` is absent, you are in **Mode B** — do not quietly infer from intent. If both a URL and "no figma" intent are ambiguous, ask which mode the user wants before proceeding.
@@ -25,12 +25,12 @@ If `--figma` is absent, you are in **Mode B** — do not quietly infer from inte
    - [`.claude/rules/no-invention.md`](.claude/rules/no-invention.md), [`naming.md`](.claude/docs/COMPONENT_REQUIREMENTS.md), [`tokens.md`](.claude/docs/DESIGN.md), [`accessibility.md`](.claude/docs/COMPONENT_REQUIREMENTS.md), [`bem-testid.md`](.claude/docs/COMPONENT_REQUIREMENTS.md).
    - [`.claude/docs/DESIGN.md`](.claude/docs/DESIGN.md) — design tokens (authoritative).
 
-2. **Parse the arguments.** Required: `<name>` (kebab-case). Optional: `--category`, `--figma`. If the name is missing or invalid, ask the user.
+2. **Parse the arguments.** `<name>` (kebab-case) is **required in Mode B**; in **Mode A it is optional** — when omitted it is derived from the frame's component name (normalized + confirmed), and a passed `<name>` overrides. **If the frame has no usable name, ask the user.** Optional: `--category`, `--figma`. If the name is missing in Mode B (no `--figma`), ask the user.
 
 3. **Refuse to overwrite** any existing `.specs/<name>.md` whose `status ∈ {approved, implemented, locked}`.
 
 4. **Invoke the `spec-author` sub-agent** with the universal envelope from `.claude/agents/_README.md`. Pass it the user's arguments, the **mode** (A or B), and ask it to:
-   - **Mode A (Figma):** run `figma-extractor` + `token-mapper` to pre-fill Tokens/regions/states; confirm the extracted values with the user; ask only about behavior/a11y/stories the frame cannot express. Infer the category from the frame + confirm.
+   - **Mode A (Figma):** run `figma-extractor` + `token-mapper` to pre-fill Tokens/regions/states; confirm the extracted values with the user; ask only about behavior/a11y/stories the frame cannot express. Derive the component **name** from the frame's `component_name` (normalize to kebab, confirm) unless `<name>` was passed (which overrides); **if the frame has no usable name, ask the user for it.** Infer the category from the frame + confirm.
    - **Mode B (Name + Category):** ask about **every** section, one at a time — Purpose / Props / Events / Slots / Sub-components (only when composition) / States / Motion & Animations / Accessibility / Stories — and **map each token to DESIGN.md with the user, never infer**. Confirm the category first. If the user leaves any mandatory section unanswered, emit `BLOCKED:` and write nothing (**no silent `TBD`** in this mode).
    - Write `.specs/<name>.md` with `status: draft`.
 

--- a/.claude/skills/figma-discover/SKILL.md
+++ b/.claude/skills/figma-discover/SKILL.md
@@ -2,7 +2,7 @@
 name: figma-discover
 description: Pull design tokens, regions, and states from a Figma frame via the Figma MCP. Pure read; emits a structured JSON blob the rest of the pipeline consumes.
 status: active
-last_updated: 2026-05-22
+last_updated: 2026-07-23
 scope: webkit
 enforced_by: [dependencies, migration]
 ---
@@ -26,11 +26,12 @@ Convert a Figma URL or `nodeId` into a structured JSON blob: colors, typography,
 
 1. **Load prerequisite skill.** Invoke `figma:figma-use` before any MCP call (mandatory per Figma plugin instructions).
 2. **Extract variables.** Call `mcp__plugin_figma_figma__get_variable_defs` on the target node. Capture every named Figma variable along with its resolved value.
-3. **Extract design context.** Call `mcp__plugin_figma_figma__get_design_context` for the regions, states, and component anatomy.
+3. **Extract design context.** Call `mcp__plugin_figma_figma__get_design_context` for the regions, states, and component anatomy. Capture the frame's component/node name **raw** (do not kebab or rewrite it) for `component_name`.
 4. **Normalize.** Emit a single JSON object:
    ```json
    {
      "figma_node": "<url>",
+     "component_name": "...",
      "variables": [
        { "name": "color/surface", "value": "...", "kind": "color" },
        { "name": "text/heading-md", "value": "...", "kind": "typography" }
@@ -66,7 +67,7 @@ Output the behavior structurally; do not paraphrase Figma's documentation into t
 
 ## Migration fidelity
 
-When the same Figma frame names a component differently from our convention (e.g. `HeaderNavigationMenuItem` or `Tabs/Variant=Primary`), keep the original name in `figma_node`/`variables` for traceability, but do **not** propose component names that bake the Figma name in. Our naming (`kind`, `size`, kebab-case files) takes precedence — see [`migration.md`](../../rules/migration.md).
+Surface the frame's component name **raw** as `component_name` (e.g. `HeaderNavigationMenuItem`, `Tabs/Variant=Primary`) for traceability and so `spec-create` can *propose* a normalized kebab name from it. Do **not** kebab or rewrite it here, and never bake a raw Figma name into a decision: the canonical name is the normalized kebab that `spec-create` confirms with the user, and our naming (`kind`, `size`, kebab-case files) always takes precedence — see [`migration.md`](../../rules/migration.md). If the frame carries no usable component name, emit `component_name: null` — `spec-create` then asks the user.
 
 ## Fallbacks
 

--- a/.claude/skills/spec-create/SKILL.md
+++ b/.claude/skills/spec-create/SKILL.md
@@ -2,7 +2,7 @@
 name: spec-create
 description: Interactively draft `.specs/<name>.md` for a new webkit component. Owns the questions, the cross-reference with DESIGN.md and Figma, and the initial `status: draft` write. Never writes component code.
 status: active
-last_updated: 2026-05-22
+last_updated: 2026-07-23
 scope: webkit
 enforced_by: [no-invention, props, styling]
 ---
@@ -20,7 +20,7 @@ Produce a `.specs/<name>.md` that is complete enough for `spec-validator` to fli
 
 ## Inputs & mode
 
-- `<name>` (kebab-case) — required in both modes.
+- `<name>` (kebab-case) — **required in Mode B; optional in Mode A.** In Mode A (Figma), when `<name>` is omitted the name is derived from the frame's component name (normalized to kebab) and **confirmed** with the user; a passed `<name>` **overrides** the frame. See **Name resolution** in the Mode A section.
 - The **mode** is chosen by input:
   - **Mode A — Figma-driven:** `--figma <url>` is present. The frame is the source of truth.
   - **Mode B — Name + Category:** no `--figma`. The user is building without a design; `--category <name>` is required (ask + confirm if missing). This mode is **more blocking** — see below.
@@ -29,7 +29,7 @@ Confirm the mode with the user before drafting. If it's ambiguous which one they
 
 ## Workflow — shared steps
 
-1. **Argument parsing.** Reject if `<name>` is missing or not kebab-case. Reject if `.specs/<name>.md` already exists with `status ∈ {approved, implemented, locked}` (the user is editing the wrong file).
+1. **Argument parsing & name resolution.** Parse the flags. A passed `<name>` must be kebab-case (reject otherwise) and always **wins** (explicit override). If `<name>` is absent: in **Mode B** reject (no frame to derive from); in **Mode A** defer — the name is resolved from the frame in **Name resolution** below, *before* any file path is computed. Only once the name is known: reject if `.specs/<name>.md` already exists with `status ∈ {approved, implemented, locked}` (the user is editing the wrong file) and ask for a different name.
 2. **Category.** Use the taxonomy in `.specs/_template.md` frontmatter. State the inferred/received category and **ask the user to confirm** (mandatory in Mode B — never assume).
 3. **Structure decision.** Call `structure-decide` with the regions/answers. Default to `monolithic` when in doubt.
 4. **Write the spec.** Copy `.specs/_template.md` to `.specs/<name>.md`, fill every section, frontmatter `status: draft`, `created`/`last_updated` = today, no `checksum`.
@@ -37,6 +37,7 @@ Confirm the mode with the user before drafting. If it's ambiguous which one they
 
 ## Mode A — Figma-driven (`--figma <url>`)
 
+- **Name resolution.** If the user passed `<name>`, use it verbatim (explicit override). Otherwise take the frame's component name from `figma-discover`'s `component_name` and **normalize it to kebab** per [`naming.md`](../../rules/naming.md) (Pascal/camel → kebab; drop variant/state/version qualifiers like `Variant=Primary` or `v2`; strip emojis, slashes, spaces). **Propose the normalized name and ask the user to confirm** — never bake the raw Figma name in (see [`migration.md`](../../rules/migration.md)). If the frame yields no usable name, ask the user for one (as in Mode B). Resolve the name **before** computing the `.specs/<name>.md` path and its collision check.
 - **Figma discovery.** Delegate to `figma-discover` via the `figma-extractor` sub-agent. Use the returned JSON to pre-populate the Tokens section.
 - **Token mapping.** Run `token-map` against the Figma output and DESIGN.md. Populate the Tokens table; flag Theme gaps.
 - **Confirm, don't assume.** Show the extracted props/regions/states/tokens and ask the user to confirm/correct.


### PR DESCRIPTION
## Summary

Adjusts how a component spec is **started** in `/spec-create`: in **Mode A** (`--figma <url>`), the component `<name>` is now **optional**. When omitted, it is derived from the frame's component name (normalized to kebab per `naming.md`) and **confirmed** with the user; a passed `<name>` still **overrides** the frame. If the frame carries no usable name, the user is asked (as in Mode B). `<name>` stays **required in Mode B** (no frame to derive from).

Why: with a Figma frame, the name is already implied by the design — requiring it verbatim was friction. The frame is treated as a *proposal* that is normalized + confirmed (never inherited raw), consistent with `migration.md`.

## Changes
- `.claude/commands/spec-create.md` — `<name>` optional in Mode A (argument-hint, parsing, Mode A instructions); ask the user when the frame has no name.
- `.claude/skills/spec-create/SKILL.md` — **Name resolution** step: derive → normalize to kebab → confirm; resolve the name before the file path / collision check.
- `.claude/skills/figma-discover/SKILL.md` — emit `component_name` (raw) in the discovery JSON; `null` when the frame has none.
- `.claude/agents/figma-extractor.md` — mirror `component_name` in the output shape.

## Notes
- Tooling/docs only under `.claude/` — no package source touched, so no semantic-release bump.
- Non-breaking: passing `<name>` still works everywhere; the behavior only adds a derive-from-frame path in Mode A.