### PR TITLE
chore: patch js-yaml per major for GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,8 @@ overrides:
   '@babel/core': '>=7.29.1 <8'
   '@hono/node-server': '>=2.0.5'
   hono: '>=4.12.34 <5'
+  js-yaml@3: '>=3.15.1 <4'
+  js-yaml@4: '>=4.3.1 <5'
 
 importers:
 
@@ -4416,12 +4418,12 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdoc-type-pratt-parser@4.8.0:
@@ -7256,7 +7258,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 10.2.6
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -7363,7 +7365,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -9486,7 +9488,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -11533,12 +11535,12 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,3 +26,10 @@ overrides:
   "@babel/core": ">=7.29.1 <8" # bounded: peer ranges (^7 || ^8.0.0-0) would jump to Babel 8
   "@hono/node-server": ">=2.0.5" # GHSA-frvp-7c67-39w9; MCP SDK still pins ^1.19.x — drop when the SDK moves to ^2
   hono: ">=4.12.34 <5" # GHSA-8j4g-w8fx-2239 (ReDoS in CORS middleware), patched 4.12.34; bounded to 4.x — MCP SDK pins ^4
+  # GHSA-5p4m-2wfm-xmqj / CVE-2026-59870 (quadratic CPU in !!omap resolution) hits js-yaml 3.x AND
+  # 4.x, which the tree carries in parallel: 3.x under storybook's jest chain (@istanbuljs/load-nyc-
+  # config), 4.x under commitlint's cosmiconfig and eslint's @eslint/eslintrc. Each line is patched
+  # per major, so the override is keyed per major — one bare `js-yaml` force would collapse the 3.x
+  # consumers onto 4.x (no `safeLoad`) or onto the 5.x line, which is a rewrite, not a patch.
+  js-yaml@3: ">=3.15.1 <4" # patched 3.15.1
+  js-yaml@4: ">=4.3.1 <5" # patched 4.3.1


### PR DESCRIPTION
## Summary

- `GHSA-5p4m-2wfm-xmqj` / CVE-2026-59870 (js-yaml quadratic CPU consumption in `!!omap` resolution) was published **2026-08-06T20:27:32Z** and fails `pnpm audit --audit-level=high` — the **Security Scans** job, and through it the **Governance Gate** — on every PR opened since. `main`'s last Governance run was at 15:13Z, before publication, which is why it went green.
- It hits **both** js-yaml lines the tree carries in parallel: 3.x under Storybook's jest chain (`@istanbuljs/load-nyc-config`) and 4.x under commitlint's `cosmiconfig` and eslint's `@eslint/eslintrc`. Both fixes are **patch** bumps — `3.15.0 → 3.15.1` and `4.3.0 → 4.3.1`.
- The override is keyed **per major** and bounded (`js-yaml@3: ">=3.15.1 <4"`, `js-yaml@4: ">=4.3.1 <5"`). One bare `js-yaml` force would resolve every consumer to the highest match, collapsing the 3.x chain onto 4.x (which dropped `safeLoad`) or onto the 5.x line — a rewrite, not a patch.

## How to test

1. `pnpm install --frozen-lockfile` — succeeds against the updated lockfile.
2. `cd packages/webkit && pnpm audit --audit-level=high` — exits **0**, "No known vulnerabilities found" (before: 2 high).
3. `git diff origin/main -- pnpm-lock.yaml` — the only version moves are `js-yaml@3.15.0→3.15.1` and `js-yaml@4.3.0→4.3.1` plus their two `snapshots` references each; no other package re-resolves.
4. Confirm both majors survive: `grep -E '^  js-yaml@[0-9]+\.' pnpm-lock.yaml` lists `3.15.1` **and** `4.3.1`.
5. `pnpm run webkit:lint` and `pnpm --filter @aziontech/webkit test:toolkit` — eslint and commitlint sit on the bumped 4.x, so they are the consumers to sanity-check.

## Notes

- **Dev-tooling only.** `pnpm audit --prod` was already clean before this change, so the advisory never reached a published package or a consumer.
- Refreshed with `pnpm install --lockfile-only` so the lockfile diff stays limited to the offending package — no opportunistic re-resolution of other `^` ranges.
- `chore`, so release-please cuts no release from it (per `.claude/rules/release-types.md`).
- **This unblocks #864, #865 and #866**, which are otherwise green and fail only on this gate. Their CI runs against the PR merge commit, so re-running them after this lands picks the fix up with no rebase.