### PR TITLE
docs(webkit): document the Release-As version override

### DIFF
--- a/packages/webkit/docs/PROCESS.md
+++ b/packages/webkit/docs/PROCESS.md
@@ -287,6 +287,24 @@ release-please (stock `release-type: node` in `release-please-config.json`),
 added or removed. release-please only counts a commit toward a package when it touches
 files under that package.
 
+**Overriding the computed version.** When the computed bump is wrong for a release — a
+breaking marker already merged that has to ship as a minor, or a version the team needs to
+pin — the override is a `Release-As: <version>` footer on a commit, which wins over the
+type/`!` calculation. Two constraints follow from how release-please reads it:
+
+- the commit must **touch a file under that package's path**, or the footer never reaches
+  the package. An **empty** commit is applied to _every_ configured package, so it would
+  pin all three at once.
+- the footer must survive into the **squash commit on `main`** — that is the message
+  release-please parses — so it belongs in the squash body, not only in a branch commit.
+
+The override is one-shot: once the tag is cut, the commit leaves the unreleased range and
+the calculation returns to normal, so the next breaking marker computes a major again.
+Holding a package's line at a fixed track permanently is a different mechanism
+(`versioning` in `release-please-config.json`), not this footer. The footer is read from
+the commits of the range **before** the Release PR is computed; the Release PR itself
+carries the resolved version in its diff, so a footer added there arrives too late.
+
 At publish time the publish workflow (`package-webkit.yml`) generates `.d.ts` files (`vue-tsc`); the
 repo itself ships source (`exports` points at `./src/...`) — `.d.ts` is never committed.
 The published package embeds [`catalog.json`](../catalog.json) — the version-locked


### PR DESCRIPTION
## Summary

- Stage 7 documented the type → bump mapping but not how to override a computed version, so pinning a release meant re-deriving the rules from the release-please source. It now records the `Release-As:` footer plus the two constraints that decide whether release-please even sees it, and that it is read *before* the Release PR is computed.
- The commit carries `Release-As: 4.3.0`, so merging this redirects the next `@aziontech/webkit` release to **4.3.0** instead of the 5.0.0 currently computed in #810 (from the `feat(webkit)!` in #833).

## How to test

1. Squash-merge this PR, keeping `Release-As: 4.3.0` as the squash body — that footer is what release-please parses, not the branch commit.
2. Wait for the `Release Please` workflow on `main`: `gh run list --workflow=release-please.yml --limit 3`.
3. Open #810 and check the diff: `packages/webkit/package.json`, `catalog.json#webkitVersion` and `.release-please-manifest.json` must read `4.3.0` (they currently read `5.0.0`). `@aziontech/theme` must stay at `4.3.0` and `@aziontech/icons` must remain absent from the PR.

## Notes

- `docs` releases nothing on its own; the footer only redirects the version release-please computes for the pending Release PR.
- One-shot by design: once `4.3.0` is tagged, this commit leaves the unreleased range and the calculation returns to normal, so the next breaking marker computes a major again. Holding the line at 4.x permanently would be `versioning` in `release-please-config.json`, not this footer.
- The `Message` API change from #833 therefore ships inside a **minor**. Consumers on `^4` receive it without a major boundary — `title`/`description` are gone and the `__title`/`__description` testids are now `__content`.
- No related issue.
