### PR TITLE
ci(release): bump @aziontech/theme to 4.2.0 [skip ci]

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [4.2.0](https://github.com/aziontech/webkit/compare/@aziontech/theme@4.1.0...@aziontech/theme@4.2.0) (2026-07-23)
+
+
+### Features
+
+* derive spec name from the Figma frame in /spec-create ([#791](https://github.com/aziontech/webkit/issues/791)) ([df59ab4](https://github.com/aziontech/webkit/commit/df59ab42c6ced1414ec0047abdfb9d5f067382ae))
+* **webkit:** overhaul EmptyState (icon tile, size-scaled type, dashed border) + Table empty state ([#786](https://github.com/aziontech/webkit/issues/786)) ([26ae5ee](https://github.com/aziontech/webkit/commit/26ae5ee6f6e878d85df5a3d9247e9936a00d405f))
+
+
+### Bug Fixes
+
+* [Inputs] normalize z-index across all inputs (ENG-46735) ([#783](https://github.com/aziontech/webkit/issues/783)) ([25d201d](https://github.com/aziontech/webkit/commit/25d201d5ae0e6054b9189bc81c76b7d9fc8c5055))
+
 ## [4.1.0](https://github.com/aziontech/webkit/compare/@aziontech/theme@4.0.0...@aziontech/theme@4.1.0) (2026-07-23)
 
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aziontech/theme",
   "type": "module",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "author": "aziontech",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Automated follow-up to the @aziontech/theme@4.2.0 release: aligns package.json and CHANGELOG.md with the published version. Release notes: https://github.com/aziontech/webkit/releases/tag/%40aziontech%2Ftheme%404.2.0 — Merging this PR does not trigger a new release (ci commits produce no version bump).