### PR TITLE
[NO-ISSUE] feat(webkit-sample): add Webkit Hub Component Grid banner at /site/hub

### DIFF
--- a/apps/webkit-sample/src/components/site/ComponentGrid.vue
+++ b/apps/webkit-sample/src/components/site/ComponentGrid.vue
@@ -1,0 +1,172 @@
+<script setup>
+  // The "Component Grid" layer of the Webkit Hub home: a 3D-tilted plane showcasing
+  // real @aziontech/webkit components. Each component sits in a ComponentGridCell
+  // that highlights it on hover/focus (dashed accent ring + floating label),
+  // recreating the Figma "Grid 3D Transform" frame. Components are rendered
+  // display-only — the grid demonstrates the library, it is not a working console.
+  import Avatar from '@aziontech/webkit/avatar'
+  import Badge from '@aziontech/webkit/badge'
+  import Button from '@aziontech/webkit/button'
+  import Chip from '@aziontech/webkit/chip'
+  import CodeBlock from '@aziontech/webkit/code-block'
+  import IconButton from '@aziontech/webkit/icon-button'
+  import InputText from '@aziontech/webkit/input-text'
+  import Message from '@aziontech/webkit/message'
+  import SegmentedButton from '@aziontech/webkit/segmented-button'
+  import Switch from '@aziontech/webkit/switch'
+  import TabView from '@aziontech/webkit/tab-view'
+  import Tag from '@aziontech/webkit/tag'
+  import { ref } from 'vue'
+
+  import ComponentGridCell from './ComponentGridCell.vue'
+
+  // Static display state for the showcased components.
+  const switchOn = ref(true)
+  const search = ref('edge-function')
+  const view = ref('grid')
+  const viewOptions = [
+    { label: 'Grid', value: 'grid' },
+    { label: 'List', value: 'list' }
+  ]
+  const tab = ref('overview')
+  const codeTabs = [
+    {
+      label: 'main.js',
+      value: 'main',
+      language: 'javascript',
+      code: "export default async function (request) {\n  return new Response('Hello from the edge')\n}"
+    }
+  ]
+</script>
+
+<template>
+  <div class="perspective relative">
+    <div class="plane grid grid-cols-2 gap-x-[var(--spacing-xl)] gap-y-[var(--spacing-xxl)] md:grid-cols-3">
+      <ComponentGridCell name="Button">
+        <Button
+          label="Deploy"
+          kind="primary"
+          size="medium"
+        />
+      </ComponentGridCell>
+
+      <ComponentGridCell name="SegmentedButton">
+        <SegmentedButton
+          v-model="view"
+          :options="viewOptions"
+          aria-label="View"
+        />
+      </ComponentGridCell>
+
+      <ComponentGridCell name="Tag">
+        <Tag
+          label="Production"
+          severity="success"
+          size="medium"
+        />
+      </ComponentGridCell>
+
+      <ComponentGridCell name="Switch">
+        <Switch
+          v-model="switchOn"
+          aria-label="Enable edge cache"
+        />
+      </ComponentGridCell>
+
+      <ComponentGridCell name="Chip">
+        <Chip label="edge-function" />
+      </ComponentGridCell>
+
+      <ComponentGridCell name="Avatar">
+        <Avatar
+          label="Ana Souza"
+          size="medium"
+          kind="square"
+        />
+      </ComponentGridCell>
+
+      <ComponentGridCell name="InputText">
+        <InputText
+          v-model="search"
+          size="medium"
+          aria-label="Search components"
+          placeholder="Search"
+          class="w-full"
+        />
+      </ComponentGridCell>
+
+      <ComponentGridCell name="Badge">
+        <Badge
+          label="99"
+          severity="danger"
+          size="medium"
+        />
+      </ComponentGridCell>
+
+      <ComponentGridCell name="IconButton">
+        <IconButton
+          icon="pi pi-bolt"
+          kind="outlined"
+          aria-label="Run"
+        />
+      </ComponentGridCell>
+
+      <ComponentGridCell name="Message">
+        <Message
+          severity="info"
+          title="Deploy started"
+        />
+      </ComponentGridCell>
+
+      <ComponentGridCell name="TabView">
+        <TabView v-model:value="tab">
+          <TabView.List>
+            <TabView.Item
+              value="overview"
+              label="Overview"
+            />
+            <TabView.Item
+              value="metrics"
+              label="Metrics"
+            />
+          </TabView.List>
+          <TabView.Content>
+            <TabView.Panel value="overview" />
+            <TabView.Panel value="metrics" />
+          </TabView.Content>
+        </TabView>
+      </ComponentGridCell>
+
+      <ComponentGridCell
+        name="CodeBlock"
+        class="col-span-2 md:col-span-1"
+      >
+        <CodeBlock
+          :tabs="codeTabs"
+          :show-line-numbers="false"
+          class="w-full"
+        />
+      </ComponentGridCell>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  /* 3D perspective plane. Geometry (perspective/rotate) has no theme token, so it
+     lives here; every color/spacing/shape token stays in the template classes. */
+  .perspective {
+    perspective: 1600px;
+    perspective-origin: 60% 20%;
+  }
+
+  .plane {
+    transform: rotateX(26deg) rotateZ(-16deg) scale(0.96);
+    transform-style: preserve-3d;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .plane {
+      transform: none;
+    }
+  }
+</style>

--- a/apps/webkit-sample/src/components/site/ComponentGridCell.vue
+++ b/apps/webkit-sample/src/components/site/ComponentGridCell.vue
@@ -1,0 +1,86 @@
+<script setup>
+  // One cell of the interactive "Component Grid" banner. It frames a single,
+  // display-only @aziontech/webkit component sitting on the 3D-tilted plane, and
+  // is the hover/focus target: on hover (or keyboard focus) the cell lifts toward
+  // the viewer and un-tilts to face them, revealing a dashed accent ring
+  // (flat corners) and a small floating label naming the component.
+  //
+  // The cell — not its inner component — owns the pointer/focus interaction, so
+  // hover hit-testing stays reliable under the parent plane's 3D transform and
+  // every component is reachable by keyboard (tabindex="0").
+  defineProps({
+    /** Component name shown in the floating highlight label. */
+    name: { type: String, required: true }
+  })
+</script>
+
+<template>
+  <div
+    class="cell group relative"
+    tabindex="0"
+    :aria-label="`${name} component`"
+  >
+    <!-- Dashed accent ring with flat corners + a soft accent glow ring. -->
+    <span
+      aria-hidden="true"
+      class="ring pointer-events-none absolute -inset-[var(--spacing-sm)] rounded-[var(--shape-flat)] border border-dashed border-[var(--primary)] opacity-0 ring-1 ring-[var(--primary)]"
+    />
+    <!-- Floating label tag (plain label, not the Tag component), top-left. -->
+    <span
+      aria-hidden="true"
+      class="label pointer-events-none absolute -top-[var(--spacing-md)] left-[calc(-1*var(--spacing-sm))] rounded-[var(--shape-flat)] bg-[var(--primary)] px-[var(--spacing-xxs)] py-px text-label-sm leading-none text-[var(--primary-contrast)] opacity-0"
+    >
+      {{ name }}
+    </span>
+    <!-- The showcased component, display-only (no inner interaction). -->
+    <div class="pointer-events-none select-none">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  /* 3D mechanics only — every color / spacing / shape value above is a theme
+     token. Perspective/rotate geometry has no token, so it lives here. */
+  .cell {
+    transform-style: preserve-3d;
+    transition: transform 240ms var(--ease-out, ease-out);
+    outline: none;
+  }
+
+  .ring,
+  .label {
+    transition:
+      opacity 150ms var(--ease-out, ease-out),
+      transform 150ms var(--ease-out, ease-out);
+  }
+
+  /* Lift toward the viewer WITHOUT relocating the cell: a centroid-stable scale
+     keeps the pointer over the cell (a translate/rotate would move it out from
+     under the cursor and make :hover flicker). translateZ pops it above
+     neighbours on the shared 3D plane; the ring + label carry the highlight. */
+  .cell:hover,
+  .cell:focus-visible {
+    transform: translateZ(40px) scale(1.06);
+    z-index: 5;
+  }
+
+  .cell:hover .ring,
+  .cell:focus-visible .ring,
+  .cell:hover .label,
+  .cell:focus-visible .label {
+    opacity: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cell,
+    .ring,
+    .label {
+      transition: none;
+    }
+    .cell:hover,
+    .cell:focus-visible {
+      transform: none;
+    }
+  }
+</style>

--- a/apps/webkit-sample/src/components/site/WebkitHub.vue
+++ b/apps/webkit-sample/src/components/site/WebkitHub.vue
@@ -1,0 +1,42 @@
+<script setup>
+  // Landing-page example: the Home of the "Webkit Hub" — an interactive banner
+  // that showcases the @aziontech/webkit component library as a 3D-tilted
+  // "Component Grid" (a recreation of the Figma "Grid 3D Transform" frame).
+  // Rendered inside the segregated marketing shell (website nav + footer, dark
+  // theme), mirroring how LandingAzion pairs SiteLayout with a content component.
+  import ComponentGrid from './ComponentGrid.vue'
+  import SiteLayout from './SiteLayout.vue'
+</script>
+
+<template>
+  <SiteLayout>
+    <section class="relative overflow-hidden border-b border-[var(--border-muted)]">
+      <div class="relative z-10 mx-auto w-full max-w-[var(--container-7xl)] px-[var(--spacing-md)]">
+        <!-- Hero copy. -->
+        <div class="flex flex-col items-start gap-[var(--spacing-md)] pb-[var(--spacing-lg)] pt-[var(--spacing-xxl)]">
+          <div class="flex items-center gap-[var(--spacing-xs)]">
+            <span
+              aria-hidden="true"
+              class="size-2.5 rounded-[var(--shape-elements)] bg-[var(--color-orange-500)]"
+            />
+            <span class="text-overline-sm uppercase tracking-widest text-[var(--text-muted)]">
+              Webkit Hub
+            </span>
+          </div>
+          <h1 class="max-w-[var(--container-4xl)] text-balance text-left text-heading-2xl text-[var(--text-default)]">
+            One design system. Every component, ready to compose.
+          </h1>
+          <p class="max-w-[var(--container-2xl)] text-pretty text-body-lg text-[var(--text-muted)]">
+            Explore the @aziontech/webkit library. Hover any component in the grid to highlight it — tokens, accessibility, and dark mode built in.
+          </p>
+        </div>
+      </div>
+
+      <!-- Component Grid layer — the 3D showcase plane. Extra bottom padding gives
+           the cells room to lift toward the viewer on hover without clipping. -->
+      <div class="mx-auto w-full max-w-[var(--container-7xl)] px-[var(--spacing-md)] pb-[var(--spacing-xxl)] pt-[var(--spacing-lg)]">
+        <ComponentGrid />
+      </div>
+    </section>
+  </SiteLayout>
+</template>

--- a/apps/webkit-sample/src/router.js
+++ b/apps/webkit-sample/src/router.js
@@ -35,6 +35,7 @@ import Playground from './components/Playground.vue'
 import SignUp from './components/SignUp.vue'
 import AzionDocs from './components/docs/AzionDocs.vue'
 import LandingAzion from './components/site/LandingAzion.vue'
+import WebkitHub from './components/site/WebkitHub.vue'
 import SqlDatabase from './components/SqlDatabase.vue'
 import SqlDatabaseDetail from './components/SqlDatabaseDetail.vue'
 import TemplateSettings from './components/TemplateSettings.vue'
@@ -49,6 +50,7 @@ const routes = [
   // from the console app shell used by every other route.
   { path: '/site', redirect: '/site/home' },
   { path: '/site/home', name: 'site-home', component: LandingAzion },
+  { path: '/site/hub', name: 'site-hub', component: WebkitHub },
   { path: '/site/docs', name: 'site-docs', component: AzionDocs },
   { path: '/login', name: 'login', component: LoginScreen },
   { path: '/signup', name: 'signup', component: SignUp },


### PR DESCRIPTION
## Summary

Adds the **Webkit Hub home** — an interactive "Component Grid" banner at `/site/hub` in the sample app, recreating the Figma "Grid 3D Transform" frame. It showcases the `@aziontech/webkit` library as a 3D perspective-tilted plane of real components; hovering (or keyboard-focusing) any component highlights it with a **dashed, flat-corner (`--shape-flat`) accent ring + a floating label** naming the component.

- New route `/site/hub` → `WebkitHub.vue` in the dark marketing shell (`SiteLayout`), mirroring how `LandingAzion` pairs the shell with a content component.
- `ComponentGrid.vue` — the "Component Grid" layer: a `perspective` plane (`rotateX/rotateZ`, `preserve-3d`) of display-only webkit components (Button, SegmentedButton, Tag, Switch, Chip, Avatar, InputText, Badge, IconButton, Message, TabView, CodeBlock).
- `ComponentGridCell.vue` — the hover/focus layer: the cell (not its inner component) owns the interaction, lifts centroid-stably (scale, no relocation, so hover never flickers), and reveals the dashed accent ring + label. All motion has a `prefers-reduced-motion` fallback.

Follows `webkit-ui-craft`: components-only, tokens-only (color/type/shape/spacing), container doctrine (`max-w-[var(--container-7xl)]`); only the raw 3D geometry (perspective/rotate) lives in scoped CSS since it has no token.

## Notes

- **No dependency on the command-menu component** — the ⌘K palette (`kbd` + `command-menu`) ships separately as the parallel webkit track (PR #792 to `main`). This PR is the banner only.
- Verified: `webkit-sample` production build is clean; the page renders and the hover highlight works (screenshot-checked); axe WCAG2A/AA is clean for the banner. Two axe findings remain in the shared `SiteNav` header (`aria-required-children` on the nav list, `color-contrast` on the nav CTA) — both pre-existing on every `/site/*` page, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
