### PR TITLE
ci(release): bump @aziontech/webkit to 4.2.0 [skip ci]

### DIFF
--- a/packages/webkit/CHANGELOG.md
+++ b/packages/webkit/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.2.0](https://github.com/aziontech/webkit/compare/@aziontech/webkit@4.1.0...@aziontech/webkit@4.2.0) (2026-07-23)
+
+### Features
+
+- derive spec name from the Figma frame in /spec-create ([#791](https://github.com/aziontech/webkit/issues/791)) ([df59ab4](https://github.com/aziontech/webkit/commit/df59ab42c6ced1414ec0047abdfb9d5f067382ae))
+- **webkit:** overhaul EmptyState (icon tile, size-scaled type, dashed border) + Table empty state ([#786](https://github.com/aziontech/webkit/issues/786)) ([26ae5ee](https://github.com/aziontech/webkit/commit/26ae5ee6f6e878d85df5a3d9247e9936a00d405f))
+
 ## [4.1.0](https://github.com/aziontech/webkit/compare/@aziontech/webkit@4.0.0...@aziontech/webkit@4.1.0) (2026-07-23)
 
 ### Features

--- a/packages/webkit/catalog.json
+++ b/packages/webkit/catalog.json
@@ -1,6 +1,6 @@
 {
   "package": "@aziontech/webkit",
-  "webkitVersion": "4.1.0",
+  "webkitVersion": "4.2.0",
   "deniedPrefixes": [
     "@aziontech/webkit/src/"
   ],

--- a/packages/webkit/package.json
+++ b/packages/webkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/webkit",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Reusable UI components and design system utilities for building Azion web interfaces.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated follow-up to the @aziontech/webkit@4.2.0 release: aligns package.json, CHANGELOG.md and catalog.json with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Fwebkit%404.2.0 — Merging this PR does not trigger a new release (ci commits produce no version bump).