### PR TITLE
fix(theme): emit the named duration and ease utilities the system already writes

### DIFF
--- a/packages/theme/dist/v4/globals.css
+++ b/packages/theme/dist/v4/globals.css
@@ -414,6 +414,18 @@
   --animate-progress-indeterminate: progressIndeterminate 2100ms cubic-bezier(0.39, 0.57, 0.56, 1) infinite;
   --animate-progress-indeterminate-short: progressIndeterminateShort 2100ms cubic-bezier(0.17, 0.84, 0.44, 1) 1100ms infinite;
   --animate-flow-dash: flowDash 700ms linear infinite;
+  --transition-duration-fast-01: 70ms;
+  --transition-duration-fast-02: 110ms;
+  --transition-duration-moderate-01: 150ms;
+  --transition-duration-moderate-02: 240ms;
+  --transition-duration-slow-01: 400ms;
+  --transition-duration-slow-02: 700ms;
+  --transition-duration-slow-03: 1100ms;
+  --transition-duration-slow-04: 2100ms;
+  --ease-productive-entrance: cubic-bezier(0.39, 0.57, 0.56, 1);
+  --ease-productive-exit: cubic-bezier(0.55, 0.09, 0.68, 0.53);
+  --ease-expressive-entrance: cubic-bezier(0.17, 0.84, 0.44, 1);
+  --ease-expressive-exit: cubic-bezier(0.95, 0.05, 0.8, 0.04);
 }
 
 :root, [data-theme=light], .azion.azion-light {

--- a/packages/theme/dist/v4/globals.scss
+++ b/packages/theme/dist/v4/globals.scss
@@ -414,6 +414,18 @@
   --animate-progress-indeterminate: progressIndeterminate 2100ms cubic-bezier(0.39, 0.57, 0.56, 1) infinite;
   --animate-progress-indeterminate-short: progressIndeterminateShort 2100ms cubic-bezier(0.17, 0.84, 0.44, 1) 1100ms infinite;
   --animate-flow-dash: flowDash 700ms linear infinite;
+  --transition-duration-fast-01: 70ms;
+  --transition-duration-fast-02: 110ms;
+  --transition-duration-moderate-01: 150ms;
+  --transition-duration-moderate-02: 240ms;
+  --transition-duration-slow-01: 400ms;
+  --transition-duration-slow-02: 700ms;
+  --transition-duration-slow-03: 1100ms;
+  --transition-duration-slow-04: 2100ms;
+  --ease-productive-entrance: cubic-bezier(0.39, 0.57, 0.56, 1);
+  --ease-productive-exit: cubic-bezier(0.55, 0.09, 0.68, 0.53);
+  --ease-expressive-entrance: cubic-bezier(0.17, 0.84, 0.44, 1);
+  --ease-expressive-exit: cubic-bezier(0.95, 0.05, 0.8, 0.04);
 }
 
 :root, [data-theme=light], .azion.azion-light {

--- a/packages/theme/src/scripts/build-tokens.mjs
+++ b/packages/theme/src/scripts/build-tokens.mjs
@@ -26,7 +26,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { animate } from '../tokens/primitives/animations/animate.js';
+import { animate, curve, duration } from '../tokens/primitives/animations/animate.js';
 import { animateExtras, keyframes } from '../tokens/primitives/animations/keyframes.js';
 import { breakpoints } from '../tokens/primitives/breakpoints.js';
 import { compilePrimitivesVars } from './compile-primitives.js';
@@ -290,6 +290,19 @@ const emitCssV4 = () => {
 
   for (const [name, shorthand] of Object.entries(animate)) {
     themeVars[`--animate-${name}`] = shorthand;
+  }
+
+  // Named `duration-*` / `ease-*` utilities. Without these the design system's
+  // own `duration-moderate-02` / `ease-productive-entrance` classes compile to
+  // NOTHING (Tailwind v4 silently drops an unknown named step), and every
+  // component that declares one falls back to Tailwind's default 150ms `ease`.
+  // The namespaces are fixed by Tailwind: `--transition-duration-*` backs
+  // `duration-*`, `--ease-*` backs `ease-*`.
+  for (const [name, value] of Object.entries(duration)) {
+    themeVars[`--transition-duration-${name}`] = value;
+  }
+  for (const [name, value] of Object.entries(curve)) {
+    themeVars[`--ease-${name}`] = value;
   }
 
   const semanticBase = {

--- a/packages/webkit/catalog.json
+++ b/packages/webkit/catalog.json
@@ -338,9 +338,13 @@
       "--drop-shadow-sm",
       "--drop-shadow-xl",
       "--drop-shadow-xs",
+      "--ease-expressive-entrance",
+      "--ease-expressive-exit",
       "--ease-in",
       "--ease-in-out",
       "--ease-out",
+      "--ease-productive-entrance",
+      "--ease-productive-exit",
       "--font-code",
       "--font-display",
       "--font-sans",
@@ -661,6 +665,14 @@
       "--tracking-wide",
       "--tracking-wider",
       "--tracking-widest",
+      "--transition-duration-fast-01",
+      "--transition-duration-fast-02",
+      "--transition-duration-moderate-01",
+      "--transition-duration-moderate-02",
+      "--transition-duration-slow-01",
+      "--transition-duration-slow-02",
+      "--transition-duration-slow-03",
+      "--transition-duration-slow-04",
       "--warning",
       "--warning-border",
       "--warning-contrast",
@@ -1038,9 +1050,13 @@
         "--drop-shadow-xs"
       ],
       "ease": [
+        "--ease-expressive-entrance",
+        "--ease-expressive-exit",
         "--ease-in",
         "--ease-in-out",
-        "--ease-out"
+        "--ease-out",
+        "--ease-productive-entrance",
+        "--ease-productive-exit"
       ],
       "font": [
         "--font-code",
@@ -1401,6 +1417,16 @@
         "--tracking-wide",
         "--tracking-wider",
         "--tracking-widest"
+      ],
+      "transition": [
+        "--transition-duration-fast-01",
+        "--transition-duration-fast-02",
+        "--transition-duration-moderate-01",
+        "--transition-duration-moderate-02",
+        "--transition-duration-slow-01",
+        "--transition-duration-slow-02",
+        "--transition-duration-slow-03",
+        "--transition-duration-slow-04"
       ],
       "warning": [
         "--warning",


### PR DESCRIPTION
## Summary

- `duration-moderate-02` and `ease-productive-entrance` compiled to **nothing**. Tailwind v4 resolves a named step through a theme namespace — `--transition-duration-*` backs `duration-*`, `--ease-*` backs `ease-*` — and neither namespace was ever emitted, so every class naming one of our steps was silently dropped and the element kept Tailwind's default 150ms `ease`. There is no error for this, which is why **46 files** across webkit, Storybook and the sample app came to depend on names that did nothing.
- The tokens already existed (`curve` and `duration` in `primitives/animations/animate.js`, shipped as `--animate-*` shorthands only); `build-tokens.mjs` now also maps them into the namespaces Tailwind reads.
- Purely additive: 12 custom properties. Tailwind's own `ease-in` / `ease-out` / `ease-in-out` are **not** overridden — our `curve` set only defines the four productive / expressive curves.

## How to test

1. `node packages/theme/src/scripts/build-tokens.mjs`, then `git diff --stat packages/theme/dist` — expect exactly 12 added lines in each of `globals.css` and `globals.scss`, and no removals.
2. `grep -E '\-\-(transition-duration|ease)-' packages/theme/dist/v4/globals.css` — the eight `fast-01 … slow-04` durations and the four `productive|expressive-entrance|exit` curves are present.
3. In Storybook, inspect any element carrying a named step (e.g. the Button's `duration-fast-02`) and confirm `getComputedStyle(el).transitionDuration` is now `0.11s` instead of `0.15s`, and `transitionTimingFunction` is the `cubic-bezier` rather than `ease`.
4. `pnpm --filter theme test` — 12 tests pass.
5. Spot-check motion in both themes: transitions should feel like the 70ms–2100ms scale, with no element becoming visibly slower than intended.

## Notes

- **This makes motion timing real everywhere at once.** Every one of those 46 files starts honouring its declared duration and curve instead of a flat 150ms `ease`. Nothing changes structurally and no static screenshot should shift (transitions do not affect end states), but if a component's timing now looks wrong, this PR is where it became visible — the class was always a no-op before.
- Regenerating the tokens also updates `packages/webkit/catalog.json` (it embeds tokens; `catalog:check` gates it).
- Blocks the curves in #864 — the NavigationMenu morph declares `duration-moderate-02` / `ease-productive-entrance` and falls back to the default until this lands.
- No new dependency, no breaking change.