### PR TITLE
fix: harden pnpm audit overrides for new advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion: '>=5.0.8'
+  brace-expansion: '>=5.0.9'
   minimatch: '>=9.0.0'
   uuid: '>=14.0.0'
+  fast-uri: '>=3.1.5 <4'
   '@babel/core': '>=7.29.1 <8'
   '@hono/node-server': '>=2.0.5'
+  hono: '>=4.12.34 <5'
 
 importers:
 
@@ -936,7 +938,7 @@ packages:
     resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.34 <5'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2518,8 +2520,8 @@ packages:
     resolution: {integrity: sha512-JtIQYts08AFAYGF4eSh3pUt3NQkYV/e75pRtQmAVTLNWR/1L7Bsswxlgzgk8nmLEM+gFszsIlA9BgD3XnSqp3g==}
     engines: {node: '>=10'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -3476,8 +3478,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -3819,8 +3821,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.12.32:
-    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -6406,6 +6408,9 @@ packages:
   vue-component-type-helpers@3.3.8:
     resolution: {integrity: sha512-troqCMmQodQDqUqn63NQaFi+CDSclSe7sc8VEBFqf5GFLqmGR2Ph3P2WEC7qwpRVyEWsTi/aAr4vyOe/B1hU3g==}
 
+  vue-component-type-helpers@3.3.9:
+    resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
+
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -7318,9 +7323,9 @@ snapshots:
     dependencies:
       '@hapi/hoek': 11.0.7
 
-  '@hono/node-server@2.0.12(hono@4.12.32)':
+  '@hono/node-server@2.0.12(hono@4.12.34)':
     dependencies:
-      hono: 4.12.32
+      hono: 4.12.34
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -7583,7 +7588,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.0.12(hono@4.12.32)
+      '@hono/node-server': 2.0.12(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -7593,7 +7598,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.1(express@5.2.1)
-      hono: 4.12.32
+      hono: 4.12.34
       jose: 6.2.4
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -8046,7 +8051,7 @@ snapshots:
       ts-dedent: 2.3.0
       type-fest: 2.19.0
       vue: 3.5.40(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.8
+      vue-component-type-helpers: 3.3.9
 
   '@storybook/vue3@8.6.18(storybook@8.6.18(prettier@3.9.6))(vue@3.5.40(typescript@6.0.3))':
     dependencies:
@@ -8060,7 +8065,7 @@ snapshots:
       ts-dedent: 2.3.0
       type-fest: 2.19.0
       vue: 3.5.40(typescript@6.0.3)
-      vue-component-type-helpers: 3.3.8
+      vue-component-type-helpers: 3.3.9
 
   '@swc/core-darwin-arm64@1.15.46':
     optional: true
@@ -8879,7 +8884,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9163,7 +9168,7 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10342,7 +10347,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastest-levenshtein@1.0.16: {}
 
@@ -10704,7 +10709,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.32: {}
+  hono@4.12.34: {}
 
   hookable@5.5.3: {}
 
@@ -11886,7 +11891,7 @@ snapshots:
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -13642,6 +13647,8 @@ snapshots:
   vue-component-type-helpers@2.2.12: {}
 
   vue-component-type-helpers@3.3.8: {}
+
+  vue-component-type-helpers@3.3.9: {}
 
   vue-demi@0.14.10(vue@3.5.40(typescript@6.0.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,8 +19,10 @@ minimumReleaseAgeExclude:
 overrides:
   # Minimal validated set (2026-07-25): each entry guards a live advisory or a
   # proven resolution hazard; the tree is audit-clean without anything else.
-  brace-expansion: ">=5.0.8" # GHSA-mh99-v99m-4gvg (DoS), patched 5.0.8
+  brace-expansion: ">=5.0.9" # GHSA-rgw5-rvv9-x895 (DoS, CVE-2026-14257 mitigation bypass), patched 5.0.9 — supersedes GHSA-mh99-v99m-4gvg
   minimatch: ">=9.0.0" # keeps minimatch@3 chains out so the brace-expansion force stays within one API major
   uuid: ">=14.0.0" # GHSA-w5hq-g745-h8pq, patched 11.1.1; jest/storybook chains pin 8.x/9.x
+  fast-uri: ">=3.1.5 <4" # GHSA-7p8r-x3mc-p8w7 (host confusion via backslash), patched 3.1.5; bounded to 3.x — ajv pins ^3
   "@babel/core": ">=7.29.1 <8" # bounded: peer ranges (^7 || ^8.0.0-0) would jump to Babel 8
   "@hono/node-server": ">=2.0.5" # GHSA-frvp-7c67-39w9; MCP SDK still pins ^1.19.x — drop when the SDK moves to ^2
+  hono: ">=4.12.34 <5" # GHSA-8j4g-w8fx-2239 (ReDoS in CORS middleware), patched 4.12.34; bounded to 4.x — MCP SDK pins ^4


### PR DESCRIPTION
## Summary

The **Security Scans → "Audit dependencies"** step (`pnpm run security:audit` = `pnpm audit`) in [`governance.yml`](.github/workflows/governance.yml) started failing on three transitive advisories that the existing `pnpm-workspace.yaml` overrides no longer cover. Example failing run: [runs/30902738667 · Security Scans](https://github.com/aziontech/webkit/actions/runs/30902738667/job/91970716381) (exit 1, `1 moderate | 2 high`).

This is a repo-wide gate (it fails on every open PR, e.g. #850), so the fix lands in its own PR off `main` per the dependency-change convention; merging it unblocks the audit step everywhere.

## The three advisories

| Package | Advisory | Severity | Path(s) | Fix |
|---|---|---|---|---|
| `brace-expansion` | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS, CVE-2026-14257 mitigation bypass | high | `@typescript-eslint/*`, `eslint`, … → `minimatch` → `brace-expansion` | bump existing override `>=5.0.8` → **`>=5.0.9`** |
| `fast-uri` | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — host confusion via backslash | high | `@commitlint/*`, `stylelint` → `ajv` → `fast-uri` | add **`>=3.1.5 <4`** |
| `hono` | [GHSA-8j4g-w8fx-2239](https://github.com/advisories/GHSA-8j4g-w8fx-2239) — ReDoS in CORS middleware | moderate | `@modelcontextprotocol/sdk` → (`@hono/node-server` →) `hono` | add **`>=4.12.34 <5`** |

## Why these bounds

Each force stays inside the dependents' expected major so nothing else in the tree breaks:

- `fast-uri` bounded to `<4` — `ajv` pins `^3`.
- `hono` bounded to `<5` — the MCP SDK pins `^4`.
- `brace-expansion` stays in major 5, kept there by the existing `minimatch: ">=9.0.0"` override.

The `brace-expansion` comment now references the superseding advisory (GHSA-rgw5-rvv9-x895) instead of the older GHSA-mh99-v99m-4gvg it already patched.

## Verification

- `pnpm install --lockfile-only` resolves `brace-expansion@5.0.9`, `fast-uri@3.1.5`, `hono@4.12.34`.
- `pnpm audit` → **`No known vulnerabilities found`** (exit 0), down from `1 moderate | 2 high`.
- Diff is limited to `pnpm-workspace.yaml` (4 lines) and `pnpm-lock.yaml`.

Release effect: `fix` → patch.