### PR TITLE
chore: bump js-yaml overrides to patch CVE-2026-59870 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,8 @@ overrides:
   '@babel/core': '>=7.29.1 <8'
   '@hono/node-server': '>=2.0.5'
   hono: '>=4.12.34 <5'
+  js-yaml@3: '>=3.15.1 <4'
+  js-yaml@4: '>=4.3.1 <5'
 
 importers:
 
@@ -4416,12 +4418,12 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdoc-type-pratt-parser@4.8.0:
@@ -7256,7 +7258,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 10.2.6
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -7363,7 +7365,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -9486,7 +9488,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -11533,12 +11535,12 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,3 +26,5 @@ overrides:
   "@babel/core": ">=7.29.1 <8" # bounded: peer ranges (^7 || ^8.0.0-0) would jump to Babel 8
   "@hono/node-server": ">=2.0.5" # GHSA-frvp-7c67-39w9; MCP SDK still pins ^1.19.x — drop when the SDK moves to ^2
   hono: ">=4.12.34 <5" # GHSA-8j4g-w8fx-2239 (ReDoS in CORS middleware), patched 4.12.34; bounded to 4.x — MCP SDK pins ^4
+  "js-yaml@3": ">=3.15.1 <4" # GHSA-5p4m-2wfm-xmqj (CVE-2026-59870, quadratic CPU in !!omap), patched 3.15.1; bounded — 4.x removed the legacy safeLoad API
+  "js-yaml@4": ">=4.3.1 <5" # GHSA-5p4m-2wfm-xmqj (CVE-2026-59870), patched 4.3.1; bounded to 4.x — 5.x is ESM-only


### PR DESCRIPTION
## Summary
- Raise the `js-yaml` pnpm overrides to the patched floors — `js-yaml@3: >=3.15.1 <4` and `js-yaml@4: >=4.3.1 <5` — closing GHSA-5p4m-2wfm-xmqj (CVE-2026-59870, quadratic CPU in `!!omap` resolution), which was failing the Security Scans gate on every PR.
- Both overrides are bounded to their own major: 4.x removed the legacy `safeLoad` API and 5.x is ESM-only, so nothing jumps a major.

## How to test
1. Run `pnpm install && pnpm run security:audit` — expected: `No known vulnerabilities found`, exit 0.
2. Check `pnpm-lock.yaml` — expected: every `js-yaml` resolution is `3.15.1` or `4.3.1`, none on 5.x.

## Notes
- None