### PR TITLE
ci: make the governance pipeline PR-only

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -3,26 +3,21 @@ name: Governance Pipeline
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 permissions:
   contents: read
   pull-requests: read
 
 # Cancel superseded runs on the same PR (a new push obsoletes the old run's
-# 8 Playwright-sharded jobs); pushes to main queue instead, so every
-# landed commit keeps its own complete status.
+# 8 Playwright-sharded jobs).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
-    # Release-please merges skip the pipeline: the same tree already passed the gate on the Release PR.
-    if: "github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore: release main')"
     outputs:
       webkit: ${{ steps.filter.outputs.webkit }}
       toolkit: ${{ steps.filter.outputs.toolkit }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Azion Webkit Monorepo</h1>
 
 <p align="center">
-  <a href="https://github.com/aziontech/webkit/actions/workflows/governance.yml?query=branch%3Amain"><img src="https://github.com/aziontech/webkit/actions/workflows/governance.yml/badge.svg?branch=main" alt="Governance"></a>
+  <a href="https://github.com/aziontech/webkit/actions/workflows/governance.yml?query=event%3Apull_request"><img src="https://github.com/aziontech/webkit/actions/workflows/governance.yml/badge.svg?event=pull_request" alt="Governance"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/node-%3E%3D22.18-brightgreen" alt="Node >=22.18">
   <img src="https://img.shields.io/badge/pnpm-10.x-orange" alt="pnpm 10.x">


### PR DESCRIPTION
## Summary
- Remove the \`push: main\` trigger from the Governance Pipeline: the Governance Gate is a required check with strict up-to-date enforcement, so the exact tree that lands on main already passed on the PR — the post-merge rerun was pure duplication.
- Drop the release-please skip condition from #869 (dead code without a push trigger) and simplify \`concurrency\` to the PR-only form.
- Point the README badge at PR runs (\`?event=pull_request\`) — \`?branch=main\` would freeze on the last pre-change run forever.

## How to test
1. On this PR, open the Checks tab: the Governance Pipeline runs on the \`pull_request\` event and **Governance Gate** reports on the head SHA (the required check that gates the merge).
2. After merging, watch the Actions tab filtered by \`main\`: no Governance Pipeline run appears for the merge push (before, every merge reran the full pipeline; #869 only skipped release-please merges).
3. Check the README badge: it links and renders from the latest \`pull_request\` run.

## Notes
- None