### PR TITLE
ci(release): bump @aziontech/webkit to 4.2.1 [skip ci]

### DIFF
--- a/packages/webkit/CHANGELOG.md
+++ b/packages/webkit/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.2.1](https://github.com/aziontech/webkit/compare/@aziontech/webkit@4.2.0...@aziontech/webkit@4.2.1) (2026-07-23)
+
+### Bug Fixes
+
+- [Inputs] normalize z-index across all inputs (ENG-46735) ([#783](https://github.com/aziontech/webkit/issues/783)) ([25d201d](https://github.com/aziontech/webkit/commit/25d201d5ae0e6054b9189bc81c76b7d9fc8c5055))
+
 ## [4.2.0](https://github.com/aziontech/webkit/compare/@aziontech/webkit@4.1.0...@aziontech/webkit@4.2.0) (2026-07-23)
 
 ### Features

--- a/packages/webkit/catalog.json
+++ b/packages/webkit/catalog.json
@@ -1,6 +1,6 @@
 {
   "package": "@aziontech/webkit",
-  "webkitVersion": "4.2.0",
+  "webkitVersion": "4.2.1",
   "deniedPrefixes": [
     "@aziontech/webkit/src/"
   ],

--- a/packages/webkit/package.json
+++ b/packages/webkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/webkit",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Reusable UI components and design system utilities for building Azion web interfaces.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated follow-up to the @aziontech/webkit@4.2.1 release: aligns package.json, CHANGELOG.md and catalog.json with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Fwebkit%404.2.1 — Merging this PR does not trigger a new release (ci commits produce no version bump).