### PR TITLE
fix(webkit): re-arm the drill entrance once a Menu level leaves the stack

### DIFF
--- a/packages/webkit/src/components/navigation/menu/menu-sub-content/menu-sub-content.vue
+++ b/packages/webkit/src/components/navigation/menu/menu-sub-content/menu-sub-content.vue
@@ -46,8 +46,18 @@
    * Was this level ALREADY on the stack when this instance was created? Then it was restored
    * (the consumer handed back a persisted `path`) rather than pushed — captured at setup,
    * because by the next tick the two are indistinguishable.
+   *
+   * It stops being true the moment the level LEAVES the stack, because from then on every
+   * arrival was travelled to. The question is per ARRIVAL, and the instance outlives all of
+   * them: the level's sub-content is created with the root and only its teleported child mounts
+   * and unmounts. Answered once for the instance, a consumer that seeds `path` — so the menu
+   * opens on the level the reader's own page is in — would own the one level that never animates
+   * its entrance again, sliding the root out from under a level already sitting in place.
    */
-  const wasRestored = isMounted.value
+  const wasRestored = ref(isMounted.value)
+  watch(isMounted, (mounted) => {
+    if (!mounted) wasRestored.value = false
+  })
 
   /** Whether the Teleport below can render at all: this is a drill, and the host exists. */
   const canTeleport = computed(() => isDrill.value && ctx.levelHost.value !== null)
@@ -86,7 +96,7 @@
    * is already in re-renders the level without replaying its entrance.
    */
   const enterFromClass = computed(() =>
-    wasRestored && !ctx.enterOnMount.value
+    wasRestored.value && !ctx.enterOnMount.value
       ? ''
       : 'motion-safe:translate-x-full! motion-safe:opacity-0'
   )


### PR DESCRIPTION
## Summary

- `wasRestored` answered "was this level already on the stack when the instance was created?" **once**, at setup, and kept that answer forever — but the question is per *arrival*, and the instance outlives every arrival: a level's sub-content is created with the root, and only its teleported child mounts and unmounts as the reader travels.
- So a consumer that seeds `path` — opening the menu on the level the reader's own page is in — owned the one level that never animated its entrance again. Travel away and back, and the root slid out from under a level already sitting in place.
- It now stops being true the moment the level leaves the stack, because from then on every arrival was travelled to.

## How to test

1. Open `Components/Navigation/Menu` in Storybook, on a story with a drill (`Menu.Sub` + `Menu.SubContent`).
2. Drill into a level, go **back**, then drill into the same level again: it must slide in from the right both times. Before this change the second entrance appeared already in place while the root slid away behind it.
3. Render a menu with `path` seeded to a drill level (the consumer case: the menu opens on the reader's current section). That first render must **not** animate — it is a restore, not a travel — and then step 2 must still hold for it afterwards.
4. Enable OS "reduce motion": no slide in any of the above, and no level left mid-transform.
5. `pnpm --filter @aziontech/webkit exec vitest run src/components/navigation/menu` — 29 tests pass.

## Notes

- One file, `menu-sub-content.vue`: `wasRestored` becomes a `ref` with a `watch` that clears it when the level unmounts. `ref` and `watch` were already imported.
- No API change — no prop, event or slot moves, so nothing for a consumer to update.
- No new dependency, no breaking change.