### PR TITLE
feat(webkit-sample): add a layout token system, equal-height Home columns and column-selector filters

### DIFF
--- a/apps/webkit-sample/src/components/AccountSettings.vue
+++ b/apps/webkit-sample/src/components/AccountSettings.vue
@@ -511,14 +511,12 @@ const onTeamAction = (event, value, row) => {
 
       <!-- Active tab body: only this region scrolls, between the bar and the
            (Account Settings) Save bar pinned below. -->
-      <div
-        class="flex min-h-0 w-full flex-1 flex-col gap-[var(--spacing-lg)] overflow-auto p-[var(--spacing-md)]"
-      >
+      <div class="min-h-0 flex-1 overflow-auto">
         <!-- Tab: Account Settings — the account identity form. One flag locks
              every control while the request is in flight. -->
         <form
           v-if="activeTab === 'account-settings'"
-          class="flex min-w-0 flex-col gap-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex min-w-0 flex-col gap-[var(--layout-section-gap)]"
           aria-label="Account settings"
           novalidate
           @submit.prevent="submit"
@@ -535,7 +533,7 @@ const onTeamAction = (event, value, row) => {
             <legend class="sr-only">Account settings</legend>
 
             <!-- Section: General -->
-            <section class="flex flex-col gap-[var(--spacing-sm)]">
+            <section class="flex flex-col gap-[var(--layout-group-gap)]">
               <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
                 General
               </p>
@@ -582,7 +580,7 @@ const onTeamAction = (event, value, row) => {
             </section>
 
             <!-- Section: Company Information -->
-            <section class="flex flex-col gap-[var(--spacing-sm)]">
+            <section class="flex flex-col gap-[var(--layout-group-gap)]">
               <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
                 Company Information
               </p>
@@ -650,7 +648,7 @@ const onTeamAction = (event, value, row) => {
             </section>
 
             <!-- Section: Address Information -->
-            <section class="flex flex-col gap-[var(--spacing-sm)]">
+            <section class="flex flex-col gap-[var(--layout-group-gap)]">
               <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
                 Address Information
               </p>
@@ -798,7 +796,7 @@ const onTeamAction = (event, value, row) => {
             </section>
 
             <!-- Section: Login Settings -->
-            <section class="flex flex-col gap-[var(--spacing-sm)]">
+            <section class="flex flex-col gap-[var(--layout-group-gap)]">
               <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
                 Login Settings
               </p>
@@ -860,7 +858,7 @@ const onTeamAction = (event, value, row) => {
             </section>
 
             <!-- Section: Source Control -->
-            <section class="flex flex-col gap-[var(--spacing-sm)]">
+            <section class="flex flex-col gap-[var(--layout-group-gap)]">
               <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
                 Source Control
               </p>
@@ -914,7 +912,7 @@ const onTeamAction = (event, value, row) => {
 
             <!-- Section: Appearance — live preferences (font + theme), outside the
                  save scope. They drive the app singletons and persist on change. -->
-            <section class="flex flex-col gap-[var(--spacing-sm)]">
+            <section class="flex flex-col gap-[var(--layout-group-gap)]">
               <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
                 Appearance
               </p>
@@ -982,7 +980,7 @@ const onTeamAction = (event, value, row) => {
             </section>
 
             <!-- Section: Danger Zone -->
-            <section class="flex flex-col gap-[var(--spacing-sm)]">
+            <section class="flex flex-col gap-[var(--layout-group-gap)]">
               <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--danger-contrast)]">
                 Danger Zone
               </p>
@@ -1012,7 +1010,7 @@ const onTeamAction = (event, value, row) => {
         <!-- Tab: Users Management — the teammates with access to this account. -->
         <section
           v-else-if="activeTab === 'users-management'"
-          class="flex min-w-0 flex-col gap-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex min-w-0 flex-col gap-[var(--layout-section-gap)]"
         >
           <PageHeading
             title="Users Management"
@@ -1092,7 +1090,7 @@ const onTeamAction = (event, value, row) => {
         <!-- Tab: Billing — current plan, payment method, and invoices. -->
         <section
           v-else-if="activeTab === 'billing'"
-          class="flex min-w-0 flex-col gap-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex min-w-0 flex-col gap-[var(--layout-section-gap)]"
         >
           <PageHeading
             title="Billing"
@@ -1100,7 +1098,7 @@ const onTeamAction = (event, value, row) => {
           />
 
           <!-- Current plan -->
-          <div class="flex flex-col gap-[var(--spacing-sm)]">
+          <div class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Current Plan
             </p>
@@ -1142,7 +1140,7 @@ const onTeamAction = (event, value, row) => {
           </div>
 
           <!-- Payment method -->
-          <div class="flex flex-col gap-[var(--spacing-sm)]">
+          <div class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Payment Method
             </p>
@@ -1177,7 +1175,7 @@ const onTeamAction = (event, value, row) => {
           </div>
 
           <!-- Invoices -->
-          <div class="flex flex-col gap-[var(--spacing-sm)]">
+          <div class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Invoices
             </p>
@@ -1213,7 +1211,7 @@ const onTeamAction = (event, value, row) => {
         <!-- Tab: Credentials — the account's API tokens. -->
         <section
           v-else-if="activeTab === 'credentials'"
-          class="flex min-w-0 flex-col gap-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex min-w-0 flex-col gap-[var(--layout-section-gap)]"
         >
           <PageHeading
             title="Credentials"
@@ -1288,7 +1286,7 @@ const onTeamAction = (event, value, row) => {
         <!-- Tab: Activity History — the recent account audit log. -->
         <section
           v-else-if="activeTab === 'activity-history'"
-          class="flex min-w-0 flex-col gap-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex min-w-0 flex-col gap-[var(--layout-section-gap)]"
         >
           <PageHeading
             title="Activity History"
@@ -1322,7 +1320,7 @@ const onTeamAction = (event, value, row) => {
         <!-- Tab: Teams Permissions — the account's teams and their access. -->
         <section
           v-else-if="activeTab === 'teams-permissions'"
-          class="flex min-w-0 flex-col gap-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex min-w-0 flex-col gap-[var(--layout-section-gap)]"
         >
           <PageHeading
             title="Teams Permissions"
@@ -1457,7 +1455,7 @@ const onTeamAction = (event, value, row) => {
         class="shrink-0 border-t-[length:var(--border-width-default)] border-[var(--border-muted)] bg-[var(--bg-surface)]"
       >
         <div
-          class="flex w-full items-center justify-end gap-[var(--spacing-sm)] p-[var(--spacing-lg)]"
+          class="layout-column flex items-center justify-end gap-[var(--spacing-sm)] px-[var(--layout-boundary-inline)] py-[var(--spacing-md)]"
         >
           <Button
             type="button"

--- a/apps/webkit-sample/src/components/ApplicationDetail.vue
+++ b/apps/webkit-sample/src/components/ApplicationDetail.vue
@@ -620,11 +620,11 @@ const submitFunction = async () => {
            Save so the two topic groups commit independently; every other tab
            renders the card + small-PageHeading + borderless Table pattern. Only
            this region scrolls. -->
-      <section class="min-h-0 flex-1 overflow-auto p-[var(--spacing-md)]">
+      <section class="min-h-0 flex-1 overflow-auto">
         <!-- Main Settings — two ItemGroups, each with its own independent Save. -->
         <div
           v-if="activeTab === 'main-settings'"
-          class="flex min-w-0 flex-col gap-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex min-w-0 flex-col gap-[var(--layout-section-gap)]"
         >
           <PageHeading
             title="Main Settings"
@@ -634,7 +634,7 @@ const submitFunction = async () => {
 
           <!-- Group 1 — General (section title, its own footer save). -->
           <form
-            class="flex flex-col gap-[var(--spacing-sm)]"
+            class="flex flex-col gap-[var(--layout-group-gap)]"
             aria-label="General settings"
             novalidate
             @submit.prevent="saveGeneral"
@@ -708,7 +708,7 @@ const submitFunction = async () => {
                force-enabled account-wide, so its Switch stays on and disabled and
                its row carries a lock badge. One footer Save commits the group. -->
           <form
-            class="flex flex-col gap-[var(--spacing-sm)]"
+            class="flex flex-col gap-[var(--layout-group-gap)]"
             aria-label="Module settings"
             novalidate
             @submit.prevent="saveModules"
@@ -806,7 +806,7 @@ const submitFunction = async () => {
              analog: it simulates a build+deploy and bumps the prefix live. -->
         <div
           v-else-if="activeTab === 'build'"
-          class="flex min-w-0 flex-col gap-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex min-w-0 flex-col gap-[var(--layout-section-gap)]"
         >
           <PageHeading
             title="Build"
@@ -827,7 +827,7 @@ const submitFunction = async () => {
 
           <!-- Git repository — the connection (actions/checkout in the workflow).
                A connection, not editable config, so this ItemGroup has no Save. -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Git repository
             </p>
@@ -879,7 +879,7 @@ const submitFunction = async () => {
                whole group locks off `savingBuildConfig` and stays disabled until a
                field diverges from its saved baseline. -->
           <form
-            class="flex flex-col gap-[var(--spacing-sm)]"
+            class="flex flex-col gap-[var(--layout-group-gap)]"
             aria-label="Build configuration"
             novalidate
             @submit.prevent="saveBuildConfig"
@@ -1008,7 +1008,7 @@ const submitFunction = async () => {
           <!-- Group 2 — Branch control. Its own ItemGroup, its own independent Save
                (locks off `savingBranch`, disabled until `branchDirty`). -->
           <form
-            class="flex flex-col gap-[var(--spacing-sm)]"
+            class="flex flex-col gap-[var(--layout-group-gap)]"
             aria-label="Branch control"
             novalidate
             @submit.prevent="saveBranch"
@@ -1078,7 +1078,7 @@ const submitFunction = async () => {
           <!-- Variables and secrets — the AZION_* set + app config injected into
                the build. Data-driven Table with a compact header and its action on
                the right (the AccountSettings list pattern), not an italic empty row. -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Variables and secrets
             </p>
@@ -1144,7 +1144,7 @@ const submitFunction = async () => {
 
           <!-- Deployment — the API token + build cache affordances (single values /
                toggles, so an ItemGroup rather than a table). -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Deployment
             </p>
@@ -1210,7 +1210,7 @@ const submitFunction = async () => {
                section carries no group Save. -->
           <section
             v-if="buildCacheEnabled"
-            class="flex flex-col gap-[var(--spacing-sm)]"
+            class="flex flex-col gap-[var(--layout-group-gap)]"
           >
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Build cache settings
@@ -1351,7 +1351,7 @@ const submitFunction = async () => {
 
         <!-- Every other tab: a small PageHeading OUT of the card (matching Main
              Settings), then the flush CardBox wrapping the borderless Table. -->
-        <div v-else class="flex min-w-0 flex-col gap-[var(--spacing-lg)]">
+        <div v-else class="layout-column layout-boundary flex min-w-0 flex-col gap-[var(--layout-section-gap)]">
           <PageHeading
             :title="activeLabel"
             :description="activeResource.description"

--- a/apps/webkit-sample/src/components/Applications.vue
+++ b/apps/webkit-sample/src/components/Applications.vue
@@ -3,22 +3,34 @@
 // (single sidebar + GlobalHeader with the module breadcrumb) comes from
 // AppLayout; this page renders only its content: a PageHeading (title +
 // description + primary actions) over a data-driven <Table> whose row actions
-// open a Dropdown menu and whose toolbar composes the table's own context-aware
-// filter / search / refresh / export / column controls. As a first-level module
-// list it carries no navigation tabs — the table's own filter builder handles
-// narrowing by infrastructure.
+// open a Dropdown menu. As a first-level module list it carries no navigation
+// tabs.
+//
+// Narrowing is a SELECTOR PER COLUMN, not a generic field/operator/value builder:
+// Authors (multiple Select), Last Modified (Calendar — a shortcut rail beside a
+// month grid for a custom range), Status (multiple Select). Each is always visible in
+// the toolbar, which is what a console list wants; the table's own filter state
+// could not host them (its `#filters` band only renders once a filter exists,
+// and `author` is not a column at all — it renders inside the Last Modified
+// cell). So the three refs pre-filter `:data` and the table sees only the rows
+// that survive. Table.Search still narrows further, through the table's own
+// global filter.
 import Button from "@aziontech/webkit/button";
+import Calendar from "@aziontech/webkit/calendar";
 import CardBox from "@aziontech/webkit/card-box";
 import CopyButton from "@aziontech/webkit/copy-button";
 import Dropdown from "@aziontech/webkit/dropdown";
 import IconButton from "@aziontech/webkit/icon-button";
+import Select from "@aziontech/webkit/select";
 import Table from "@aziontech/webkit/table";
 import Tag from "@aziontech/webkit/tag";
 import { toast } from "@aziontech/webkit/toast";
 import Tooltip from "@aziontech/webkit/tooltip";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
+import { daysAgo, formatListDate, monthsAgo, withinRange } from "../lib/dates";
+import { filterDisplay } from "../lib/filters";
 import { authorAt } from "../lib/people";
 import AppLayout from "./ui/AppLayout.vue";
 import LastModifiedCell from "./ui/LastModifiedCell.vue";
@@ -52,6 +64,11 @@ const presetIcon = (preset) => presetMeta[preset]?.icon ?? "";
 // first row mirrors the real reference repo gab-az/webkit-sample-vue (id, preset,
 // domain from its azion/azion.json). The Last Modified avatar comes from the
 // shared team roster (src/lib/people.js), assigned round-robin per row.
+//
+// `modifiedAt` is the real instant — the Last Modified filter compares it, the
+// cell renders it relative, and `lastModified` (the sortable / exportable
+// display string) is derived from it by one formatter instead of being
+// hand-written per row.
 const applications = ref([
   {
     id: "1784552864",
@@ -62,7 +79,7 @@ const applications = ref([
     domainName: "e7b4verynr.map.azionedge.net",
     infrastructure: "Production",
     status: "Active",
-    lastModified: "July 20, 2026, 01:03:00 PM",
+    modifiedAt: daysAgo(2),
   },
   {
     id: "9823746510",
@@ -73,7 +90,7 @@ const applications = ref([
     domainName: "d9m8j2k4l5.map.azion.com",
     infrastructure: "Staging",
     status: "Active",
-    lastModified: "July 15, 2025, 11:30:00 AM",
+    modifiedAt: daysAgo(375),
   },
   {
     id: "7658392017",
@@ -84,7 +101,7 @@ const applications = ref([
     domainName: "q7w8e9r0t1.map.azion.com",
     infrastructure: "Production",
     status: "Active",
-    lastModified: "August 12, 2025, 09:15:00 AM",
+    modifiedAt: daysAgo(320),
   },
   {
     id: "4532109876",
@@ -95,7 +112,7 @@ const applications = ref([
     domainName: "y6u7i8o9p0.map.azion.com",
     infrastructure: "Development",
     status: "Inactive",
-    lastModified: "September 03, 2025, 04:45:00 PM",
+    modifiedAt: daysAgo(250),
   },
   {
     id: "1122334455",
@@ -106,7 +123,7 @@ const applications = ref([
     domainName: "a1s2d3f4g5.map.azion.com",
     infrastructure: "Production",
     status: "Active",
-    lastModified: "October 20, 2025, 02:10:00 PM",
+    modifiedAt: daysAgo(190),
   },
   {
     id: "9988776655",
@@ -117,7 +134,7 @@ const applications = ref([
     domainName: "z9x8c7v6b5.map.azion.com",
     infrastructure: "Production",
     status: "Active",
-    lastModified: "November 14, 2025, 08:00:00 AM",
+    modifiedAt: daysAgo(141),
   },
   {
     id: "3344556677",
@@ -128,7 +145,7 @@ const applications = ref([
     domainName: "n0m9b8v7c6.map.azion.com",
     infrastructure: "Development",
     status: "Active",
-    lastModified: "December 01, 2025, 03:30:00 PM",
+    modifiedAt: daysAgo(88),
   },
   {
     id: "5566778899",
@@ -139,7 +156,7 @@ const applications = ref([
     domainName: "k1l2m3n4o5.map.azion.com",
     infrastructure: "Staging",
     status: "Inactive",
-    lastModified: "January 18, 2026, 12:20:00 PM",
+    modifiedAt: daysAgo(63),
   },
   {
     id: "6677889900",
@@ -150,7 +167,7 @@ const applications = ref([
     domainName: "p9o8i7u6y5.map.azion.com",
     infrastructure: "Production",
     status: "Active",
-    lastModified: "February 22, 2026, 10:05:00 AM",
+    modifiedAt: daysAgo(47),
   },
   {
     id: "7788990011",
@@ -161,7 +178,7 @@ const applications = ref([
     domainName: "m4n5b6v7c8.map.azion.com",
     infrastructure: "Staging",
     status: "Active",
-    lastModified: "March 09, 2026, 06:40:00 PM",
+    modifiedAt: daysAgo(21),
   },
   {
     id: "8899001122",
@@ -172,7 +189,7 @@ const applications = ref([
     domainName: "t1r2e3w4q5.map.azion.com",
     infrastructure: "Production",
     status: "Active",
-    lastModified: "April 17, 2026, 09:55:00 AM",
+    modifiedAt: daysAgo(12),
   },
   {
     id: "9900112233",
@@ -183,11 +200,16 @@ const applications = ref([
     domainName: "g6h7j8k9l0.map.azion.com",
     infrastructure: "Development",
     status: "Inactive",
-    lastModified: "May 02, 2026, 01:15:00 PM",
+    modifiedAt: daysAgo(5),
   },
 ].map((app, index) => {
   const person = authorAt(index);
-  return { ...app, author: person.name, authorAvatar: person.avatar };
+  return {
+    ...app,
+    author: person.name,
+    authorAvatar: person.avatar,
+    lastModified: formatListDate(app.modifiedAt),
+  };
 }));
 
 // Column model. `name` is the principal (emphasized) column; the trailing
@@ -204,40 +226,46 @@ const columns = [
   { id: "actions", kind: "action", hideable: false },
 ];
 
-// Fields the built-in Table.Filter builder offers.
-const filterFields = [
-  { id: "name", label: "Name", type: "text" },
-  { id: "repository", label: "Repository", type: "text" },
-  {
-    id: "preset",
-    label: "Framework",
-    type: "select",
-    options: Object.entries(presetMeta).map(([value, meta]) => ({
-      label: meta.label,
-      value,
-    })),
-  },
-  { id: "domainName", label: "Domain Name", type: "text" },
-  {
-    id: "infrastructure",
-    label: "Infrastructure",
-    type: "select",
-    options: [
-      { label: "Production", value: "Production" },
-      { label: "Staging", value: "Staging" },
-      { label: "Development", value: "Development" },
-    ],
-  },
-  {
-    id: "status",
-    label: "Status",
-    type: "select",
-    options: [
-      { label: "Active", value: "Active" },
-      { label: "Inactive", value: "Inactive" },
-    ],
-  },
+// ── Column selectors ──────────────────────────────────────────────────────
+// Authors options come from the data itself, so the selector can never offer a
+// person who has nothing in the list.
+const authorOptions = [...new Set(applications.value.map((app) => app.author))]
+  .sort((a, b) => a.localeCompare(b))
+  .map((author) => ({ value: author, label: author }));
+
+const statusOptions = [
+  { value: "Active", label: "Active" },
+  { value: "Inactive", label: "Inactive" },
 ];
+
+// The Calendar's shortcut rail. Picking one applies a range in a single click;
+// the month grid beside it fine-tunes the same range value.
+const periodPresets = [
+  { label: "Last 7 Days", value: { start: daysAgo(7), end: new Date() } },
+  { label: "Last 30 Days", value: { start: daysAgo(30), end: new Date() } },
+  { label: "Last 3 Months", value: { start: monthsAgo(3), end: new Date() } },
+  { label: "Last 12 Months", value: { start: monthsAgo(12), end: new Date() } },
+];
+
+const authorFilter = ref([]);
+const statusFilter = ref([]);
+const modifiedRange = ref(null);
+
+const filteredApplications = computed(() =>
+  applications.value.filter((app) => {
+    if (authorFilter.value.length && !authorFilter.value.includes(app.author)) return false;
+    if (statusFilter.value.length && !statusFilter.value.includes(app.status)) return false;
+    return withinRange(app.modifiedAt, modifiedRange.value);
+  }),
+);
+
+// Filtering `:data` from outside the table does not trip TanStack's
+// `autoResetPageIndex`, so narrowing to fewer rows than the current page's
+// offset would render an empty table. Own the pagination state and rewind it.
+const pagination = ref({ pageIndex: 0, pageSize: 8 });
+watch([authorFilter, statusFilter, modifiedRange], () => {
+  pagination.value = { ...pagination.value, pageIndex: 0 };
+});
 
 // Entering the module and choosing "create" opens the dedicated create PAGE
 // (a form route), not a modal — see CreateApplication.vue.
@@ -273,7 +301,7 @@ const onRowAction = (event, value, row) => {
 
 <template>
   <AppLayout active="applications" :breadcrumb="[{ label: 'Applications' }]">
-    <main class="flex h-full flex-col gap-[var(--spacing-lg)]">
+    <main class="flex h-full flex-col gap-[var(--layout-section-gap)]">
       <!-- First-level module list. The module name lives in the header breadcrumb
            crumb (AppLayout); the PageHeading sits OUT of the card (consistent with
            every list view) and carries the primary actions. The borderless Table
@@ -305,9 +333,9 @@ const onRowAction = (event, value, row) => {
         <CardBox :padded="false">
           <template #content>
         <Table
-          :data="applications"
+          v-model:pagination="pagination"
+          :data="filteredApplications"
           :columns="columns"
-          :filter-fields="filterFields"
           row-key="id"
           enable-sorting
           paginated
@@ -316,17 +344,86 @@ const onRowAction = (event, value, row) => {
           @row-click="openApp"
         >
           <template #toolbar>
-            <div class="flex w-full items-center gap-[var(--spacing-xs)]">
-              <Table.Filter :fields="filterFields" />
-              <Table.Search size="large" placeholder="Search..." class="flex-1" />
+            <!-- One selector per column, always visible: Authors, Last Modified,
+                 Status. Search takes the remaining width. -->
+            <div class="flex w-full flex-wrap items-center gap-[var(--spacing-xs)]">
+              <!-- Width lives on the wrapper: the Select root declares w-full in its own
+                   static class, which wins over a consumer w-[…] on a specificity tie. -->
+              <div class="w-[var(--container-2xs)] shrink-0">
+                <Select
+                  v-model="authorFilter"
+                  multiple
+                  size="medium"
+                  placeholder="All Authors"
+                  :display-value="filterDisplay('All Authors', authorOptions)"
+                >
+                  <Select.Trigger aria-label="Filter by author" />
+                  <Select.Content>
+                    <Select.Option
+                      v-for="option in authorOptions"
+                      :key="option.value"
+                      :value="option.value"
+                    >
+                      {{ option.label }}
+                    </Select.Option>
+                  </Select.Content>
+                </Select>
+              </div>
+
+              <!-- The shortcut rail (Last 7 Days …) plus the month grid for a custom
+                   range both come from :presets — with presets the component splits the
+                   trigger into a preset dropdown + the range itself. NOT `period`: that
+                   flag REPLACES the pair (`isTwoPart = hasPresets && !period`) with the
+                   relative-span parser, and takes the placeholder with it. -->
+              <Calendar
+                v-model="modifiedRange"
+                mode="range"
+                size="medium"
+                :presets="periodPresets"
+                placeholder="Last Modified"
+                class="shrink-0"
+              >
+                <!-- Resetting the filter is Calendar.Clear in the panel footer, not the
+                     `clearable` prop: that renders an X on the trigger only in the
+                     SINGLE-part branch, so alongside :presets it would be inert. Clear
+                     empties the draft; Apply Range commits the empty range, which reads
+                     as "no Last Modified filter". -->
+                <template #footer>
+                  <Calendar.Clear>Clear</Calendar.Clear>
+                </template>
+              </Calendar>
+
+              <!-- Width lives on the wrapper: the Select root declares w-full in its own
+                   static class, which wins over a consumer w-[…] on a specificity tie. -->
+              <div class="w-[var(--container-3xs)] shrink-0">
+                <Select
+                  v-model="statusFilter"
+                  multiple
+                  size="medium"
+                  placeholder="All Statuses"
+                  :display-value="filterDisplay('All Statuses', statusOptions)"
+                >
+                  <Select.Trigger aria-label="Filter by status" />
+                  <Select.Content>
+                    <Select.Option
+                      v-for="option in statusOptions"
+                      :key="option.value"
+                      :value="option.value"
+                    >
+                      {{ option.label }}
+                    </Select.Option>
+                  </Select.Content>
+                </Select>
+              </div>
+
+              <Table.Search
+                placeholder="Search..."
+                class="min-w-[var(--container-3xs)] flex-1"
+              />
               <Table.RefreshButton />
               <Table.Export />
               <Table.ColumnSelector />
             </div>
-          </template>
-
-          <template #filters>
-            <Table.AppliedFilters />
           </template>
 
           <template #cell-name="{ value, row }">
@@ -389,8 +486,12 @@ const onRowAction = (event, value, row) => {
             />
           </template>
 
-          <template #cell-lastModified="{ value, row }">
-            <LastModifiedCell :author="row.author" :avatar-src="row.authorAvatar" :date="value" />
+          <template #cell-lastModified="{ row }">
+            <LastModifiedCell
+              :author="row.author"
+              :avatar-src="row.authorAvatar"
+              :date="row.modifiedAt"
+            />
           </template>
 
           <template #cell-actions="{ row }">

--- a/apps/webkit-sample/src/components/CardBoxSaves.vue
+++ b/apps/webkit-sample/src/components/CardBoxSaves.vue
@@ -71,7 +71,7 @@ const saveProtection = () =>
     active="forms"
     :breadcrumb="[{ label: 'Forms', href: '/forms' }, { label: 'CardBox with independent saves' }]"
   >
-    <main class="flex w-full flex-col gap-[var(--spacing-lg)]">
+    <main class="flex w-full flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         title="Project Settings"
         description="A long configuration page split into cards — each card owns its own save, so changes commit in parts."

--- a/apps/webkit-sample/src/components/CreateApplication.vue
+++ b/apps/webkit-sample/src/components/CreateApplication.vue
@@ -189,7 +189,7 @@ const submit = async () => {
       >
       <!-- Scrollable form body -->
       <div
-        class="mx-auto flex w-full max-w-[var(--container-7xl)] flex-1 flex-col gap-[var(--spacing-lg)] p-[var(--spacing-lg)]"
+        class="layout-column layout-boundary flex flex-1 flex-col gap-[var(--layout-section-gap)]"
       >
         <!-- One flag locks every control while the request is in flight. -->
         <fieldset
@@ -199,7 +199,7 @@ const submit = async () => {
           <legend class="sr-only">Create application</legend>
 
           <!-- Section: General -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               General
             </p>
@@ -241,7 +241,7 @@ const submit = async () => {
           </section>
 
           <!-- Section: Delivery Settings -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Delivery Settings
             </p>
@@ -342,7 +342,7 @@ const submit = async () => {
           </section>
 
           <!-- Section: Origins -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Origins
             </p>
@@ -450,7 +450,7 @@ const submit = async () => {
           </section>
 
           <!-- Section: Cache Expiration Policies -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Cache Expiration Policies
             </p>
@@ -536,7 +536,7 @@ const submit = async () => {
           </section>
 
           <!-- Section: Debug Rules -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Debug Rules
             </p>
@@ -572,7 +572,7 @@ const submit = async () => {
         class="sticky bottom-0 border-t-[length:var(--border-width-default)] border-[var(--border-muted)] bg-[var(--bg-surface)]"
       >
         <div
-          class="flex w-full items-center justify-end gap-[var(--spacing-sm)] p-[var(--spacing-lg)]"
+          class="layout-column flex items-center justify-end gap-[var(--spacing-sm)] px-[var(--layout-boundary-inline)] py-[var(--spacing-md)]"
         >
           <Button
             type="button"

--- a/apps/webkit-sample/src/components/CreateSqlDatabase.vue
+++ b/apps/webkit-sample/src/components/CreateSqlDatabase.vue
@@ -95,7 +95,7 @@ const submit = async () => {
       >
         <!-- Scrollable form body -->
         <div
-          class="mx-auto flex w-full max-w-[var(--container-7xl)] flex-1 flex-col gap-[var(--spacing-lg)] p-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex flex-1 flex-col gap-[var(--layout-section-gap)]"
         >
           <p class="text-body-sm text-[var(--text-muted)]">
             Configure a SQL Database instance that can be accessed by
@@ -167,7 +167,7 @@ const submit = async () => {
           class="sticky bottom-0 border-t-[length:var(--border-width-default)] border-[var(--border-muted)] bg-[var(--bg-surface)]"
         >
           <div
-            class="flex w-full items-center justify-end gap-[var(--spacing-sm)] p-[var(--spacing-lg)]"
+            class="layout-column flex items-center justify-end gap-[var(--spacing-sm)] px-[var(--layout-boundary-inline)] py-[var(--spacing-md)]"
           >
             <Button
               type="button"

--- a/apps/webkit-sample/src/components/CreateTeam.vue
+++ b/apps/webkit-sample/src/components/CreateTeam.vue
@@ -220,7 +220,7 @@ const breadcrumb = [
         @submit.prevent="submit"
       >
       <div
-        class="mx-auto flex w-full max-w-[var(--container-7xl)] flex-1 flex-col gap-[var(--spacing-lg)] p-[var(--spacing-lg)]"
+        class="layout-column layout-boundary flex flex-1 flex-col gap-[var(--layout-section-gap)]"
       >
         <div class="flex flex-col gap-[var(--spacing-xxs)]">
           <h1 class="text-heading-xs text-[var(--text-default)]">
@@ -428,7 +428,7 @@ const breadcrumb = [
         class="sticky bottom-0 border-t-[length:var(--border-width-default)] border-[var(--border-muted)] bg-[var(--bg-surface)]"
       >
         <div
-          class="mx-auto flex w-full max-w-[var(--container-7xl)] items-center gap-[var(--spacing-sm)] p-[var(--spacing-lg)]"
+          class="layout-column flex items-center gap-[var(--spacing-sm)] px-[var(--layout-boundary-inline)] py-[var(--spacing-md)]"
         >
           <Button
             v-if="editing"

--- a/apps/webkit-sample/src/components/CreateWorkload.vue
+++ b/apps/webkit-sample/src/components/CreateWorkload.vue
@@ -173,7 +173,7 @@ const saveAndDeploy = () => persist({ deploy: true });
         @submit.prevent="saveAndDeploy"
       >
         <div
-          class="mx-auto flex w-full max-w-[var(--container-7xl)] flex-1 flex-col gap-[var(--spacing-lg)] p-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex flex-1 flex-col gap-[var(--layout-section-gap)]"
         >
           <fieldset
             class="m-0 flex min-w-0 flex-col gap-[var(--spacing-lg)] border-0 p-0"
@@ -182,7 +182,7 @@ const saveAndDeploy = () => persist({ deploy: true });
             <legend class="sr-only">Create workload</legend>
 
             <!-- Section: General -->
-            <section class="flex flex-col gap-[var(--spacing-sm)]">
+            <section class="flex flex-col gap-[var(--layout-group-gap)]">
               <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
                 General
               </p>
@@ -229,7 +229,7 @@ const saveAndDeploy = () => persist({ deploy: true });
             <!-- Section: Domains — the Teams Permissions pattern: a flush CardBox
                  whose borderless Table carries a search + primary "add" toolbar and
                  a row-action Dropdown; empty state prompts the first domain. -->
-            <section class="flex flex-col gap-[var(--spacing-sm)]">
+            <section class="flex flex-col gap-[var(--layout-group-gap)]">
               <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
                 Domains
               </p>
@@ -325,7 +325,7 @@ const saveAndDeploy = () => persist({ deploy: true });
             </section>
 
             <!-- Section: Environments -->
-            <section class="flex flex-col gap-[var(--spacing-sm)]">
+            <section class="flex flex-col gap-[var(--layout-group-gap)]">
               <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
                 Environments
               </p>
@@ -448,7 +448,7 @@ const saveAndDeploy = () => persist({ deploy: true });
           class="sticky bottom-0 border-t-[length:var(--border-width-default)] border-[var(--border-muted)] bg-[var(--bg-surface)]"
         >
           <div
-            class="flex w-full items-center justify-end gap-[var(--spacing-sm)] p-[var(--spacing-lg)]"
+            class="layout-column flex items-center justify-end gap-[var(--spacing-sm)] px-[var(--layout-boundary-inline)] py-[var(--spacing-md)]"
           >
             <Button
               type="button"

--- a/apps/webkit-sample/src/components/CreateZone.vue
+++ b/apps/webkit-sample/src/components/CreateZone.vue
@@ -105,7 +105,7 @@ const submit = async () => {
       >
         <!-- Scrollable form body -->
         <div
-          class="mx-auto flex w-full max-w-[var(--container-7xl)] flex-1 flex-col gap-[var(--spacing-lg)] p-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex flex-1 flex-col gap-[var(--layout-section-gap)]"
         >
           <p class="text-body-sm text-[var(--text-muted)]">
             Configure DNS records and zone settings used for authoritative domain
@@ -250,7 +250,7 @@ const submit = async () => {
           class="sticky bottom-0 border-t-[length:var(--border-width-default)] border-[var(--border-muted)] bg-[var(--bg-surface)]"
         >
           <div
-            class="flex w-full items-center justify-end gap-[var(--spacing-sm)] p-[var(--spacing-lg)]"
+            class="layout-column flex items-center justify-end gap-[var(--spacing-sm)] px-[var(--layout-boundary-inline)] py-[var(--spacing-md)]"
           >
             <Button
               type="button"

--- a/apps/webkit-sample/src/components/CreationCenter.vue
+++ b/apps/webkit-sample/src/components/CreationCenter.vue
@@ -295,7 +295,7 @@ const createResource = (res) =>
     <!-- Flow content -->
     <main class="min-w-0 flex-1 overflow-auto">
       <div
-        class="mx-auto flex w-full flex-col gap-[var(--spacing-lg)] p-[var(--spacing-lg)]"
+        class="layout-column layout-boundary flex flex-col gap-[var(--layout-section-gap)]"
       >
         <PageHeading
           size="large"
@@ -322,7 +322,7 @@ const createResource = (res) =>
                 <CardBox v-if="!gitConnected">
                   <template #content>
                     <EmptyState
-                      size="large"
+                      size="medium"
                       title="Connect your Repository"
                       description="Choose a Git provider to connect your repository and start the deployment process."
                       class=" flex-1 rounded-[var(--shape-card)] border border-dashed border-[var(--border-default)] bg-[var(--bg-surface-raised)]"

--- a/apps/webkit-sample/src/components/Dashboard.vue
+++ b/apps/webkit-sample/src/components/Dashboard.vue
@@ -163,251 +163,249 @@ const openZoneActions = (event, row) =>
 
 <template>
   <AppLayout active="home" :breadcrumb="[{ label: 'Home' }]">
-    <main class="min-w-0 flex-1">
-      <div class="flex flex-col gap-[var(--spacing-lg)] xl:flex-row xl:items-start">
-        <!-- Primary column -->
-        <div class="flex min-w-0 flex-1 flex-col gap-[var(--spacing-lg)]">
-          <!-- Metrics -->
-          <section class="flex flex-col gap-[var(--spacing-md)]">
-            <div class="flex items-center gap-[var(--spacing-xs)]">
-              <h2 class="text-heading-xs text-[var(--text-default)]">Metrics</h2>
-              <IconButton
-                icon="pi pi-question-circle"
-                kind="transparent"
-                size="small"
-                aria-label="About metrics"
-              />
-            </div>
+    <main class="layout-column flex flex-col gap-[var(--layout-section-gap)] xl:flex-row xl:items-start">
+      <!-- Primary column -->
+      <div class="flex min-w-0 flex-1 flex-col gap-[var(--layout-section-gap)]">
+        <!-- Metrics -->
+        <section class="flex flex-col gap-[var(--layout-group-gap)]">
+          <div class="flex items-center gap-[var(--spacing-xs)]">
+            <h2 class="text-heading-xs text-[var(--text-default)]">Metrics</h2>
+            <IconButton
+              icon="pi pi-question-circle"
+              kind="transparent"
+              size="small"
+              aria-label="About metrics"
+            />
+          </div>
 
-            <div
-              class="grid grid-cols-1 gap-[var(--spacing-md)] sm:grid-cols-2 xl:grid-cols-4"
-            >
-              <CardBox v-for="metric in metrics" :key="metric.label">
-                <template #content>
-                  <div class="flex flex-col gap-[var(--spacing-md)]">
-                    <div class="flex items-center gap-[var(--spacing-xs)]">
-                      <span class="min-w-0 truncate text-label-sm text-[var(--text-default)]">
-                        {{ metric.label }}
-                      </span>
-                      <Tooltip :text="metric.hint">
-                        <i
-                          class="pi pi-info-circle text-body-sm text-[var(--text-muted)]"
-                          aria-hidden="true"
-                        />
-                      </Tooltip>
-                    </div>
-                    <div class="flex items-baseline gap-[var(--spacing-xxs)]">
-                      <span
-                        class="text-big-number-sm tabular-nums text-[var(--text-default)]"
-                      >
-                        {{ metric.value }}
-                      </span>
-                      <span
-                        v-if="metric.unit"
-                        class="text-body-xs text-[var(--text-muted)]"
-                      >
-                        {{ metric.unit }}
-                      </span>
-                    </div>
-                  </div>
-                </template>
-              </CardBox>
-            </div>
-
-            <p class="text-pretty text-right text-body-xxs text-[var(--text-muted)]">
-              {{ metricsRange }}
-            </p>
-          </section>
-
-          <!-- Resources -->
-          <section class="flex flex-col gap-[var(--spacing-md)]">
-            <div class="flex items-center gap-[var(--spacing-xs)]">
-              <h2 class="text-heading-xs text-[var(--text-default)]">Resources</h2>
-              <IconButton
-                icon="pi pi-question-circle"
-                kind="transparent"
-                size="small"
-                aria-label="About resources"
-              />
-            </div>
-
-            <CardBox :padded="false">
+          <div
+            class="grid grid-cols-1 gap-[var(--spacing-md)] sm:grid-cols-2 xl:grid-cols-4"
+          >
+            <CardBox v-for="metric in metrics" :key="metric.label">
               <template #content>
-                <Table :data="resources" :columns="resourceColumns" row-key="id">
-                  <template #cell-domain="{ value }">
-                    <!-- Domain link (truncates) + external-redirect arrow; copy button pinned to the cell's right edge so it aligns across rows. -->
-                    <div class="flex w-full min-w-0 items-center gap-[var(--spacing-xs)]">
-                      <a
-                        :href="`https://${value}`"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="flex min-w-0 items-center gap-[var(--spacing-xxs)] hover:underline"
-                        @click.stop
-                      >
-                        <span class="truncate">{{ value }}</span>
-                        <i class="pi pi-arrow-up-right shrink-0 text-[var(--text-muted)]" aria-hidden="true" />
-                      </a>
-                      <CopyButton
-                        kind="outlined"
-                        :value="value"
-                        aria-label="Copy domain name"
-                        class="ml-auto shrink-0"
-                      />
-                    </div>
-                  </template>
-                  <template #cell-status="{ value }">
-                    <Tag :label="value" severity="success" size="small" />
-                  </template>
-                  <template #cell-lastModified="{ value, row }">
-                    <LastModifiedCell :author="row.author" :avatar-src="row.authorAvatar" :date="value" />
-                  </template>
-                  <template #cell-actions="{ row }">
-                    <Tooltip text="Zone actions">
-                      <IconButton
-                        icon="pi pi-ellipsis-h"
-                        kind="transparent"
-                        size="small"
-                        aria-label="Zone actions"
-                        @click="(event) => openZoneActions(event, row)"
+                <div class="flex flex-col gap-[var(--spacing-md)]">
+                  <div class="flex items-center gap-[var(--spacing-xs)]">
+                    <span class="min-w-0 truncate text-label-sm text-[var(--text-default)]">
+                      {{ metric.label }}
+                    </span>
+                    <Tooltip :text="metric.hint">
+                      <i
+                        class="pi pi-info-circle text-body-sm text-[var(--text-muted)]"
+                        aria-hidden="true"
                       />
                     </Tooltip>
-                  </template>
-                </Table>
-              </template>
-              <template #footer>
-                <Link
-                  label="View all Edge DNS..."
-                  size="medium"
-                  :show-icon="false"
-                  href="#"
-                />
-              </template>
-            </CardBox>
-          </section>
-
-          <!-- Recent Activity -->
-          <section class="flex flex-col gap-[var(--spacing-md)]">
-            <h2 class="text-heading-xs text-[var(--text-default)]">Recent Activity</h2>
-
-            <CardBox :padded="false">
-              <template #content>
-                <Table :data="activity" :columns="activityColumns" row-key="id">
-                  <template #cell-operation="{ value }">
-                    <Tag
-                      v-if="operationSeverity(value)"
-                      :label="value"
-                      :severity="operationSeverity(value)"
-                      size="small"
-                    />
-                    <span v-else class="text-[var(--text-default)]">{{ value }}</span>
-                  </template>
-                </Table>
-              </template>
-              <template #footer>
-                <Link
-                  label="View all Activity..."
-                  size="medium"
-                  :show-icon="false"
-                  href="#"
-                />
+                  </div>
+                  <div class="flex items-baseline gap-[var(--spacing-xxs)]">
+                    <span
+                      class="text-big-number-sm tabular-nums text-[var(--text-default)]"
+                    >
+                      {{ metric.value }}
+                    </span>
+                    <span
+                      v-if="metric.unit"
+                      class="text-body-xs text-[var(--text-muted)]"
+                    >
+                      {{ metric.unit }}
+                    </span>
+                  </div>
+                </div>
               </template>
             </CardBox>
-          </section>
-        </div>
+          </div>
 
-        <!-- Right rail -->
-        <aside
-          class="flex w-full flex-col gap-[var(--spacing-lg)] xl:max-w-[var(--container-xs)] xl:shrink-0"
-        >
-          <!-- Monthly Usage -->
-          <CardBox>
-            <template #header>
-              <h2 class="text-heading-xs text-[var(--text-default)]">Monthly Usage</h2>
-            </template>
+          <p class="text-pretty text-right text-body-xxs text-[var(--text-muted)]">
+            {{ metricsRange }}
+          </p>
+        </section>
+
+        <!-- Resources -->
+        <section class="flex flex-col gap-[var(--layout-group-gap)]">
+          <div class="flex items-center gap-[var(--spacing-xs)]">
+            <h2 class="text-heading-xs text-[var(--text-default)]">Resources</h2>
+            <IconButton
+              icon="pi pi-question-circle"
+              kind="transparent"
+              size="small"
+              aria-label="About resources"
+            />
+          </div>
+
+          <CardBox :padded="false">
             <template #content>
-              <ul class="flex flex-col gap-[var(--spacing-sm)]">
-                <li
-                  v-for="usage in monthlyUsage"
-                  :key="usage.label"
-                  class="flex items-center justify-between gap-[var(--spacing-md)]"
-                >
-                  <span class="min-w-0 truncate text-body-sm text-[var(--text-muted)]">
-                    {{ usage.label }}
-                  </span>
-                  <span
-                    class="shrink-0 text-label-sm tabular-nums text-[var(--text-default)]"
-                  >
-                    {{ usage.value }}
-                  </span>
-                </li>
-              </ul>
+              <Table :data="resources" :columns="resourceColumns" row-key="id">
+                <template #cell-domain="{ value }">
+                  <!-- Domain link (truncates) + external-redirect arrow; copy button pinned to the cell's right edge so it aligns across rows. -->
+                  <div class="flex w-full min-w-0 items-center gap-[var(--spacing-xs)]">
+                    <a
+                      :href="`https://${value}`"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="flex min-w-0 items-center gap-[var(--spacing-xxs)] hover:underline"
+                      @click.stop
+                    >
+                      <span class="truncate">{{ value }}</span>
+                      <i class="pi pi-arrow-up-right shrink-0 text-[var(--text-muted)]" aria-hidden="true" />
+                    </a>
+                    <CopyButton
+                      kind="outlined"
+                      :value="value"
+                      aria-label="Copy domain name"
+                      class="ml-auto shrink-0"
+                    />
+                  </div>
+                </template>
+                <template #cell-status="{ value }">
+                  <Tag :label="value" severity="success" size="small" />
+                </template>
+                <template #cell-lastModified="{ value, row }">
+                  <LastModifiedCell :author="row.author" :avatar-src="row.authorAvatar" :date="value" />
+                </template>
+                <template #cell-actions="{ row }">
+                  <Tooltip text="Zone actions">
+                    <IconButton
+                      icon="pi pi-ellipsis-h"
+                      kind="transparent"
+                      size="small"
+                      aria-label="Zone actions"
+                      @click="(event) => openZoneActions(event, row)"
+                    />
+                  </Tooltip>
+                </template>
+              </Table>
             </template>
             <template #footer>
-              <Link label="View all Usage..." size="medium" :show-icon="false" href="#" />
+              <Link
+                label="View all Edge DNS..."
+                size="medium"
+                :show-icon="false"
+                href="#"
+              />
             </template>
           </CardBox>
+        </section>
 
-          <!-- Marketplace Trends -->
-          <CardBox>
-            <template #header>
-              <h2 class="text-heading-xs text-[var(--text-default)]">
-                Marketplace Trends
-              </h2>
-            </template>
+        <!-- Recent Activity -->
+        <section class="flex flex-col gap-[var(--layout-group-gap)]">
+          <h2 class="text-heading-xs text-[var(--text-default)]">Recent Activity</h2>
+
+          <CardBox :padded="false">
             <template #content>
-              <article class="flex flex-col gap-[var(--spacing-sm)]">
-                <div class="flex items-center gap-[var(--spacing-sm)]">
-                  <span
-                    class="flex size-6 shrink-0 items-center justify-center rounded-[var(--shape-elements)] bg-[var(--bg-surface-raised)] text-[var(--primary)]"
-                  >
-                    <i class="ai ai-marketplace text-body-sm" aria-hidden="true" />
-                  </span>
-                  <Link
-                    :label="featuredTemplate.name"
-                    size="medium"
-                    :show-icon="false"
-                    href="#"
+              <Table :data="activity" :columns="activityColumns" row-key="id">
+                <template #cell-operation="{ value }">
+                  <Tag
+                    v-if="operationSeverity(value)"
+                    :label="value"
+                    :severity="operationSeverity(value)"
+                    size="small"
                   />
-                </div>
-                <p class="text-pretty text-body-xs text-[var(--text-muted)]">
-                  {{ featuredTemplate.description }}
-                </p>
-                <p class="flex items-center gap-[var(--spacing-md)] text-body-xxs text-[var(--text-muted)]">
-                  <span>
-                    By
-                    <span class="text-[var(--text-default)]">{{ featuredTemplate.author }}</span>
-                  </span>
-                  <span>
-                    Version
-                    <span class="text-[var(--text-default)]">{{ featuredTemplate.version }}</span>
-                  </span>
-                </p>
-              </article>
+                  <span v-else class="text-[var(--text-default)]">{{ value }}</span>
+                </template>
+              </Table>
             </template>
             <template #footer>
+              <Link
+                label="View all Activity..."
+                size="medium"
+                :show-icon="false"
+                href="#"
+              />
+            </template>
+          </CardBox>
+        </section>
+      </div>
+
+      <!-- Right rail -->
+      <aside
+        class="flex w-full flex-col gap-[var(--layout-section-gap)] xl:max-w-[var(--container-xs)] xl:shrink-0"
+      >
+        <!-- Monthly Usage -->
+        <CardBox>
+          <template #header>
+            <h2 class="text-heading-xs text-[var(--text-default)]">Monthly Usage</h2>
+          </template>
+          <template #content>
+            <ul class="flex flex-col gap-[var(--spacing-sm)]">
+              <li
+                v-for="usage in monthlyUsage"
+                :key="usage.label"
+                class="flex items-center justify-between gap-[var(--spacing-md)]"
+              >
+                <span class="min-w-0 truncate text-body-sm text-[var(--text-muted)]">
+                  {{ usage.label }}
+                </span>
+                <span
+                  class="shrink-0 text-label-sm tabular-nums text-[var(--text-default)]"
+                >
+                  {{ usage.value }}
+                </span>
+              </li>
+            </ul>
+          </template>
+          <template #footer>
+            <Link label="View all Usage..." size="medium" :show-icon="false" href="#" />
+          </template>
+        </CardBox>
+
+        <!-- Marketplace Trends -->
+        <CardBox>
+          <template #header>
+            <h2 class="text-heading-xs text-[var(--text-default)]">
+              Marketplace Trends
+            </h2>
+          </template>
+          <template #content>
+            <article class="flex flex-col gap-[var(--spacing-sm)]">
               <div class="flex items-center gap-[var(--spacing-sm)]">
-                <IconButton
-                  icon="pi pi-chevron-left"
-                  kind="transparent"
-                  size="small"
-                  aria-label="Previous trend"
-                />
-                <div class="flex items-center gap-[var(--spacing-xs)]">
-                  <span class="size-2 rounded-full bg-[var(--text-default)]" />
-                  <span class="size-2 rounded-full bg-[var(--border-default)]" />
-                  <span class="size-2 rounded-full bg-[var(--border-default)]" />
-                </div>
-                <IconButton
-                  icon="pi pi-chevron-right"
-                  kind="transparent"
-                  size="small"
-                  aria-label="Next trend"
+                <span
+                  class="flex size-6 shrink-0 items-center justify-center rounded-[var(--shape-elements)] bg-[var(--bg-surface-raised)] text-[var(--primary)]"
+                >
+                  <i class="ai ai-marketplace text-body-sm" aria-hidden="true" />
+                </span>
+                <Link
+                  :label="featuredTemplate.name"
+                  size="medium"
+                  :show-icon="false"
+                  href="#"
                 />
               </div>
-            </template>
-          </CardBox>
-        </aside>
-      </div>
+              <p class="text-pretty text-body-xs text-[var(--text-muted)]">
+                {{ featuredTemplate.description }}
+              </p>
+              <p class="flex items-center gap-[var(--spacing-md)] text-body-xxs text-[var(--text-muted)]">
+                <span>
+                  By
+                  <span class="text-[var(--text-default)]">{{ featuredTemplate.author }}</span>
+                </span>
+                <span>
+                  Version
+                  <span class="text-[var(--text-default)]">{{ featuredTemplate.version }}</span>
+                </span>
+              </p>
+            </article>
+          </template>
+          <template #footer>
+            <div class="flex items-center gap-[var(--spacing-sm)]">
+              <IconButton
+                icon="pi pi-chevron-left"
+                kind="transparent"
+                size="small"
+                aria-label="Previous trend"
+              />
+              <div class="flex items-center gap-[var(--spacing-xs)]">
+                <span class="size-2 rounded-full bg-[var(--text-default)]" />
+                <span class="size-2 rounded-full bg-[var(--border-default)]" />
+                <span class="size-2 rounded-full bg-[var(--border-default)]" />
+              </div>
+              <IconButton
+                icon="pi pi-chevron-right"
+                kind="transparent"
+                size="small"
+                aria-label="Next trend"
+              />
+            </div>
+          </template>
+        </CardBox>
+      </aside>
     </main>
   </AppLayout>
 </template>

--- a/apps/webkit-sample/src/components/DialogForm.vue
+++ b/apps/webkit-sample/src/components/DialogForm.vue
@@ -70,7 +70,7 @@ const toastFailed = (error) =>
     active="forms"
     :breadcrumb="[{ label: 'Forms', href: '/forms' }, { label: 'Dialog form' }]"
   >
-    <main class="flex h-full flex-col gap-[var(--spacing-lg)]">
+    <main class="flex h-full flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         title="Dialog form"
         description="A short, blocking decision in a modal. This destructive delete stays disabled until the exact application name is typed."

--- a/apps/webkit-sample/src/components/DrawerForm.vue
+++ b/apps/webkit-sample/src/components/DrawerForm.vue
@@ -91,7 +91,7 @@ const submit = async () => {
     active="forms"
     :breadcrumb="[{ label: 'Forms', href: '/forms' }, { label: 'Drawer form' }]"
   >
-    <main class="flex h-full flex-col">
+    <main class="flex h-full flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         title="Environments"
         description="Drawer form — create a resource in context without leaving the list. The drawer owns one scoped save."
@@ -108,7 +108,7 @@ const submit = async () => {
       </PageHeading>
 
       <!-- The list the drawer creates into -->
-      <ul class="mt-[var(--spacing-md)] flex flex-col gap-[var(--spacing-xs)]">
+      <ul class="flex flex-col gap-[var(--spacing-xs)]">
         <li
           v-for="env in environments"
           :key="env.id"

--- a/apps/webkit-sample/src/components/DrawerItemGroups.vue
+++ b/apps/webkit-sample/src/components/DrawerItemGroups.vue
@@ -145,7 +145,7 @@ const submit = async () => {
     active="forms"
     :breadcrumb="[{ label: 'Forms', href: '/forms' }, { label: 'ItemGroups in a Drawer' }]"
   >
-    <main class="flex h-full flex-col">
+    <main class="flex h-full flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         title="Services"
         description="Drawer create whose body is several section-titled ItemGroup sections — the settings layout, in context, with one scoped save."
@@ -162,7 +162,7 @@ const submit = async () => {
       </PageHeading>
 
       <!-- The list the drawer creates into -->
-      <ul class="mt-[var(--spacing-md)] flex flex-col gap-[var(--spacing-xs)]">
+      <ul class="flex flex-col gap-[var(--spacing-xs)]">
         <li
           v-for="service in services"
           :key="service.id"

--- a/apps/webkit-sample/src/components/EdgeDns.vue
+++ b/apps/webkit-sample/src/components/EdgeDns.vue
@@ -132,7 +132,7 @@ const onRowAction = (event, value, row) => {
     active="edge-dns"
     :breadcrumb="[{ label: 'Edge DNS' }]"
   >
-    <main class="flex h-full flex-col gap-[var(--spacing-lg)]">
+    <main class="flex h-full flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         title="Edge DNS"
         description="Host authoritative DNS zones and serve authoritative DNS responses used to resolve domain names."
@@ -170,7 +170,7 @@ const onRowAction = (event, value, row) => {
         <CardBox class="w-full max-w-[var(--container-2xl)]">
           <template #content>
             <EmptyState
-              size="large"
+              size="medium"
               title="No zones yet"
               description="Create your first zone to host a domain on Azion's authoritative DNS."
               class="flex-1 rounded-[var(--shape-card)] border border-dashed border-[var(--border-default)] bg-[var(--bg-surface-raised)]"

--- a/apps/webkit-sample/src/components/EdgeDnsZoneDetail.vue
+++ b/apps/webkit-sample/src/components/EdgeDnsZoneDetail.vue
@@ -247,12 +247,12 @@ const onRecordAction = (event, value, row) => {
            independent Save. Only this region scrolls. -->
       <section
         v-if="activeTab === 'main-settings'"
-        class="min-h-0 flex-1 overflow-auto p-[var(--spacing-md)]"
+        class="min-h-0 flex-1 overflow-auto"
       >
-        <div class="flex min-w-0 flex-col gap-[var(--spacing-lg)]">
+        <div class="layout-column layout-boundary flex min-w-0 flex-col gap-[var(--layout-section-gap)]">
           <!-- Group: General (own Save) -->
           <form
-            class="flex flex-col gap-[var(--spacing-sm)]"
+            class="flex flex-col gap-[var(--layout-group-gap)]"
             aria-label="General settings"
             novalidate
             @submit.prevent="saveGeneral"
@@ -316,7 +316,7 @@ const onRecordAction = (event, value, row) => {
 
           <!-- Group: Domain (own Save) -->
           <form
-            class="flex flex-col gap-[var(--spacing-sm)]"
+            class="flex flex-col gap-[var(--layout-group-gap)]"
             aria-label="Domain settings"
             novalidate
             @submit.prevent="saveDomain"
@@ -382,7 +382,7 @@ const onRecordAction = (event, value, row) => {
           <!-- Group: Configure your Nameserver (read-only copy-out — no Save).
                Each value is an InputText with a copy IconButton as an InputGroup
                addon. -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Configure your Nameserver
             </p>
@@ -428,7 +428,7 @@ const onRecordAction = (event, value, row) => {
           <!-- Group: DNSSEC (own Save on the enablement toggle; key material is
                read-only copy-out via InputGroup addons). -->
           <form
-            class="flex flex-col gap-[var(--spacing-sm)]"
+            class="flex flex-col gap-[var(--layout-group-gap)]"
             aria-label="DNSSEC settings"
             novalidate
             @submit.prevent="saveDnssec"
@@ -586,7 +586,7 @@ const onRecordAction = (event, value, row) => {
 
           <!-- Group: Status (own Save) -->
           <form
-            class="flex flex-col gap-[var(--spacing-sm)]"
+            class="flex flex-col gap-[var(--layout-group-gap)]"
             aria-label="Status settings"
             novalidate
             @submit.prevent="saveStatus"
@@ -639,100 +639,102 @@ const onRecordAction = (event, value, row) => {
       </section>
 
       <!-- Records — a flush borderless Table; the create action is on the tab bar. -->
-      <section v-else class="min-h-0 flex-1 overflow-auto p-[var(--spacing-md)]">
-        <CardBox :padded="false">
-          <template #content>
-            <Table
-              :data="records"
-              :columns="recordColumns"
-              row-key="id"
-              enable-sorting
-              paginated
-              :page-size="8"
-              :border="false"
-            >
-              <template #toolbar>
-                <div class="flex w-full items-center gap-[var(--spacing-xs)]">
-                  <Table.Search
-                    size="large"
-                    placeholder="Search records..."
-                    class="flex-1"
-                  />
-                  <Table.RefreshButton />
-                  <Table.Export />
-                  <Table.ColumnSelector />
-                </div>
-              </template>
+      <section v-else class="min-h-0 flex-1 overflow-auto">
+        <div class="layout-column layout-boundary">
+          <CardBox :padded="false">
+            <template #content>
+              <Table
+                :data="records"
+                :columns="recordColumns"
+                row-key="id"
+                enable-sorting
+                paginated
+                :page-size="8"
+                :border="false"
+              >
+                <template #toolbar>
+                  <div class="flex w-full items-center gap-[var(--spacing-xs)]">
+                    <Table.Search
+                      size="large"
+                      placeholder="Search records..."
+                      class="flex-1"
+                    />
+                    <Table.RefreshButton />
+                    <Table.Export />
+                    <Table.ColumnSelector />
+                  </div>
+                </template>
 
-              <template #cell-name="{ value }">
-                <span class="truncate text-label-sm text-[var(--text-default)]">{{ value }}</span>
-              </template>
+                <template #cell-name="{ value }">
+                  <span class="truncate text-label-sm text-[var(--text-default)]">{{ value }}</span>
+                </template>
 
-              <template #cell-id="{ value }">
-                <span class="text-label-code-sm text-[var(--text-muted)]">{{ value }}</span>
-              </template>
+                <template #cell-id="{ value }">
+                  <span class="text-label-code-sm text-[var(--text-muted)]">{{ value }}</span>
+                </template>
 
-              <template #cell-type="{ value }">
-                <Tag :label="value" severity="secondary" size="medium" />
-              </template>
+                <template #cell-type="{ value }">
+                  <Tag :label="value" severity="secondary" size="medium" />
+                </template>
 
-              <template #cell-value="{ value }">
-                <div class="flex w-full min-w-0 items-center gap-[var(--spacing-xs)]">
-                  <span class="min-w-0 truncate font-code text-label-code-sm text-[var(--text-default)]">
-                    {{ value }}
-                  </span>
-                  <CopyButton
-                    kind="outlined"
-                    :value="value"
-                    aria-label="Copy record value"
-                    class="ml-auto shrink-0"
-                    @click.stop
-                  />
-                </div>
-              </template>
+                <template #cell-value="{ value }">
+                  <div class="flex w-full min-w-0 items-center gap-[var(--spacing-xs)]">
+                    <span class="min-w-0 truncate font-code text-label-code-sm text-[var(--text-default)]">
+                      {{ value }}
+                    </span>
+                    <CopyButton
+                      kind="outlined"
+                      :value="value"
+                      aria-label="Copy record value"
+                      class="ml-auto shrink-0"
+                      @click.stop
+                    />
+                  </div>
+                </template>
 
-              <template #cell-policy="{ value }">
-                <span class="text-body-sm text-[var(--text-muted)]">{{ policyLabel(value) }}</span>
-              </template>
+                <template #cell-policy="{ value }">
+                  <span class="text-body-sm text-[var(--text-muted)]">{{ policyLabel(value) }}</span>
+                </template>
 
-              <template #cell-weight="{ value }">
-                <span class="text-body-sm text-[var(--text-muted)]">{{ value ?? "—" }}</span>
-              </template>
+                <template #cell-weight="{ value }">
+                  <span class="text-body-sm text-[var(--text-muted)]">{{ value ?? "—" }}</span>
+                </template>
 
-              <template #cell-description="{ value }">
-                <span class="truncate text-body-sm text-[var(--text-muted)]">{{ value || "—" }}</span>
-              </template>
+                <template #cell-description="{ value }">
+                  <span class="truncate text-body-sm text-[var(--text-muted)]">{{ value || "—" }}</span>
+                </template>
 
-              <template #cell-actions="{ row }">
-                <Dropdown
-                  placement="bottom-end"
-                  @select="(event, value) => onRecordAction(event, value, row)"
-                >
-                  <Dropdown.Trigger>
-                    <Tooltip text="Row actions">
-                      <IconButton
-                        icon="pi pi-ellipsis-h"
-                        kind="outlined"
-                        size="small"
-                        aria-label="Row actions"
-                      />
-                    </Tooltip>
-                  </Dropdown.Trigger>
-                  <Dropdown.Group>
-                    <Dropdown.Option value="edit" label="Edit">
-                      <template #left><i class="pi pi-pencil" aria-hidden="true" /></template>
-                    </Dropdown.Option>
-                  </Dropdown.Group>
-                  <Dropdown.Group>
-                    <Dropdown.Option value="delete" label="Delete">
-                      <template #left><i class="pi pi-trash" aria-hidden="true" /></template>
-                    </Dropdown.Option>
-                  </Dropdown.Group>
-                </Dropdown>
-              </template>
-            </Table>
-          </template>
-        </CardBox>
+                <template #cell-actions="{ row }">
+                  <Dropdown
+                    placement="bottom-end"
+                    @select="(event, value) => onRecordAction(event, value, row)"
+                  >
+                    <Dropdown.Trigger>
+                      <Tooltip text="Row actions">
+                        <IconButton
+                          icon="pi pi-ellipsis-h"
+                          kind="outlined"
+                          size="small"
+                          aria-label="Row actions"
+                        />
+                      </Tooltip>
+                    </Dropdown.Trigger>
+                    <Dropdown.Group>
+                      <Dropdown.Option value="edit" label="Edit">
+                        <template #left><i class="pi pi-pencil" aria-hidden="true" /></template>
+                      </Dropdown.Option>
+                    </Dropdown.Group>
+                    <Dropdown.Group>
+                      <Dropdown.Option value="delete" label="Delete">
+                        <template #left><i class="pi pi-trash" aria-hidden="true" /></template>
+                      </Dropdown.Option>
+                    </Dropdown.Group>
+                  </Dropdown>
+                </template>
+              </Table>
+            </template>
+          </CardBox>
+        </div>
       </section>
     </main>
 

--- a/apps/webkit-sample/src/components/FormsIndex.vue
+++ b/apps/webkit-sample/src/components/FormsIndex.vue
@@ -122,7 +122,7 @@ const open = (example) =>
 
 <template>
   <AppLayout active="forms" :breadcrumb="[{ label: 'Forms' }]">
-    <main class="flex h-full flex-col gap-[var(--spacing-lg)]">
+    <main class="flex h-full flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         title="Forms"
         description="The form types on @aziontech/webkit. Every form shares the same Form Layout (spacing + hierarchy); a type only changes the container and its save model. Open an example to see it in a real flow."

--- a/apps/webkit-sample/src/components/Home.vue
+++ b/apps/webkit-sample/src/components/Home.vue
@@ -231,240 +231,251 @@ const onRowAction = (event, value, row) => {
 
 <template>
   <AppLayout active="home" :breadcrumb="[{ label: 'Home' }]">
-    <div class="mx-auto flex w-full max-w-[var(--container-7xl)] justify-center pb-[var(--spacing-xxl)] pt-[var(--spacing-xl)]">
-      <ContrastBanner />
-    </div>
+    <div class="layout-column flex flex-col gap-[var(--layout-section-gap)]">
+      <div class="flex justify-center">
+        <ContrastBanner />
+      </div>
 
-    <main class="mx-auto flex w-full max-w-[var(--container-7xl)] flex-col items-start gap-[var(--spacing-lg)] md:flex-row">
-      <!-- Left (minor): account usage — one metric per card, its reading beside a
-           small progress bar showing plan consumption. On mobile it spans the
-           full width above the resources; on `md`+ it becomes the narrow rail. -->
-      <aside class="flex w-full shrink-0 flex-col gap-[var(--spacing-md)] md:max-w-[var(--container-xs)]">
-        <div class="flex min-h-[var(--size-8)] items-center px-[var(--spacing-xs)]">
-          <h2 class="text-heading-xxs text-[var(--text-default)]">Usage</h2>
-        </div>
-
-        <!-- 2-up on mobile where the aside is full width; single column once it
-             narrows into the desktop rail. -->
-        <div class="grid grid-cols-2 gap-[var(--spacing-md)] md:grid-cols-1">
-          <CardBox
-            v-for="metric in metrics"
-            :key="metric.label"
-            :padded="false"
-          >
-            <template #content>
-              <div class="flex flex-col gap-[var(--spacing-sm)] p-[var(--spacing-md)]">
-                <div class="flex items-center gap-[var(--spacing-xs)]">
-                  <span class="min-w-0 truncate text-label-sm text-[var(--text-default)]">
-                    {{ metric.label }}
-                  </span>
-                  <Tooltip :text="metric.hint">
-                    <i
-                      class="pi pi-info-circle text-body-sm text-[var(--text-muted)]"
-                      aria-hidden="true"
-                    />
-                  </Tooltip>
-                </div>
-                <div class="flex items-baseline gap-[var(--spacing-xxs)]">
-                  <span class="text-big-number-sm tabular-nums text-[var(--text-default)]">
-                    {{ metric.value }}
-                  </span>
-                  <span
-                    v-if="metric.unit"
-                    class="text-body-xs text-[var(--text-muted)]"
-                  >{{ metric.unit }}</span>
-                </div>
-              </div>
-              <!-- Progress reads as a flush bar on the card's bottom edge — a
-                   consumption "border" that costs no inline space. -->
-              <ProgressBar
-                :value="metric.percent"
-                :max="100"
-                size="small"
-                shape="flat"
-                class="w-full"
-                :aria-label="`${metric.label} usage`"
-              />
-            </template>
-          </CardBox>
-        </div>
-      </aside>
-
-      <!-- Right (major): resources with a filter Dropdown whose selected option
-           carries the checkmark; choosing one swaps the card below. -->
-      <section class="flex w-full min-w-0 flex-col gap-[var(--spacing-md)] md:flex-1">
-        <header class="flex min-h-[var(--size-8)] items-center gap-[var(--spacing-sm)] px-[var(--spacing-xs)]">
-          <h2 class="text-heading-xxs text-[var(--text-default)]">Resources</h2>
-
-        <Dropdown placement="bottom-start" @select="onFilter">
-          <Dropdown.Trigger>
-            <IconButton
-              icon="pi pi-sliders-h"
-              kind="outlined"
-              size="medium"
-              aria-label="Filter by resource"
-            />
-          </Dropdown.Trigger>
-
-          <Dropdown.Group label="Filter by Resource">
-            <Dropdown.Option
-              v-for="option in filterOptions"
-              :key="option.value"
-              :value="option.value"
-              :label="option.label"
-              :selected="selected === option.value"
-            >
-              <template
-                v-if="selected === option.value"
-                #right
-              >
-                <i
-                  class="pi pi-check text-[var(--text-default)]"
-                  aria-hidden="true"
-                />
-              </template>
-            </Dropdown.Option>
-          </Dropdown.Group>
-        </Dropdown>
-      </header>
-
-      <!-- Empty state (Workloads on a fresh account): one CardBox holding a
-           centered lead and an Item.List of the ways to create a first resource
-           — each row an Item with a left icon, its title/description, and action. -->
-      <CardBox
-        v-if="isEmpty"
-        key="resource-empty"
-        :padded="false"
-      >
-        <template #content>
-          <div class="flex flex-col items-center gap-[var(--spacing-xs)] px-[var(--spacing-md)] py-[var(--spacing-xl)] text-center">
-            <!-- Featured icon (same pattern as CreationCenter's Git-provider
-                 tile): a solid box framed by two concentric translucent
-                 squares. -->
-            <span
-              class="mb-[var(--spacing-xs)] relative flex size-10 items-center justify-center"
-            >
-              <span
-                aria-hidden="true"
-                class="absolute left-1/2 top-1/2 size-14 -translate-x-1/2 -translate-y-1/2 rounded-[var(--radius-xl,12px)] border border-[var(--border-strong)] bg-[var(--bg-canvas)] opacity-5"
-              />
-              <span
-                aria-hidden="true"
-                class="absolute left-1/2 top-1/2 size-12 -translate-x-1/2 -translate-y-1/2 rounded-[var(--shape-card)] border border-[var(--border-strong)] bg-[var(--bg-canvas)] opacity-10"
-              />
-              <span
-                class="relative flex size-10 items-center justify-center rounded-[var(--shape-elements)] border border-[var(--border-default)] bg-[var(--bg-surface)]"
-              >
-                <i
-                  :class="[
-                    current.empty.icon,
-                    'text-[1rem] leading-none text-[var(--text-default)]',
-                  ]"
-                  aria-hidden="true"
-                />
-              </span>
-            </span>
-            <h3 class="text-heading-xs text-[var(--text-default)]">
-              {{ current.empty.title }}
-            </h3>
-            <p class="max-w-[var(--container-sm)] text-pretty text-body-sm text-[var(--text-muted)]">
-              {{ current.empty.description }}
-            </p>
+      <!-- Two columns that terminate at the same y. No `items-start`: the row
+           keeps `align-items: stretch`, so its height is max(aside, section) and
+           both columns stretch to it. Each column then needs one internal grow
+           target (the metric grid; the resources CardBox) or the slack would
+           pile up below the cards. `grow`, never `flex-1` — a zero flex-basis
+           makes a column's intrinsic height contribution ill-defined, and that
+           contribution is exactly what the row height derives from. -->
+      <main class="flex flex-col gap-[var(--layout-section-gap)] lg:flex-row">
+        <!-- Left (minor): account usage — one metric per card, its reading beside a
+             small progress bar showing plan consumption. On mobile it spans the
+             full width above the resources; on `md`+ it becomes the narrow rail. -->
+        <aside class="flex w-full shrink-0 flex-col gap-[var(--layout-group-gap)] lg:max-w-[var(--container-xs)]">
+          <div class="flex min-h-[var(--size-8)] items-center px-[var(--spacing-xs)]">
+            <h2 class="text-heading-xxs text-[var(--text-default)]">Usage</h2>
           </div>
 
-          <Item.List class="border-t border-[var(--border-muted)]">
-            <Item
-              v-for="action in current.empty.actions"
-              :key="action.id"
+          <!-- 2-up on mobile where the aside is full width; single column once it
+               narrows into the desktop rail. -->
+          <div class="grid grow auto-rows-fr grid-cols-2 gap-[var(--layout-group-gap)] lg:grid-cols-1">
+            <CardBox
+              v-for="metric in metrics"
+              :key="metric.label"
+              :padded="false"
             >
-              <Item.Media>
-                <!-- Icon frame: 32px square, surface-raised fill, muted
-                     hairline border, shape-elements radius, 18px glyph. -->
+              <template #content>
+                <div class="flex grow flex-col gap-[var(--spacing-sm)] p-[var(--spacing-md)]">
+                  <div class="flex items-center gap-[var(--spacing-xs)]">
+                    <span class="min-w-0 truncate text-label-sm text-[var(--text-default)]">
+                      {{ metric.label }}
+                    </span>
+                    <Tooltip :text="metric.hint">
+                      <i
+                        class="pi pi-info-circle text-body-sm text-[var(--text-muted)]"
+                        aria-hidden="true"
+                      />
+                    </Tooltip>
+                  </div>
+                  <div class="flex items-baseline gap-[var(--spacing-xxs)]">
+                    <span class="text-big-number-sm tabular-nums text-[var(--text-default)]">
+                      {{ metric.value }}
+                    </span>
+                    <span
+                      v-if="metric.unit"
+                      class="text-body-xs text-[var(--text-muted)]"
+                    >{{ metric.unit }}</span>
+                  </div>
+                </div>
+                <!-- Progress reads as a flush bar on the card's bottom edge — a
+                     consumption "border" that costs no inline space. -->
+                <ProgressBar
+                  :value="metric.percent"
+                  :max="100"
+                  size="small"
+                  shape="flat"
+                  class="w-full shrink-0"
+                  :aria-label="`${metric.label} usage`"
+                />
+              </template>
+            </CardBox>
+          </div>
+        </aside>
+
+        <!-- Right (major): resources with a filter Dropdown whose selected option
+             carries the checkmark; choosing one swaps the card below. -->
+        <section class="flex w-full min-w-0 flex-col gap-[var(--layout-group-gap)] lg:flex-1">
+          <header class="flex min-h-[var(--size-8)] items-center gap-[var(--spacing-sm)] px-[var(--spacing-xs)]">
+            <h2 class="text-heading-xxs text-[var(--text-default)]">Resources</h2>
+
+          <Dropdown placement="bottom-start" @select="onFilter">
+            <Dropdown.Trigger>
+              <IconButton
+                icon="pi pi-sliders-h"
+                kind="outlined"
+                size="medium"
+                aria-label="Filter by resource"
+              />
+            </Dropdown.Trigger>
+
+            <Dropdown.Group label="Filter by Resource">
+              <Dropdown.Option
+                v-for="option in filterOptions"
+                :key="option.value"
+                :value="option.value"
+                :label="option.label"
+                :selected="selected === option.value"
+              >
+                <template
+                  v-if="selected === option.value"
+                  #right
+                >
+                  <i
+                    class="pi pi-check text-[var(--text-default)]"
+                    aria-hidden="true"
+                  />
+                </template>
+              </Dropdown.Option>
+            </Dropdown.Group>
+          </Dropdown>
+        </header>
+
+        <!-- Empty state (Workloads on a fresh account): one CardBox holding a
+             centered lead and an Item.List of the ways to create a first resource
+             — each row an Item with a left icon, its title/description, and action. -->
+        <CardBox
+          v-if="isEmpty"
+          key="resource-empty"
+          :padded="false"
+          class="grow"
+        >
+          <template #content>
+            <div class="flex grow flex-col items-center justify-center gap-[var(--spacing-sm)] px-[var(--spacing-lg)] py-[var(--spacing-xl)] text-center">
+              <!-- Featured icon (same pattern as CreationCenter's Git-provider
+                   tile): a solid box framed by two concentric translucent
+                   squares. -->
+              <span
+                class="mb-[var(--spacing-xs)] relative flex size-12 items-center justify-center"
+              >
                 <span
-                  class="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-[var(--shape-elements)] border-[length:var(--border-width-default)] border-[var(--border-muted)] bg-[var(--bg-surface-raised)]"
+                  aria-hidden="true"
+                  class="absolute left-1/2 top-1/2 size-16 -translate-x-1/2 -translate-y-1/2 rounded-[var(--radius-xl,12px)] border border-[var(--border-strong)] bg-[var(--bg-canvas)] opacity-5"
+                />
+                <span
+                  aria-hidden="true"
+                  class="absolute left-1/2 top-1/2 size-14 -translate-x-1/2 -translate-y-1/2 rounded-[var(--shape-card)] border border-[var(--border-strong)] bg-[var(--bg-canvas)] opacity-10"
+                />
+                <span
+                  class="relative flex size-12 items-center justify-center rounded-[var(--shape-elements)] border border-[var(--border-default)] bg-[var(--bg-surface)]"
                 >
                   <i
                     :class="[
-                      action.icon,
-                      'text-[18px] leading-none text-[var(--text-default)]',
+                      current.empty.icon,
+                      'text-[1.25rem] leading-none text-[var(--text-default)]',
                     ]"
                     aria-hidden="true"
                   />
                 </span>
-              </Item.Media>
-              <Item.Content>
-                <Item.Title>{{ action.title }}</Item.Title>
-                <Item.Description>{{ action.description }}</Item.Description>
-              </Item.Content>
-              <Item.Actions>
-                <Button
-                  :label="action.button"
-                  kind="outlined"
-                  size="medium"
-                  @click="createFrom(action)"
-                />
-              </Item.Actions>
-            </Item>
-          </Item.List>
-        </template>
-      </CardBox>
+              </span>
+              <h3 class="text-heading-md text-[var(--text-default)]">
+                {{ current.empty.title }}
+              </h3>
+              <p class="max-w-[var(--container-md)] text-pretty text-body-md text-[var(--text-muted)]">
+                {{ current.empty.description }}
+              </p>
+            </div>
 
-      <!-- Populated resource: data-driven Table inside a flush CardBox, with a
-           per-row action menu. -->
-      <CardBox
-        v-else
-        key="resource-table"
-        :padded="false"
-      >
-        <template #content>
-          <Table
-            :data="current.rows"
-            :columns="current.columns"
-            row-key="id"
-            enable-sorting
-          >
-            <template #cell-status="{ value }">
-              <Tag
-                :label="value"
-                :severity="statusSeverity(value)"
-                size="medium"
-              />
-            </template>
-
-            <template #cell-actions="{ row }">
-              <Dropdown
-                placement="bottom-end"
-                @select="(event, value) => onRowAction(event, value, row)"
+            <Item.List class="border-t border-[var(--border-muted)]">
+              <Item
+                v-for="action in current.empty.actions"
+                :key="action.id"
               >
-                <Dropdown.Trigger>
-                  <Tooltip text="Row actions">
-                    <IconButton
-                      icon="pi pi-ellipsis-h"
-                      kind="outlined"
-                      size="small"
-                      aria-label="Row actions"
+                <Item.Media>
+                  <!-- Icon frame: 32px square, surface-raised fill, muted
+                       hairline border, shape-elements radius, 18px glyph. -->
+                  <span
+                    class="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-[var(--shape-elements)] border-[length:var(--border-width-default)] border-[var(--border-muted)] bg-[var(--bg-surface-raised)]"
+                  >
+                    <i
+                      :class="[
+                        action.icon,
+                        'text-[18px] leading-none text-[var(--text-default)]',
+                      ]"
+                      aria-hidden="true"
                     />
-                  </Tooltip>
-                </Dropdown.Trigger>
+                  </span>
+                </Item.Media>
+                <Item.Content>
+                  <Item.Title>{{ action.title }}</Item.Title>
+                  <Item.Description>{{ action.description }}</Item.Description>
+                </Item.Content>
+                <Item.Actions>
+                  <Button
+                    :label="action.button"
+                    kind="outlined"
+                    size="medium"
+                    @click="createFrom(action)"
+                  />
+                </Item.Actions>
+              </Item>
+            </Item.List>
+          </template>
+        </CardBox>
 
-                <Dropdown.Group>
-                  <Dropdown.Option value="view" label="View details" />
-                  <Dropdown.Option value="edit" label="Edit" />
-                </Dropdown.Group>
+        <!-- Populated resource: data-driven Table inside a flush CardBox, with a
+             per-row action menu. -->
+        <CardBox
+          v-else
+          key="resource-table"
+          :padded="false"
+          class="grow"
+        >
+          <template #content>
+            <Table
+              :data="current.rows"
+              :columns="current.columns"
+              row-key="id"
+              enable-sorting
+            >
+              <template #cell-status="{ value }">
+                <Tag
+                  :label="value"
+                  :severity="statusSeverity(value)"
+                  size="medium"
+                />
+              </template>
 
-                <Dropdown.Group>
-                  <Dropdown.Option value="delete" label="Delete">
-                    <template #left>
-                      <i class="pi pi-trash" aria-hidden="true" />
-                    </template>
-                  </Dropdown.Option>
-                </Dropdown.Group>
-              </Dropdown>
-            </template>
-          </Table>
-        </template>
-      </CardBox>
-      </section>
-    </main>
+              <template #cell-actions="{ row }">
+                <Dropdown
+                  placement="bottom-end"
+                  @select="(event, value) => onRowAction(event, value, row)"
+                >
+                  <Dropdown.Trigger>
+                    <Tooltip text="Row actions">
+                      <IconButton
+                        icon="pi pi-ellipsis-h"
+                        kind="outlined"
+                        size="small"
+                        aria-label="Row actions"
+                      />
+                    </Tooltip>
+                  </Dropdown.Trigger>
+
+                  <Dropdown.Group>
+                    <Dropdown.Option value="view" label="View details" />
+                    <Dropdown.Option value="edit" label="Edit" />
+                  </Dropdown.Group>
+
+                  <Dropdown.Group>
+                    <Dropdown.Option value="delete" label="Delete">
+                      <template #left>
+                        <i class="pi pi-trash" aria-hidden="true" />
+                      </template>
+                    </Dropdown.Option>
+                  </Dropdown.Group>
+                </Dropdown>
+              </template>
+            </Table>
+          </template>
+        </CardBox>
+        </section>
+      </main>
+    </div>
   </AppLayout>
 </template>

--- a/apps/webkit-sample/src/components/InPageForm.vue
+++ b/apps/webkit-sample/src/components/InPageForm.vue
@@ -192,7 +192,7 @@ const submit = async () => {
       >
       <!-- Scrollable form body -->
       <div
-        class="mx-auto flex w-full max-w-[var(--container-7xl)] flex-1 flex-col gap-[var(--spacing-lg)] p-[var(--spacing-lg)]"
+        class="layout-column layout-boundary flex flex-1 flex-col gap-[var(--layout-section-gap)]"
       >
         <!-- One flag locks every control while the request is in flight. -->
         <fieldset
@@ -202,7 +202,7 @@ const submit = async () => {
           <legend class="sr-only">Create application</legend>
 
           <!-- Section: General -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               General
             </p>
@@ -244,7 +244,7 @@ const submit = async () => {
           </section>
 
           <!-- Section: Delivery Settings -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Delivery Settings
             </p>
@@ -345,7 +345,7 @@ const submit = async () => {
           </section>
 
           <!-- Section: Origins -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Origins
             </p>
@@ -453,7 +453,7 @@ const submit = async () => {
           </section>
 
           <!-- Section: Cache Expiration Policies -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Cache Expiration Policies
             </p>
@@ -539,7 +539,7 @@ const submit = async () => {
           </section>
 
           <!-- Section: Debug Rules -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Debug Rules
             </p>
@@ -575,7 +575,7 @@ const submit = async () => {
         class="sticky bottom-0 border-t-[length:var(--border-width-default)] border-[var(--border-muted)] bg-[var(--bg-surface)]"
       >
         <div
-          class="flex w-full items-center justify-end gap-[var(--spacing-sm)] p-[var(--spacing-lg)]"
+          class="layout-column flex items-center justify-end gap-[var(--spacing-sm)] px-[var(--layout-boundary-inline)] py-[var(--spacing-md)]"
         >
           <Button
             type="button"

--- a/apps/webkit-sample/src/components/ItemGroupSaves.vue
+++ b/apps/webkit-sample/src/components/ItemGroupSaves.vue
@@ -68,14 +68,14 @@ const saveNotifications = () =>
     active="forms"
     :breadcrumb="[{ label: 'Forms', href: '/forms' }, { label: 'ItemGroup with independent saves' }]"
   >
-    <main class="flex w-full flex-col gap-[var(--spacing-lg)]">
+    <main class="flex w-full flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         title="Preferences"
         description="The same partitioned-save idea as CardBox, on the ItemGroup surface — Item rows in a flush card, each topic group owning its own save, so changes commit in parts."
       />
 
       <!-- Group 1 — General (section title, its own footer save). -->
-      <section class="flex flex-col gap-[var(--spacing-sm)]">
+      <section class="flex flex-col gap-[var(--layout-group-gap)]">
         <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
           General
         </p>
@@ -147,7 +147,7 @@ const saveNotifications = () =>
       </section>
 
       <!-- Group 2 — Notifications (section title, its own footer save). -->
-      <section class="flex flex-col gap-[var(--spacing-sm)]">
+      <section class="flex flex-col gap-[var(--layout-group-gap)]">
         <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
           Notifications
         </p>

--- a/apps/webkit-sample/src/components/ItemGroupSettings.vue
+++ b/apps/webkit-sample/src/components/ItemGroupSettings.vue
@@ -90,7 +90,7 @@ const submit = async () => {
       @submit.prevent="submit"
     >
       <div
-        class="flex w-full flex-1 flex-col gap-[var(--spacing-lg)] p-[var(--spacing-lg)]"
+        class="layout-column layout-boundary flex flex-1 flex-col gap-[var(--layout-section-gap)]"
       >
         <PageHeading
           title-id="profile-title"
@@ -106,7 +106,7 @@ const submit = async () => {
           <legend class="sr-only">Profile settings</legend>
 
           <!-- Section: General — an section title over a flush CardBox. -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               General
             </p>
@@ -177,7 +177,7 @@ const submit = async () => {
           </section>
 
           <!-- Section: Preferences -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Preferences
             </p>
@@ -243,7 +243,7 @@ const submit = async () => {
           </section>
 
           <!-- Section: Notifications -->
-          <section class="flex flex-col gap-[var(--spacing-sm)]">
+          <section class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Notifications
             </p>
@@ -275,7 +275,7 @@ const submit = async () => {
         class="sticky bottom-0 border-t-[length:var(--border-width-default)] border-[var(--border-muted)] bg-[var(--bg-surface)]"
       >
         <div
-          class="flex w-full items-center justify-end gap-[var(--spacing-sm)] p-[var(--spacing-lg)]"
+          class="layout-column flex items-center justify-end gap-[var(--spacing-sm)] px-[var(--layout-boundary-inline)] py-[var(--spacing-md)]"
         >
           <Button
             type="button"

--- a/apps/webkit-sample/src/components/ManageResources.vue
+++ b/apps/webkit-sample/src/components/ManageResources.vue
@@ -163,7 +163,7 @@
     active="resources"
     :breadcrumb="[{ label: 'Manage Resources' }]"
   >
-    <main class="flex h-full min-h-0 flex-col gap-[var(--spacing-md)]">
+    <main class="flex h-full min-h-0 flex-col gap-[var(--layout-group-gap)]">
       <PageHeading
         title="Manage Resources"
         description="Organize accounts into a hierarchy of brands, resellers, groups, and clients."

--- a/apps/webkit-sample/src/components/Marketplace.vue
+++ b/apps/webkit-sample/src/components/Marketplace.vue
@@ -14,6 +14,7 @@ import TabView from "@aziontech/webkit/tab-view";
 import { toast } from "@aziontech/webkit/toast";
 import { computed, ref } from "vue";
 
+import { filterDisplay } from "../lib/filters";
 import AppLayout from "./ui/AppLayout.vue";
 import IntegrationCard from "./ui/IntegrationCard.vue";
 import PageHeading from "./ui/PageHeading.vue";
@@ -366,17 +367,6 @@ const categoryOptions = [...new Set(integrations.map((i) => i.group))].map((grou
 
 const contextOptions = Object.entries(contextLabels).map(([value, label]) => ({ value, label }));
 
-// Trigger label: no selection means "all", so the placeholder ("All X") shows.
-// Once something is picked, show the single label or "N selected".
-const filterDisplay = (allLabel, options) => (values) => {
-  if (!values.length) return allLabel;
-  if (values.length === 1) {
-    const match = options.find((o) => o.value === values[0]);
-    return match ? match.label : values[0];
-  }
-  return `${values.length} selected`;
-};
-
 // Search across name/vendor/description, then apply each active filter axis.
 const filteredIntegrations = computed(() => {
   const term = integrationQuery.value.trim().toLowerCase();
@@ -406,7 +396,7 @@ const openIntegration = (item) =>
 
 <template>
   <AppLayout active="marketplace" :breadcrumb="[{ label: 'Marketplace' }]">
-    <main class="mx-auto flex w-full flex-col gap-[var(--spacing-lg)]">
+    <main class="layout-column flex flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         size="large"
         title="Marketplace"

--- a/apps/webkit-sample/src/components/NestedDrawer.vue
+++ b/apps/webkit-sample/src/components/NestedDrawer.vue
@@ -187,7 +187,7 @@ const submitChild = async () => {
     active="forms"
     :breadcrumb="[{ label: 'Forms', href: '/forms' }, { label: 'Nested drawer' }]"
   >
-    <main class="flex h-full flex-col">
+    <main class="flex h-full flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         title="Functions Instances"
         description="Create a resource whose Select needs a related resource that may not exist yet — the quick-add opens a second drawer, then selects the new resource back into the parent. Each drawer is its own scoped save."
@@ -204,7 +204,7 @@ const submitChild = async () => {
       </PageHeading>
 
       <!-- The list the parent drawer creates into -->
-      <ul class="mt-[var(--spacing-md)] flex flex-col gap-[var(--spacing-xs)]">
+      <ul class="flex flex-col gap-[var(--spacing-xs)]">
         <li
           v-for="instance in instances"
           :key="instance.id"

--- a/apps/webkit-sample/src/components/ObjectStorage.vue
+++ b/apps/webkit-sample/src/components/ObjectStorage.vue
@@ -104,7 +104,7 @@ const onRowAction = (event, value, row) => {
     active="object-storage"
     :breadcrumb="[{ label: 'Object Storage' }]"
   >
-    <main class="flex h-full flex-col gap-[var(--spacing-lg)]">
+    <main class="flex h-full flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         title="Object Storage"
         description="Store and serve static objects at the edge — buckets, folders, and files accessed by Applications, Functions, and APIs."
@@ -137,7 +137,7 @@ const onRowAction = (event, value, row) => {
         <CardBox class="w-full max-w-[var(--container-2xl)]">
           <template #content>
             <EmptyState
-              size="large"
+              size="medium"
               title="No buckets yet"
               description="Create your first bucket to store and serve static objects at the edge."
               class="flex-1 rounded-[var(--shape-card)] border border-dashed border-[var(--border-default)] bg-[var(--bg-surface-raised)]"

--- a/apps/webkit-sample/src/components/PersonalTokens.vue
+++ b/apps/webkit-sample/src/components/PersonalTokens.vue
@@ -253,7 +253,7 @@ watch(dialogOpen, (open) => {
 
 <template>
   <AppLayout :breadcrumb="[{ label: 'Personal Tokens' }]">
-    <main class="flex h-full flex-col gap-[var(--spacing-lg)]">
+    <main class="flex h-full flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         title="Personal Tokens"
         description="Personal tokens securely access your account via API. Create one, then copy it — it's shown only once."

--- a/apps/webkit-sample/src/components/Playground.vue
+++ b/apps/webkit-sample/src/components/Playground.vue
@@ -38,7 +38,7 @@ const fontLabel = computed(() => labelOf(fonts)(font.value));
 
 <template>
   <AppLayout active="playground" :padded="false" :breadcrumb="[{ label: 'Playground' }]">
-    <div class="flex w-full flex-col gap-[var(--spacing-lg)] p-[var(--spacing-lg)]">
+    <div class="layout-column layout-boundary flex flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         title-id="playground-title"
         title="Playground"
@@ -46,7 +46,7 @@ const fontLabel = computed(() => labelOf(fonts)(font.value));
       />
 
       <!-- Section: Appearance — an section title over a flush CardBox. -->
-      <section class="flex flex-col gap-[var(--spacing-sm)]">
+      <section class="flex flex-col gap-[var(--layout-group-gap)]">
         <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
           Appearance
         </p>
@@ -116,7 +116,7 @@ const fontLabel = computed(() => labelOf(fonts)(font.value));
 
       <!-- Section: Preview — shows the active font/theme across the type scale
            and a few components so the swap is immediately visible. -->
-      <section class="flex flex-col gap-[var(--spacing-sm)]">
+      <section class="flex flex-col gap-[var(--layout-group-gap)]">
         <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
           Preview · {{ fontLabel }}
         </p>

--- a/apps/webkit-sample/src/components/SqlDatabase.vue
+++ b/apps/webkit-sample/src/components/SqlDatabase.vue
@@ -107,7 +107,7 @@ const onRowAction = (event, value, row) => {
     active="sql-database"
     :breadcrumb="[{ label: 'SQL Database' }]"
   >
-    <main class="flex h-full flex-col gap-[var(--spacing-lg)]">
+    <main class="flex h-full flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         title="SQL Database"
         description="Create and manage SQL Database instances accessed by Applications, Functions, and APIs."
@@ -143,7 +143,7 @@ const onRowAction = (event, value, row) => {
                  dashed, raised EmptyState surface with a featured icon tile
                  (concentric translucent squares) + one clear action. -->
             <EmptyState
-              size="large"
+              size="medium"
               title="No databases yet"
               description="Create your first SQL Database to store relational and vector data at the edge."
               class="flex-1 rounded-[var(--shape-card)] border border-dashed border-[var(--border-default)] bg-[var(--bg-surface-raised)]"

--- a/apps/webkit-sample/src/components/SqlDatabaseDetail.vue
+++ b/apps/webkit-sample/src/components/SqlDatabaseDetail.vue
@@ -551,7 +551,7 @@ const runQuery = async () => {
                      a dashed, raised EmptyState surface with a featured icon tile
                      (concentric translucent squares) + one clear action. -->
                 <EmptyState
-                  size="large"
+                  size="medium"
                   title="No tables yet"
                   description="Create your first table to store your data."
                   class="flex-1 rounded-[var(--shape-card)] border border-dashed border-[var(--border-default)] bg-[var(--bg-surface-raised)]"

--- a/apps/webkit-sample/src/components/TemplateSettings.vue
+++ b/apps/webkit-sample/src/components/TemplateSettings.vue
@@ -243,7 +243,7 @@ const submit = async () => {
     >
       <!-- Scrollable form body -->
       <div
-        class="flex w-full flex-1 flex-col gap-[var(--spacing-lg)] p-[var(--spacing-lg)]"
+        class="layout-column layout-boundary flex flex-1 flex-col gap-[var(--layout-section-gap)]"
       >
         <PageHeading
           title-id="template-settings-title"

--- a/apps/webkit-sample/src/components/Variables.vue
+++ b/apps/webkit-sample/src/components/Variables.vue
@@ -235,7 +235,7 @@ const onRowAction = (event, value, row) => {
 
 <template>
   <AppLayout active="variables" :breadcrumb="[{ label: 'Variables' }]">
-    <main class="flex h-full flex-col gap-[var(--spacing-lg)]">
+    <main class="flex h-full flex-col gap-[var(--layout-section-gap)]">
       <!-- Module intro + primary action -->
       <PageHeading
         title="Variables"

--- a/apps/webkit-sample/src/components/WorkloadDetail.vue
+++ b/apps/webkit-sample/src/components/WorkloadDetail.vue
@@ -229,11 +229,11 @@ const deleteWorkload = () => {
         </div>
       </div>
 
-      <section class="min-h-0 flex-1 overflow-auto p-[var(--spacing-md)]">
+      <section class="min-h-0 flex-1 overflow-auto">
         <!-- ── Overview ── -->
         <div
           v-if="activeTab === 'overview'"
-          class="flex min-w-0 flex-col gap-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex min-w-0 flex-col gap-[var(--layout-section-gap)]"
         >
           <!-- Active Deployment -->
           <CardBox :padded="false">
@@ -373,7 +373,7 @@ const deleteWorkload = () => {
           </CardBox>
 
           <!-- Version History -->
-          <div class="flex flex-col gap-[var(--spacing-sm)]">
+          <div class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Version History
             </p>
@@ -454,7 +454,7 @@ const deleteWorkload = () => {
         <!-- ── Deployments ── -->
         <div
           v-else-if="activeTab === 'deployments'"
-          class="flex min-w-0 flex-col gap-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex min-w-0 flex-col gap-[var(--layout-section-gap)]"
         >
           <CardBox :padded="false">
             <template #content>
@@ -534,7 +534,7 @@ const deleteWorkload = () => {
         <!-- ── Settings ── -->
         <div
           v-else
-          class="flex min-w-0 flex-col gap-[var(--spacing-lg)]"
+          class="layout-column layout-boundary flex min-w-0 flex-col gap-[var(--layout-section-gap)]"
         >
           <PageHeading
             title="Settings"
@@ -543,7 +543,7 @@ const deleteWorkload = () => {
           />
 
           <form
-            class="flex flex-col gap-[var(--spacing-sm)]"
+            class="flex flex-col gap-[var(--layout-group-gap)]"
             aria-label="General settings"
             novalidate
             @submit.prevent="saveSettings"
@@ -595,7 +595,7 @@ const deleteWorkload = () => {
           </form>
 
           <!-- Danger zone -->
-          <div class="flex flex-col gap-[var(--spacing-sm)]">
+          <div class="flex flex-col gap-[var(--layout-group-gap)]">
             <p class="px-[var(--spacing-xs)] text-heading-xxs text-[var(--text-default)]">
               Danger Zone
             </p>

--- a/apps/webkit-sample/src/components/Workloads.vue
+++ b/apps/webkit-sample/src/components/Workloads.vue
@@ -2,22 +2,31 @@
 // Workloads list — the Azion Console "Workloads" module. The app shell (sidebar +
 // GlobalHeader breadcrumb) comes from AppLayout; this page renders a PageHeading
 // (title + description + "Documentation" / "+ Workload") over a data-driven <Table>
-// whose toolbar composes the table's own filter / search / refresh / export /
-// column controls and whose rows open the workload detail view. As a first-level
-// module list it carries no navigation tabs.
+// whose rows open the workload detail view. As a first-level module list it
+// carries no navigation tabs.
+//
+// Narrowing is a SELECTOR PER COLUMN (the same model as Applications): Authors,
+// Last Modified (Calendar — a shortcut rail beside a month grid for a custom range), and
+// Status, all always visible in the toolbar. They pre-filter `:data`; the table's
+// own Search narrows what is left. See Applications.vue for why the table's
+// filter state cannot host them.
 import Button from "@aziontech/webkit/button";
+import Calendar from "@aziontech/webkit/calendar";
 import CardBox from "@aziontech/webkit/card-box";
 import CopyButton from "@aziontech/webkit/copy-button";
 import Dropdown from "@aziontech/webkit/dropdown";
 import IconButton from "@aziontech/webkit/icon-button";
 import Popover from "@aziontech/webkit/popover";
+import Select from "@aziontech/webkit/select";
 import Table from "@aziontech/webkit/table";
 import Tag from "@aziontech/webkit/tag";
 import { toast } from "@aziontech/webkit/toast";
 import Tooltip from "@aziontech/webkit/tooltip";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
+import { daysAgo, formatListDate, monthsAgo, withinRange } from "../lib/dates";
+import { filterDisplay } from "../lib/filters";
 import { authorAt } from "../lib/people";
 import AppLayout from "./ui/AppLayout.vue";
 import LastModifiedCell from "./ui/LastModifiedCell.vue";
@@ -42,6 +51,7 @@ const workloads = ref(
         (_, j) => `my-workload-${n}-alias-${j + 1}.azion.app`,
       ),
     ];
+    const modified = daysAgo(i * 18);
     return {
       id: `10${(20482 + n * 173).toString()}`,
       name: `workload_${String(n).padStart(2, "0")}`,
@@ -49,7 +59,10 @@ const workloads = ref(
       domains,
       domainCount: extraCount,
       status: n % 9 === 0 ? "Inactive" : "Active",
-      lastModified: "May 15, 2026, 11:00:25 am",
+      // Spread across ~12 months (18 days apart) so the Last Modified filter has
+      // something to narrow — every row used to carry the identical timestamp.
+      modifiedAt: modified,
+      lastModified: formatListDate(modified),
       owner: authorAt(i).name,
       ownerAvatar: authorAt(i).avatar,
     };
@@ -64,19 +77,46 @@ const columns = [
   { id: "actions", kind: "action", hideable: false },
 ];
 
-const filterFields = [
-  { id: "name", label: "Name", type: "text" },
-  { id: "domain", label: "Domain", type: "text" },
-  {
-    id: "status",
-    label: "Status",
-    type: "select",
-    options: [
-      { label: "Active", value: "Active" },
-      { label: "Inactive", value: "Inactive" },
-    ],
-  },
+// ── Column selectors ──────────────────────────────────────────────────────
+// Authors come from the data, so the selector can never offer someone with no
+// rows in the list. (The column is "Last Modified"; the person renders inside
+// that cell as `owner`.)
+const authorOptions = [...new Set(workloads.value.map((workload) => workload.owner))]
+  .sort((a, b) => a.localeCompare(b))
+  .map((owner) => ({ value: owner, label: owner }));
+
+const statusOptions = [
+  { value: "Active", label: "Active" },
+  { value: "Inactive", label: "Inactive" },
 ];
+
+// The Calendar's shortcut rail — one click applies a range; the grid beside it
+// fine-tunes it.
+const periodPresets = [
+  { label: "Last 7 Days", value: { start: daysAgo(7), end: new Date() } },
+  { label: "Last 30 Days", value: { start: daysAgo(30), end: new Date() } },
+  { label: "Last 3 Months", value: { start: monthsAgo(3), end: new Date() } },
+  { label: "Last 12 Months", value: { start: monthsAgo(12), end: new Date() } },
+];
+
+const authorFilter = ref([]);
+const statusFilter = ref([]);
+const modifiedRange = ref(null);
+
+const filteredWorkloads = computed(() =>
+  workloads.value.filter((workload) => {
+    if (authorFilter.value.length && !authorFilter.value.includes(workload.owner)) return false;
+    if (statusFilter.value.length && !statusFilter.value.includes(workload.status)) return false;
+    return withinRange(workload.modifiedAt, modifiedRange.value);
+  }),
+);
+
+// External `:data` filtering does not trip TanStack's `autoResetPageIndex`, so
+// own the pagination state and rewind to the first page when a filter changes.
+const pagination = ref({ pageIndex: 0, pageSize: 10 });
+watch([authorFilter, statusFilter, modifiedRange], () => {
+  pagination.value = { ...pagination.value, pageIndex: 0 };
+});
 
 const createWorkload = () =>
   router.push({ path: "/workloads/new", query: { email: userEmail.value } });
@@ -102,7 +142,7 @@ const onRowAction = (event, value, row) => {
 
 <template>
   <AppLayout active="workloads" :breadcrumb="[{ label: 'Workloads' }]">
-    <main class="flex h-full flex-col gap-[var(--spacing-lg)]">
+    <main class="flex h-full flex-col gap-[var(--layout-section-gap)]">
       <PageHeading
         title="Workloads"
         description="View and manage your workloads."
@@ -130,9 +170,9 @@ const onRowAction = (event, value, row) => {
         <CardBox :padded="false">
           <template #content>
             <Table
-              :data="workloads"
+              v-model:pagination="pagination"
+              :data="filteredWorkloads"
               :columns="columns"
-              :filter-fields="filterFields"
               row-key="id"
               enable-sorting
               paginated
@@ -141,17 +181,86 @@ const onRowAction = (event, value, row) => {
               @row-click="openWorkload"
             >
               <template #toolbar>
-                <div class="flex w-full items-center gap-[var(--spacing-xs)]">
-                  <Table.Filter :fields="filterFields" />
-                  <Table.Search size="large" placeholder="Search workloads..." class="flex-1" />
+                <!-- One selector per column, always visible: Authors, Last Modified,
+                     Status. Search takes the remaining width. -->
+                <div class="flex w-full flex-wrap items-center gap-[var(--spacing-xs)]">
+                  <!-- Width lives on the wrapper: the Select root declares w-full in its own
+                       static class, which wins over a consumer w-[…] on a specificity tie. -->
+                  <div class="w-[var(--container-2xs)] shrink-0">
+                    <Select
+                      v-model="authorFilter"
+                      multiple
+                      size="medium"
+                      placeholder="All Authors"
+                      :display-value="filterDisplay('All Authors', authorOptions)"
+                    >
+                      <Select.Trigger aria-label="Filter by author" />
+                      <Select.Content>
+                        <Select.Option
+                          v-for="option in authorOptions"
+                          :key="option.value"
+                          :value="option.value"
+                        >
+                          {{ option.label }}
+                        </Select.Option>
+                      </Select.Content>
+                    </Select>
+                  </div>
+
+                  <!-- The shortcut rail (Last 7 Days …) plus the month grid for a custom
+                       range both come from :presets — with presets the component splits the
+                       trigger into a preset dropdown + the range itself. NOT `period`: that
+                       flag REPLACES the pair (`isTwoPart = hasPresets && !period`) with the
+                       relative-span parser, and takes the placeholder with it. -->
+                  <Calendar
+                    v-model="modifiedRange"
+                    mode="range"
+                    size="medium"
+                    :presets="periodPresets"
+                    placeholder="Last Modified"
+                    class="shrink-0"
+                  >
+                    <!-- Resetting the filter is Calendar.Clear in the panel footer, not the
+                         `clearable` prop: that renders an X on the trigger only in the
+                         SINGLE-part branch, so alongside :presets it would be inert. Clear
+                         empties the draft; Apply Range commits the empty range, which reads
+                         as "no Last Modified filter". -->
+                    <template #footer>
+                      <Calendar.Clear>Clear</Calendar.Clear>
+                    </template>
+                  </Calendar>
+
+                  <!-- Width lives on the wrapper: the Select root declares w-full in its own
+                       static class, which wins over a consumer w-[…] on a specificity tie. -->
+                  <div class="w-[var(--container-3xs)] shrink-0">
+                    <Select
+                      v-model="statusFilter"
+                      multiple
+                      size="medium"
+                      placeholder="All Statuses"
+                      :display-value="filterDisplay('All Statuses', statusOptions)"
+                    >
+                      <Select.Trigger aria-label="Filter by status" />
+                      <Select.Content>
+                        <Select.Option
+                          v-for="option in statusOptions"
+                          :key="option.value"
+                          :value="option.value"
+                        >
+                          {{ option.label }}
+                        </Select.Option>
+                      </Select.Content>
+                    </Select>
+                  </div>
+
+                  <Table.Search
+                    placeholder="Search workloads..."
+                    class="min-w-[var(--container-3xs)] flex-1"
+                  />
                   <Table.RefreshButton />
                   <Table.Export />
                   <Table.ColumnSelector />
                 </div>
-              </template>
-
-              <template #filters>
-                <Table.AppliedFilters />
               </template>
 
               <template #cell-domain="{ row, value }">
@@ -217,8 +326,12 @@ const onRowAction = (event, value, row) => {
                 />
               </template>
 
-              <template #cell-lastModified="{ value, row }">
-                <LastModifiedCell :author="row.owner" :avatar-src="row.ownerAvatar" :date="value" />
+              <template #cell-lastModified="{ row }">
+                <LastModifiedCell
+                  :author="row.owner"
+                  :avatar-src="row.ownerAvatar"
+                  :date="row.modifiedAt"
+                />
               </template>
 
               <template #cell-actions="{ row }">

--- a/apps/webkit-sample/src/components/ui/AppLayout.vue
+++ b/apps/webkit-sample/src/components/ui/AppLayout.vue
@@ -349,12 +349,13 @@
         </GlobalHeader.Right>
       </GlobalHeader>
 
-      <!-- Content inset matches the GlobalHeader's edge padding
-           (`--spacing-md`), so the page content aligns with the header's
-           breadcrumb / actions on every breakpoint. -->
+      <!-- Content inset comes from the app's layout tokens (`.layout-boundary`
+           in src/styles/layout.css): `--layout-boundary-inline` on the sides,
+           one step more at the top so the header's bottom border gets air
+           below it. Retuning the boundary is a one-line edit in that file. -->
       <div
         class="min-h-0 flex-1 overflow-auto"
-        :class="{ 'p-[var(--spacing-md)]': padded }"
+        :class="{ 'layout-boundary': padded }"
       >
         <slot />
       </div>

--- a/apps/webkit-sample/src/lib/dates.js
+++ b/apps/webkit-sample/src/lib/dates.js
@@ -1,0 +1,95 @@
+// Date helpers shared by the console list views.
+//
+// A list row keeps its instant as a real `Date` (`modifiedAt`) and derives the
+// display string from it — never the other way round. Parsing a display string
+// like "July 20, 2026, 01:03:00 PM" with `new Date()` is engine-dependent (the
+// comma before the time is not part of any format the spec requires an engine
+// to accept), so a filter built on it would compare garbage on some browsers.
+
+// Composed from two formatters instead of one: a single Intl instance with both
+// date and time parts inserts either ", " or " at " depending on the ICU
+// version, so the output would drift between environments.
+const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
+  month: "long",
+  day: "2-digit",
+  year: "numeric",
+});
+const TIME_FORMAT = new Intl.DateTimeFormat("en-US", {
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: true,
+});
+
+/**
+ * The console's "Last Modified" display string: "July 20, 2026, 01:03:00 PM".
+ *
+ * @param {Date} date
+ * @returns {string} Empty string for a missing or invalid date.
+ */
+export function formatListDate(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return "";
+  return `${DATE_FORMAT.format(date)}, ${TIME_FORMAT.format(date)}`;
+}
+
+/**
+ * `n` days before `from` (default: now), keeping the time of day.
+ *
+ * @param {number} n
+ * @param {Date} [from]
+ * @returns {Date}
+ */
+export const daysAgo = (n, from = new Date()) => {
+  const date = new Date(from);
+  date.setDate(date.getDate() - n);
+  return date;
+};
+
+/**
+ * `n` months before `from` (default: now). Uses the native month arithmetic, so
+ * an overflowing day-of-month rolls forward the way `Date` defines it
+ * (March 31 minus one month → March 3).
+ *
+ * @param {number} n
+ * @param {Date} [from]
+ * @returns {Date}
+ */
+export const monthsAgo = (n, from = new Date()) => {
+  const date = new Date(from);
+  date.setMonth(date.getMonth() - n);
+  return date;
+};
+
+/**
+ * Whether `date` falls inside a Calendar range value.
+ *
+ * A range whose `end` sits exactly at midnight came from a day-granular pick
+ * (the month grid or a preset), so it means "through the end of that day" —
+ * comparing against midnight itself would drop every row modified after 00:00
+ * on the final day. An `end` that carries a time came from the Period parser or
+ * the time fields and is taken literally.
+ *
+ * @param {Date} date
+ * @param {{ start?: Date | null, end?: Date | null } | null} [range]
+ * @returns {boolean} True when there is no range to apply.
+ */
+export function withinRange(date, range) {
+  if (!range) return true;
+  const { start, end } = range;
+  if (!start && !end) return true;
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return false;
+
+  if (start && date.getTime() < start.getTime()) return false;
+  if (end) {
+    const midnight =
+      end.getHours() === 0 &&
+      end.getMinutes() === 0 &&
+      end.getSeconds() === 0 &&
+      end.getMilliseconds() === 0;
+    const bound = midnight
+      ? new Date(end.getFullYear(), end.getMonth(), end.getDate(), 23, 59, 59, 999)
+      : end;
+    if (date.getTime() > bound.getTime()) return false;
+  }
+  return true;
+}

--- a/apps/webkit-sample/src/lib/filters.js
+++ b/apps/webkit-sample/src/lib/filters.js
@@ -1,0 +1,22 @@
+// Shared filter-control helpers for the console's list and catalog views.
+
+/**
+ * A `:display-value` resolver for a multiple `<Select>` used as a filter.
+ *
+ * No selection means "no narrowing", so the placeholder ("All Authors") reads as
+ * the state of the data rather than as an empty field. One selection shows that
+ * option's label; more than one collapses to "N selected" so the trigger cannot
+ * outgrow its column.
+ *
+ * @param {string} allLabel Label for the empty (unfiltered) state.
+ * @param {Array<{ value: unknown, label: string }>} options
+ * @returns {(values: unknown[]) => string}
+ */
+export const filterDisplay = (allLabel, options) => (values) => {
+  if (!values.length) return allLabel;
+  if (values.length === 1) {
+    const match = options.find((option) => option.value === values[0]);
+    return match ? match.label : String(values[0]);
+  }
+  return `${values.length} selected`;
+};

--- a/apps/webkit-sample/src/style.css
+++ b/apps/webkit-sample/src/style.css
@@ -1,6 +1,8 @@
 /* Theme tokens + the Tailwind v4 entry are imported from src/main.js
    (`import '@aziontech/theme'`); see the note there. This file carries only
-   the app's own font faces, icon fonts and shell rules. */
+   the app's own layout tokens, font faces, icon fonts and shell rules. */
+/* Layout tokens — the container system (boundary / rhythm / measure). */
+@import './styles/layout.css';
 /* PrimeIcons — webkit components reference `pi pi-*` glyphs. */
 @import 'primeicons/primeicons.css';
 /* Azion icon library — monochrome brand/UI glyphs (`ai ai-*`, colored via

--- a/apps/webkit-sample/src/styles/layout.css
+++ b/apps/webkit-sample/src/styles/layout.css
@@ -1,0 +1,67 @@
+/* ---------------------------------------------------------------------------
+ * Layout tokens — the console's container system.
+ *
+ * Three decisions, expressed once: how far content sits from the app chrome
+ * (BOUNDARY), how far things sit from each other (RHYTHM), and how wide a
+ * reading column may get (MEASURE). Every value builds on @aziontech/theme's
+ * fluid --spacing-* / --container-* scales, so the whole system stays
+ * responsive without a single media query in this file.
+ *
+ * These are app-level tokens today, deliberately shaped like theme tokens
+ * (semantic names, zero raw values) so the set can be promoted into
+ * @aziontech/theme as `semantic/layouts`.
+ *
+ * Promotion path:
+ *   1. Move the `:root` block to packages/theme/src/tokens/semantic/
+ *      layouts.data.js, in the same breakpoint-map form as spacings.data.js /
+ *      containers.data.js — or keep the values as var(--spacing-*) references
+ *      so the layout scale stays derived rather than duplicated.
+ *   2. Register it in packages/theme/src/scripts/build-tokens.mjs beside
+ *      containers / spacings, so it lands in dist/v4/globals.css as responsive
+ *      cascade custom properties (exactly how --spacing-* already works).
+ *   3. Move .layout-boundary / .layout-column into the theme's own
+ *      Tailwind-processed CSS, where `@utility` IS available, so they gain
+ *      variant support (md:layout-column).
+ *   4. This file then goes away and every consuming app inherits the system.
+ *
+ * Why plain classes and not Tailwind `@utility`: this file is part of the
+ * src/style.css entry, while the Tailwind v4 directive lives in the theme's
+ * globals.css (imported from main.js) — so an `@utility` declared here would be
+ * outside Tailwind's stylesheet graph and never processed. Plain classes work
+ * unconditionally, and the theme is imported first, so on a specificity tie
+ * these win over the utilities.
+ * ------------------------------------------------------------------------ */
+:root {
+  /* BOUNDARY — content ↔ app chrome. The top is one step larger than the
+     sides: the header's bottom border reads as a hard edge, so the eye wants
+     more air below it than beside the content (optical alignment). */
+  --layout-boundary-inline: var(--spacing-lg); /* 16 → 24            */
+  --layout-boundary-end: var(--spacing-lg); /* 16 → 24            */
+  --layout-boundary-start: var(--spacing-xl); /* 24 → 32 → 48       */
+
+  /* RHYTHM — two levels, nothing else. */
+  --layout-section-gap: var(--spacing-xl); /* between sections   */
+  --layout-group-gap: var(--spacing-lg); /* within a section   */
+
+  /* MEASURE — the widest a configuration / form / dashboard column may get.
+     Table pages opt out and run full-bleed. */
+  --layout-measure: var(--container-7xl); /* 1280px             */
+}
+
+/* The page boundary. Padding, never margin: a top margin on an `h-full` child
+   of a padded scroll box overflows by exactly the margin (h-full resolves
+   against the parent's content box, the margin sits outside it) and the
+   overflow lands as a silent clip at the bottom of a table. */
+.layout-boundary {
+  padding-inline: var(--layout-boundary-inline);
+  padding-block-start: var(--layout-boundary-start);
+  padding-block-end: var(--layout-boundary-end);
+}
+
+/* A centered reading column at the measure. Table pages omit it — full-bleed
+   is the absence of this class, not a `w-full`. */
+.layout-column {
+  margin-inline: auto;
+  width: 100%;
+  max-width: var(--layout-measure);
+}


### PR DESCRIPTION
## Summary

`apps/webkit-sample` had grown to ~34 pages that each invented their own content container. The four archetypes disagreed on all three axes that matter — width, boundary inset, and section rhythm — so the boundary read tight, sections sat too close together, and Home's two columns ended at different heights.

This encodes the container system **once, as CSS layout tokens**, and moves every archetype onto it. A token file is what makes the standard enforceable instead of aspirational: retuning the boundary is now a one-line edit rather than a 25-file sweep. It is shaped deliberately like theme tokens (semantic names, zero raw values) so the set can be promoted into `@aziontech/theme` as the first Azion **layout** token set — the promotion path is recorded in the file header.

Separately, the Applications and Workloads tables shipped `Table.Filter`, a generic field/operator/value popover builder. That is the wrong model for a console list; what a user wants is a selector per column.

Four commits, reviewable in isolation:

1. **`feat`** — the token layer (`src/styles/layout.css` + wiring, no page edits)
2. **`refactor`** — all four archetypes onto the tokens (AppLayout alone moves 19 padded pages)
3. **`style`** — Home's equal-height columns + a more generous resources empty state
4. **`feat`** — column-selector filters, and the shared `lib/dates.js` / `lib/filters.js` behind them

## Notes

**No new dependencies. No breaking changes.** `webkit-sample` is private and outside `release-please-config.json`'s paths, so none of these commits cuts a release.

**Verified in a real browser** (Playwright over the dev server), not just by build:

| check | result |
|---|---|
| All 43 routes | zero console / page errors |
| Home columns end at same `y` | delta `0` at 1600 and 1280, for both the 3-action (Workloads) and 2-action (Edge DNS) empty state |
| Archetype-C alignment | form column and save bar share both edges (320…1600) — the 320px save-bar misalignment is gone |
| Archetype-B alignment | tab bar aligns with the header breadcrumb (264/264); content is inset by the boundary (468) |
| Column selectors | presets narrow 12→7 rows; multi-author narrows and restores; filtering from page 2 rewinds to page 1; Clear + Apply restores |
| Token layer is wired | overriding `--layout-boundary-inline` at runtime moved every page's inset at once (card left 273→313px) |

### Three deliberate divergences from the original plan

- **The tab bar is chrome, not content.** It keeps its own `--spacing-md` edge padding and stays full-bleed, aligned with the header's breadcrumb, rather than sharing the content column's boundary. Tabs and content are therefore intentionally offset by 24px.
- **`period` and `:presets` do not compose** on `Calendar` — `isTwoPart` is `hasPresets && !period`, so `period` *replaces* the presets rail and the grid and swaps the placeholder for the literal "Period". Last Modified uses `:presets` (rail + custom range + the real placeholder). `clearable` is inert in the two-part trigger for the same reason, so reset is `<Calendar.Clear>` composed into the panel's `#footer`.
- **The `sm`→`lg` group-gap sweep covers 46 sites, not all 70.** The 24 inside drawer panels keep `sm`: their enclosing fieldset separates sections with the same `lg` value, so raising both would flatten the hierarchy.

### Two webkit fixes this surfaced (out of scope here)

- `table-search.vue` renders `InputText` with `v-bind="$attrs"` *before* a literal `size="small"`, so a consumer `size` always loses. Both `Table.Search` call sites dropped their ignored `size="large"`.
- `select.vue` declares `w-full` in its own static `class` alongside `:class="attrs.class"`, so a consumer `w-[…]` loses the specificity tie — the first toolbar render stacked into four rows. Worked around with a wrapper div; that root should merge through `cn`.

### Known, pre-existing, not fixed here

At a ~700px viewport the Applications / Workloads pagination row sits below the fold (bottom 769px). It was **already** clipped before this change (713px) — the boundary bump widens an existing overflow. `07c4f649` and `ce8e785f` tuned that `min-h-0` behaviour on purpose, so it is left alone as a follow-up; the row is still reachable by scrolling.

### Worth a second look in review

1. **The `lg` group gap.** The section-label→CardBox relationship goes 12px → 16/24px in 46 places. At 24px a small "General" label starts to float away from the card it titles — the value most worth an opinion, and the one the token file makes trivial to retune.
2. **Home's 48px gutter at ≥1280px** — 320 aside + 48 gutter + 912 section. Fine on paper; judge whether it reads as separation or as a hole.
3. **Content vs. chrome alignment.** `GlobalHeader` is a fixed `px-md` (16px), so at ≥640px content insets 24px while the breadcrumb stays at 16 — an 8px offset on every padded page, not fixable from the sample. Flow pages already have exactly this relationship and read fine, so I recommend accepting it; the alternative is `--layout-boundary-inline: var(--spacing-md)`, a one-line change in the token file.
