### PR TITLE
docs: fix PR body to a fixed structure with a How to test section

### DIFF
--- a/.claude/commands/open-pr.md
+++ b/.claude/commands/open-pr.md
@@ -46,7 +46,21 @@ If the diff spans multiple packages, prefer **one commit per scope** (CONTRIBUTI
 ### 6. Push and open the PR
 - `git push -u origin <branch>`.
 - If a PR already exists for the branch, update it; otherwise `gh pr create --base main --head <branch>`.
-- **Title:** the conventional commit header (normalize `$ARGUMENTS` into that form when given). Merges are **squash merges**, so the PR title is the commit release-please parses — it must **start with the bare type**, with the ticket tag after the colon only when an issue exists (`<type>(<scope>): [<ISSUE>] <subject>`), and put `!` in the title for a breaking change. **Body:** `## Summary` (what + why) and `## Notes`; call out any new dependency and any breaking change; reference the issue. No Figma links, no attribution footer.
+- **Title:** the conventional commit header (normalize `$ARGUMENTS` into that form when given). Merges are **squash merges**, so the PR title is the commit release-please parses — it must **start with the bare type**, with the ticket tag after the colon only when an issue exists (`<type>(<scope>): [<ISSUE>] <subject>`), and put `!` in the title for a breaking change.
+- **Body — fixed structure.** Exactly these three sections, in this order, nothing else (the same skeleton as [`PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md)):
+
+  ```md
+  ## Summary
+  - <1–3 bullets: what changed and why>
+
+  ## How to test
+  1. <numbered, concrete steps to verify THIS PR: the command to run (`pnpm storybook:dev`, `pnpm webkit:test`, …), where to look (story / page / component), and the expected result>
+
+  ## Notes
+  - <breaking change (what + migration), new dependency, related issue — `None` when there is nothing>
+  ```
+
+  Keep it terse: Summary never restates the diff (max 3 bullets); "How to test" is the minimum end-to-end path a reviewer can follow, each step with its expected result; no intro prose. No Figma links, no attribution footer.
 - Report the PR URL.
 
 ## Rules

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- 1–3 bullets: what changed and why. Don't restate the diff. -->
+
+## How to test
+
+<!-- Numbered, concrete steps to verify THIS PR: the command to run, where to look (story / page / component), and the expected result. -->
+
+## Notes
+
+<!-- Breaking change (what + migration), new dependency, related issue. Write "None" when there is nothing. -->


### PR DESCRIPTION
## Summary
- `/open-pr` now writes the PR body in a fixed three-section structure — `## Summary`, `## How to test`, `## Notes` — so every PR says how to test it, with terseness rules (max 3 Summary bullets, no intro prose).
- Adds `.github/PULL_REQUEST_TEMPLATE.md` with the same skeleton so manually opened PRs follow the same structure.

## How to test
1. Run `/open-pr` on any working diff and confirm the generated PR body has exactly the three sections, in order, with numbered steps and expected results under "How to test".
2. Start a PR manually on GitHub and confirm the description is pre-filled with the same three-section template.

## Notes
- None