### PR TITLE
[NO-ISSUE] chore: bump brace-expansion override to >=5.0.8 (GHSA-mh99-v99m-4gvg)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   lodash-es: '>=4.18.0'
   '@xmldom/xmldom': '>=0.8.13'
   mathjs: '>=15.2.0'
-  brace-expansion: '>=5.0.6'
+  brace-expansion: '>=5.0.8'
   serialize-javascript: '>=7.0.5'
   follow-redirects: '>=1.16.0'
   uuid: '>=14.0.0'
@@ -2535,9 +2535,9 @@ packages:
     resolution: {integrity: sha512-JtIQYts08AFAYGF4eSh3pUt3NQkYV/e75pRtQmAVTLNWR/1L7Bsswxlgzgk8nmLEM+gFszsIlA9BgD3XnSqp3g==}
     engines: {node: '>=10'}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -9139,7 +9139,7 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -11803,7 +11803,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,7 +26,7 @@ overrides:
   lodash-es: ">=4.18.0"
   "@xmldom/xmldom": ">=0.8.13"
   mathjs: ">=15.2.0"
-  brace-expansion: ">=5.0.6"
+  brace-expansion: ">=5.0.8"
   serialize-javascript: ">=7.0.5"
   follow-redirects: ">=1.16.0"
   uuid: ">=14.0.0"


### PR DESCRIPTION
## Audit
```
robson.junior@FVFFPGCAQ6L4 webkit % pnpm audit
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ brace-expansion: DoS via unbounded expansion length    │
│                     │ causing an out-of-memory process crash                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ brace-expansion                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <=5.0.7                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=5.0.8                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@typescript-eslint/eslint-plugin>@typescript-eslint/ │
│                     │ parser>@typescript-eslint/typescript-                  │
│                     │ estree>minimatch>brace-expansion                       │
│                     │                                                        │
│                     │ .>@typescript-eslint/eslint-plugin>@typescript-eslint/ │
│                     │ parser>eslint>@eslint/config-array>minimatch>brace-    │
│                     │ expansion                                              │
│                     │                                                        │
│                     │ .>@typescript-eslint/eslint-plugin>@typescript-eslint/ │
│                     │ parser>eslint>@eslint/eslintrc>minimatch>brace-        │
│                     │ expansion                                              │
│                     │                                                        │
│                     │ ... Found 100 paths, run `pnpm why brace-expansion`    │
│                     │ for more information                                   │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-mh99-v99m-4gvg      │
└─────────────────────┴────────────────────────────────────────────────────────┘
1 vulnerabilities found
Severity: 1 high
```

## Summary

`pnpm audit` (the **Security Scans** gate in `governance.yml`) was failing with one advisory: [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) — **high** — `brace-expansion` DoS via unbounded expansion length causing an out-of-memory crash. Patched in `>=5.0.8`.

`brace-expansion` is not a direct dependency anywhere; it reaches the graph transitively through the root's `@typescript-eslint` toolchain (via `minimatch`) and was already unified to the 5.x line by the existing `pnpm-workspace.yaml` override (`>=5.0.6` → resolved `5.0.7`). This PR raises that override floor to `>=5.0.8`, re-resolving to `5.0.8` — a **patch** bump.

## Notes

- **No new dependency, no breaking change** — the lockfile diff is limited to `brace-expansion 5.0.7 → 5.0.8` plus the recorded override line.
- `brace-expansion@5.0.8` tightens its engine range to `node: 20 || >=22`; CI runs `lts/*`, so this is satisfied.
- Validation (CI parity): `pnpm install --frozen-lockfile` ✅ · `pnpm audit` from `packages/webkit` ✅ exit 0 (**No known vulnerabilities found**, any severity) · `pnpm audit --audit-level=high` ✅ exit 0.
- Issue: NO-ISSUE.