### PR TITLE
[NO-ISSUE] ci: removing opening pr bump version, replace to ci squash merge

### DIFF
--- a/.github/workflows/package-icons.yml
+++ b/.github/workflows/package-icons.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: release-icons
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Semantic Release
@@ -52,7 +56,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GIT_PKG }}
         run: |
           if git diff --quiet -- packages/icons/package.json; then
-            echo "No release published; skipping version bump PR."
+            echo "No release published; skipping packages/icons version bump PR."
             exit 0
           fi
           VERSION="$(node -p "require('./packages/icons/package.json').version")"
@@ -63,6 +67,12 @@ jobs:
           git add packages/icons/package.json packages/icons/CHANGELOG.md
           git commit -m "ci(release): bump @aziontech/icons to ${VERSION}"
           git push --force origin "$BRANCH"
-          gh pr create --base main --head "$BRANCH" \
+          PR_URL=$(gh pr create --base main --head "$BRANCH" \
             --title "ci(release): bump @aziontech/icons to ${VERSION} [skip ci]" \
-            --body "Automated follow-up to the @aziontech/icons@${VERSION} release: aligns package.json and CHANGELOG.md with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Ficons%40${VERSION} — Merging this PR does not trigger a new release (ci commits produce no version bump)."
+            --body "Automated follow-up to the @aziontech/icons@${VERSION} release: aligns package.json and CHANGELOG.md with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Ficons%40${VERSION} — Merging this PR does not trigger a new release (ci commits produce no version bump).")
+          gh pr merge --squash --auto \
+            --subject "ci(release): bump @aziontech/icons to ${VERSION} [skip ci] (#${PR_URL##*/})" \
+            "$PR_URL" \
+            || gh pr merge --squash \
+              --subject "ci(release): bump @aziontech/icons to ${VERSION} [skip ci] (#${PR_URL##*/})" \
+              "$PR_URL"

--- a/.github/workflows/package-theme.yml
+++ b/.github/workflows/package-theme.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: release-theme
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Semantic Release
@@ -52,7 +56,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GIT_PKG }}
         run: |
           if git diff --quiet -- packages/theme/package.json; then
-            echo "No release published; skipping version bump PR."
+            echo "No release published; skipping packages/theme version bump PR."
             exit 0
           fi
           VERSION="$(node -p "require('./packages/theme/package.json').version")"
@@ -63,6 +67,12 @@ jobs:
           git add packages/theme/package.json packages/theme/CHANGELOG.md
           git commit -m "ci(release): bump @aziontech/theme to ${VERSION}"
           git push --force origin "$BRANCH"
-          gh pr create --base main --head "$BRANCH" \
+          PR_URL=$(gh pr create --base main --head "$BRANCH" \
             --title "ci(release): bump @aziontech/theme to ${VERSION} [skip ci]" \
-            --body "Automated follow-up to the @aziontech/theme@${VERSION} release: aligns package.json and CHANGELOG.md with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Ftheme%40${VERSION} — Merging this PR does not trigger a new release (ci commits produce no version bump)."
+            --body "Automated follow-up to the @aziontech/theme@${VERSION} release: aligns package.json and CHANGELOG.md with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Ftheme%40${VERSION} — Merging this PR does not trigger a new release (ci commits produce no version bump).")
+          gh pr merge --squash --auto \
+            --subject "ci(release): bump @aziontech/theme to ${VERSION} [skip ci] (#${PR_URL##*/})" \
+            "$PR_URL" \
+            || gh pr merge --squash \
+              --subject "ci(release): bump @aziontech/theme to ${VERSION} [skip ci] (#${PR_URL##*/})" \
+              "$PR_URL"

--- a/.github/workflows/package-webkit.yml
+++ b/.github/workflows/package-webkit.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: release-webkit
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Semantic Release
@@ -52,7 +56,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GIT_PKG }}
         run: |
           if git diff --quiet -- packages/webkit/package.json; then
-            echo "No release published; skipping version bump PR."
+            echo "No release published; skipping packages/webkit version bump PR."
             exit 0
           fi
           VERSION="$(node -p "require('./packages/webkit/package.json').version")"
@@ -63,6 +67,12 @@ jobs:
           git add packages/webkit/package.json packages/webkit/CHANGELOG.md packages/webkit/catalog.json
           git commit -m "ci(release): bump @aziontech/webkit to ${VERSION}"
           git push --force origin "$BRANCH"
-          gh pr create --base main --head "$BRANCH" \
+          PR_URL=$(gh pr create --base main --head "$BRANCH" \
             --title "ci(release): bump @aziontech/webkit to ${VERSION} [skip ci]" \
-            --body "Automated follow-up to the @aziontech/webkit@${VERSION} release: aligns package.json, CHANGELOG.md and catalog.json with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Fwebkit%40${VERSION} — Merging this PR does not trigger a new release (ci commits produce no version bump)."
+            --body "Automated follow-up to the @aziontech/webkit@${VERSION} release: aligns package.json, CHANGELOG.md and catalog.json with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Fwebkit%40${VERSION} — Merging this PR does not trigger a new release (ci commits produce no version bump).")
+          gh pr merge --squash --auto \
+            --subject "ci(release): bump @aziontech/webkit to ${VERSION} [skip ci] (#${PR_URL##*/})" \
+            "$PR_URL" \
+            || gh pr merge --squash \
+              --subject "ci(release): bump @aziontech/webkit to ${VERSION} [skip ci] (#${PR_URL##*/})" \
+              "$PR_URL"


### PR DESCRIPTION
## Summary

Follow-up to #787. The release pipeline works, but each release left a version-bump PR waiting for a human to merge. This PR removes that manual step and hardens the pipeline against concurrent releases — the bump PR still exists (satisfying the "changes via pull request" ruleset), it just merges itself.

Two changes per publish workflow (webkit / theme / icons):

1. **Auto-merge the bump PR.** Right after `gh pr create`, the workflow arms GitHub auto-merge (`gh pr merge --squash --auto`): the PR waits for required checks and lands with no human action. A direct-merge fallback covers the case where the PR is already in clean status (nothing pending), in which the auto-merge API refuses to arm; if checks genuinely fail, both commands fail and the step goes red — nothing is silently swallowed. The repo setting `allow_auto_merge` was enabled to support this.

2. **Serialize release runs.** A `concurrency` group per package (`release-webkit` / `release-theme` / `release-icons`, `cancel-in-progress: false`) queues a second run instead of letting it race the first. Without it, two merges seconds apart could both read the same last tag: the run computing the lower version would publish after the higher one and be rejected by npm ("cannot implicitly apply the latest tag"). With the group, run 2 waits, reads the tag run 1 just pushed, and releases cleanly. `cancel-in-progress: false` matters — a release run must be queued, never killed.

## Notes

- **Why `--subject "... [skip ci] (#N)"` on the merge:** the repo squashes with `COMMIT_OR_PR_TITLE`, so a single-commit bump PR previously landed on `main` with the *commit* title — which has no `[skip ci]` — costing one no-op workflow run per bump merge (see the `ci(release)` commits from 4.1.0). Forcing the squash subject restores `[skip ci]` on `main`, so nothing runs at all. The `(#N)` is appended manually because a custom subject skips GitHub's automatic PR-number suffix.
- **Loop safety is unchanged and double-layered:** the bump commit type `ci(release)` maps to `release: false` in every `.releaserc` (backstop even if `[skip ci]` is edited away), and the no-diff guard skips the step when no release was published.
- **Rare residual case:** if release N+1 finishes before bump PR N has auto-merged (checks still running), bump PR N becomes conflicted on the version line — close it; the release itself is unaffected and its notes remain on the GitHub Releases page.
- The skip-log message now names the package (`skipping packages/<pkg> version bump PR`) for clearer run logs.
