### PR TITLE
ci: skip the governance rerun on release-please merges

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -21,6 +21,8 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    # Release-please merges skip the pipeline: the same tree already passed the gate on the Release PR.
+    if: "github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore: release main')"
     outputs:
       webkit: ${{ steps.filter.outputs.webkit }}
       toolkit: ${{ steps.filter.outputs.toolkit }}


### PR DESCRIPTION
## Summary
- Skip the Governance Pipeline on pushes to `main` whose head commit is the release-please merge (`chore: release main`): the identical tree already passed the required Governance Gate on the Release PR (strict up-to-date checks), and the npm publish workflows (`release: published`) never waited for this run — v4.3.0 was on npm ~51s after merge while the redundant rerun spent ~4 more minutes gating nothing.
- The condition lives on the root `changes` job; every downstream job keys off its outputs, so all jobs skip and the `Governance Gate` (`if: always()`) still completes green — the `?branch=main` README badge and the release commit status stay healthy.

## How to test
1. This PR's own Governance Pipeline run proves `pull_request` events are unaffected (the expression short-circuits on event name) — expect the full pipeline to run and pass.
2. After merge, land any regular `feat`/`fix` PR — expect the push run on `main` to execute all jobs as before.
3. Merge the next Release PR (`chore: release main`) — expect the push run to skip every job, the Governance Gate to complete green in seconds, and the publish workflows to proceed unaffected.

## Notes
- None